### PR TITLE
Create artist venue shows screen

### DIFF
--- a/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venue/[venueUuid]/index.tsx
+++ b/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venue/[venueUuid]/index.tsx
@@ -2,10 +2,10 @@ import Plur from '@/relisten/components/plur';
 import { RefreshContextProvider } from '@/relisten/components/refresh_context';
 import { RelistenText } from '@/relisten/components/relisten_text';
 import { DisappearingHeaderScreen } from '@/relisten/components/screens/disappearing_title_screen';
-import { ShowList } from '@/relisten/components/shows_list';
+import { ShowListContainer } from '@/relisten/components/shows_list';
 import { VenueShows, useArtistVenueShows } from '@/relisten/realm/models/venue_shows_repo';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { View } from 'react-native';
 
 export default function Page() {
@@ -22,13 +22,17 @@ export default function Page() {
     });
   }, []);
 
+  const data = useMemo(() => {
+    return [{ data: [...venue.shows] }];
+  }, [venue]);
+
   return (
     <View style={{ flex: 1, width: '100%' }}>
       <RefreshContextProvider networkBackedResults={results}>
         <DisappearingHeaderScreen
-          ScrollableComponent={ShowList}
+          ScrollableComponent={ShowListContainer}
           ListHeaderComponent={<VenueHeader venue={venue} />}
-          shows={venue.shows}
+          data={data}
           artist={artist}
           filterOptions={{
             persistence: { key: ['artists', artistUuid, 'venue', venueUuid].join('/') },

--- a/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venues.tsx
+++ b/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venues.tsx
@@ -6,7 +6,7 @@ import { DisappearingHeaderScreen } from '@/relisten/components/screens/disappea
 import { SectionedListItem } from '@/relisten/components/sectioned_list_item';
 import { Venue } from '@/relisten/realm/models/venue';
 import { useArtistVenues } from '@/relisten/realm/models/venue_repo';
-import { useLocalSearchParams } from 'expo-router';
+import { Link, useLocalSearchParams } from 'expo-router';
 import {
   FilterableList,
   FilterableListProps,
@@ -42,17 +42,28 @@ interface VenueListItemProps {
 
 const VenueListItem = ({ venue }: VenueListItemProps) => {
   return (
-    <SectionedListItem>
-      <Flex column>
-        <RowTitle>{venue.name}</RowTitle>
-        <SubtitleRow>
-          <SubtitleText>{venue.location}</SubtitleText>
-          <SubtitleText>
-            <Plur word="show" count={venue.showsAtVenue} />
-          </SubtitleText>
-        </SubtitleRow>
-      </Flex>
-    </SectionedListItem>
+    <Link
+      href={{
+        pathname: '/relisten/(tabs)/artists/[artistUuid]/venue/[venueUuid]/' as const,
+        params: {
+          artistUuid: venue.artistUuid,
+          venueUuid: venue.uuid,
+        },
+      }}
+      asChild
+    >
+      <SectionedListItem>
+        <Flex column>
+          <RowTitle>{venue.name}</RowTitle>
+          <SubtitleRow>
+            <SubtitleText>{venue.location}</SubtitleText>
+            <SubtitleText>
+              <Plur word="show" count={venue.showsAtVenue} />
+            </SubtitleText>
+          </SubtitleRow>
+        </Flex>
+      </SectionedListItem>
+    </Link>
   );
 };
 
@@ -120,7 +131,6 @@ const VenueList = ({
     <FilteringProvider filters={VENUE_FILTERS} options={filterOptions}>
       <FilterableList
         ListHeaderComponent={<VenueHeader venues={venues} />}
-        className="w-full flex-1"
         data={[{ data: venues }]}
         renderItem={({ item }) => {
           return <VenueListItem venue={item} />;

--- a/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venues.tsx
+++ b/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venues.tsx
@@ -6,7 +6,7 @@ import { DisappearingHeaderScreen } from '@/relisten/components/screens/disappea
 import { SectionedListItem } from '@/relisten/components/sectioned_list_item';
 import { Venue } from '@/relisten/realm/models/venue';
 import { useArtistVenues } from '@/relisten/realm/models/venue_repo';
-import { Link, useLocalSearchParams } from 'expo-router';
+import { Link, useLocalSearchParams, useNavigation } from 'expo-router';
 import {
   FilterableList,
   FilterableListProps,
@@ -19,11 +19,19 @@ import {
   FilteringProvider,
   SortDirection,
 } from '@/relisten/components/filtering/filters';
+import { useEffect } from 'react';
 
 export default function Page() {
+  const navigation = useNavigation();
   const { artistUuid } = useLocalSearchParams();
   const results = useArtistVenues(String(artistUuid));
   const { data } = results;
+
+  useEffect(() => {
+    navigation.setOptions({
+      title: 'Venues',
+    });
+  }, []);
 
   return (
     <RefreshContextProvider networkBackedResults={results}>

--- a/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venues.tsx
+++ b/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venues.tsx
@@ -20,6 +20,7 @@ import {
   SortDirection,
 } from '@/relisten/components/filtering/filters';
 import { useEffect } from 'react';
+import { useGroupSegment } from '@/relisten/util/routes';
 
 export default function Page() {
   const navigation = useNavigation();
@@ -49,10 +50,12 @@ interface VenueListItemProps {
 }
 
 const VenueListItem = ({ venue }: VenueListItemProps) => {
+  const groupSegment = useGroupSegment(true);
+
   return (
     <Link
       href={{
-        pathname: '/relisten/(tabs)/artists/[artistUuid]/venue/[venueUuid]/' as const,
+        pathname: `/relisten/(tabs)/${groupSegment}/[artistUuid]/venue/[venueUuid]/` as const,
         params: {
           artistUuid: venue.artistUuid,
           venueUuid: venue.uuid,

--- a/app/relisten/(tabs)/(artists,downloaded)/_layout.tsx
+++ b/app/relisten/(tabs)/(artists,downloaded)/_layout.tsx
@@ -50,6 +50,12 @@ export default function ArtistsLayout() {
         }}
       />
       <Stack.Screen
+        name="[artistUuid]/venue/[venueUuid]/index"
+        options={{
+          title: '',
+        }}
+      />
+      <Stack.Screen
         name="[artistUuid]/year/[yearUuid]/index"
         options={{
           title: '',

--- a/app/relisten/(tabs)/artists/[artistUuid]/venue/[venueUuid]/index.tsx
+++ b/app/relisten/(tabs)/artists/[artistUuid]/venue/[venueUuid]/index.tsx
@@ -1,13 +1,40 @@
+import { RefreshContextProvider } from '@/relisten/components/refresh_context';
 import { RelistenText } from '@/relisten/components/relisten_text';
-import { useLocalSearchParams } from 'expo-router';
+import { DisappearingHeaderScreen } from '@/relisten/components/screens/disappearing_title_screen';
+import { ShowList } from '@/relisten/components/shows_list';
+import { Artist } from '@/relisten/realm/models/artist';
+import { useArtistVenueShows } from '@/relisten/realm/models/venue_shows_repo';
+import { Year } from '@/relisten/realm/models/year';
+import { useLocalSearchParams, useNavigation } from 'expo-router';
+import { useEffect } from 'react';
+import { View } from 'react-native';
 
 export default function Page() {
+  const navigation = useNavigation();
   const { artistUuid, venueUuid } = useLocalSearchParams();
+  const results = useArtistVenueShows(String(artistUuid), String(venueUuid));
+
+  useEffect(() => {
+    navigation.setOptions({
+      title: results.data.venues.venue?.name,
+    });
+  }, []);
 
   return (
-    <>
+    <View style={{ flex: 1, width: '100%' }}>
       <RelistenText>Artist uuid: {artistUuid}</RelistenText>
       <RelistenText>Venue uuid: {venueUuid}</RelistenText>
-    </>
+      <RefreshContextProvider networkBackedResults={results}>
+        {/* <DisappearingHeaderScreen
+          ScrollableComponent={ShowList}
+          ListHeaderComponent={<VenueHeader artist={artist} year={year} />}
+          shows={shows}
+          artist={artist}
+          filterOptions={{
+            persistence: { key: ['artists', artistUuid, 'years', yearUuid].join('/') },
+          }}
+        /> */}
+      </RefreshContextProvider>
+    </View>
   );
 }

--- a/app/relisten/(tabs)/artists/[artistUuid]/venue/[venueUuid]/index.tsx
+++ b/app/relisten/(tabs)/artists/[artistUuid]/venue/[venueUuid]/index.tsx
@@ -1,10 +1,9 @@
+import Plur from '@/relisten/components/plur';
 import { RefreshContextProvider } from '@/relisten/components/refresh_context';
 import { RelistenText } from '@/relisten/components/relisten_text';
 import { DisappearingHeaderScreen } from '@/relisten/components/screens/disappearing_title_screen';
 import { ShowList } from '@/relisten/components/shows_list';
-import { Artist } from '@/relisten/realm/models/artist';
-import { useArtistVenueShows } from '@/relisten/realm/models/venue_shows_repo';
-import { Year } from '@/relisten/realm/models/year';
+import { VenueShows, useArtistVenueShows } from '@/relisten/realm/models/venue_shows_repo';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { useEffect } from 'react';
 import { View } from 'react-native';
@@ -13,28 +12,44 @@ export default function Page() {
   const navigation = useNavigation();
   const { artistUuid, venueUuid } = useLocalSearchParams();
   const results = useArtistVenueShows(String(artistUuid), String(venueUuid));
+  const {
+    data: { venue, artist },
+  } = results;
 
   useEffect(() => {
     navigation.setOptions({
-      title: results.data.venues.venue?.name,
+      title: venue.venue?.name,
     });
   }, []);
 
   return (
     <View style={{ flex: 1, width: '100%' }}>
-      <RelistenText>Artist uuid: {artistUuid}</RelistenText>
-      <RelistenText>Venue uuid: {venueUuid}</RelistenText>
       <RefreshContextProvider networkBackedResults={results}>
-        {/* <DisappearingHeaderScreen
+        <DisappearingHeaderScreen
           ScrollableComponent={ShowList}
-          ListHeaderComponent={<VenueHeader artist={artist} year={year} />}
-          shows={shows}
+          ListHeaderComponent={<VenueHeader venue={venue} />}
+          shows={venue.shows}
           artist={artist}
           filterOptions={{
-            persistence: { key: ['artists', artistUuid, 'years', yearUuid].join('/') },
+            persistence: { key: ['artists', artistUuid, 'venue', venueUuid].join('/') },
           }}
-        /> */}
+        />
       </RefreshContextProvider>
     </View>
   );
 }
+
+const VenueHeader = ({ venue }: { venue: VenueShows | null }) => {
+  const totalShows = venue?.shows.length;
+  return (
+    <View className="flex w-full flex-col items-center gap-1 py-2">
+      <RelistenText className="w-full text-center text-4xl font-bold text-white" selectable={false}>
+        {venue?.venue?.name}
+      </RelistenText>
+
+      <RelistenText className="text-l w-full text-center italic text-gray-400">
+        <Plur word="show" count={totalShows} />
+      </RelistenText>
+    </View>
+  );
+};

--- a/app/relisten/(tabs)/artists/[artistUuid]/venue/[venueUuid]/index.tsx
+++ b/app/relisten/(tabs)/artists/[artistUuid]/venue/[venueUuid]/index.tsx
@@ -1,0 +1,13 @@
+import { RelistenText } from '@/relisten/components/relisten_text';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function Page() {
+  const { artistUuid, venueUuid } = useLocalSearchParams();
+
+  return (
+    <>
+      <RelistenText>Artist uuid: {artistUuid}</RelistenText>
+      <RelistenText>Venue uuid: {venueUuid}</RelistenText>
+    </>
+  );
+}

--- a/relisten/api/client.ts
+++ b/relisten/api/client.ts
@@ -226,7 +226,7 @@ export class RelistenApiClient {
     venueUuid: string,
     options?: RelistenApiRequestOptions
   ): Promise<RelistenApiResponse<VenueWithShows>> {
-    return this.getJson(`/v2/artists/${artistUuid}/venue/${venueUuid}`, options);
+    return this.getJson(`/v2/artists/${artistUuid}/venues/${venueUuid}`, options);
   }
 
   public tours(

--- a/relisten/api/client.ts
+++ b/relisten/api/client.ts
@@ -226,7 +226,7 @@ export class RelistenApiClient {
     venueUuid: string,
     options?: RelistenApiRequestOptions
   ): Promise<RelistenApiResponse<VenueWithShows>> {
-    return this.getJson(`/v2/artists/${artistUuid}/venues/${venueUuid}`, options);
+    return this.getJson(`/v3/artists/${artistUuid}/venues/${venueUuid}`, options);
   }
 
   public tours(

--- a/relisten/realm/models/venue_repo.ts
+++ b/relisten/realm/models/venue_repo.ts
@@ -5,7 +5,6 @@ import { useArtist } from './artist_repo';
 import { mergeNetworkBackedResults } from '../network_backed_results';
 import { useMemo } from 'react';
 import { Venue } from './venue';
-import { NetworkBackedBehaviorFetchStrategy } from '@/relisten/realm/network_backed_behavior';
 
 export const venueRepo = new Repository(Venue);
 

--- a/relisten/realm/models/venue_shows_repo.ts
+++ b/relisten/realm/models/venue_shows_repo.ts
@@ -1,0 +1,123 @@
+import { useObject, useQuery } from '../schema';
+import { useNetworkBackedBehavior } from '../network_backed_behavior_hooks';
+import { useArtist } from './artist_repo';
+import { NetworkBackedResults, mergeNetworkBackedResults } from '../network_backed_results';
+import { useMemo } from 'react';
+import { Venue } from './venue';
+import { VenueWithShows } from '@/relisten/api/models/venue';
+import { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
+import {
+  ThrottledNetworkBackedBehavior,
+  NetworkBackedBehaviorOptions,
+} from '../network_backed_behavior';
+import { Show } from './show';
+import { showRepo } from './show_repo';
+import { venueRepo } from './venue_repo';
+import Realm from 'realm';
+import * as R from 'remeda';
+
+export interface VenueShows {
+  venue: Venue | null;
+  shows: Realm.Results<Show>;
+}
+
+class VenueShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
+  VenueShows,
+  VenueWithShows
+> {
+  constructor(
+    public artistUuid: string,
+    public venueUuid: string,
+    options?: NetworkBackedBehaviorOptions
+  ) {
+    super(options);
+  }
+
+  fetchFromApi(api: RelistenApiClient): Promise<RelistenApiResponse<VenueWithShows>> {
+    return api.venue(this.artistUuid, this.venueUuid);
+  }
+
+  fetchFromLocal(): VenueShows {
+    const venue = useObject(Venue, this.venueUuid) || null;
+    const shows = useQuery(Show, (query) => query.filtered('venueUuid == $0', this.venueUuid), [
+      this.venueUuid,
+    ]);
+
+    const obj = useMemo(() => {
+      return { venue, shows };
+    }, [venue, shows]);
+
+    return obj;
+  }
+
+  isLocalDataShowable(localData: VenueShows): boolean {
+    return localData.venue !== null && localData.shows.length > 0;
+  }
+
+  upsert(realm: Realm, localData: VenueShows, apiData: VenueWithShows): void {
+    if (!localData.shows.isValid()) {
+      return;
+    }
+
+    const apiVenuesByUuid = R.flatMapToObj(
+      apiData.shows.filter((s) => !!s.venue),
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (s) => [[s.venue!.uuid, s.venue!]]
+    );
+
+    realm.write(() => {
+      const { createdModels: createdShows } = showRepo.upsertMultiple(
+        realm,
+        apiData.shows,
+        localData.shows
+      );
+
+      for (const show of createdShows.concat(localData.shows)) {
+        if (show.venueUuid) {
+          const apiVenue = apiVenuesByUuid[show.venueUuid];
+
+          if (!show.venue) {
+            const localVenue = realm.objectForPrimaryKey(Venue, show.venueUuid);
+
+            if (localVenue) {
+              show.venue = localVenue;
+            } else {
+              const { createdModels: createdVenues } = venueRepo.upsert(realm, apiVenue, undefined);
+
+              if (createdVenues.length > 0) {
+                show.venue = createdVenues[0];
+              }
+            }
+          } else {
+            venueRepo.upsert(realm, apiVenue, show.venue);
+          }
+        }
+      }
+    });
+  }
+}
+
+export function useVenueShows(
+  artistUuid: string,
+  venueUuid: string
+): NetworkBackedResults<VenueShows> {
+  const behavior = useMemo(() => {
+    return new VenueShowsNetworkBackedBehavior(artistUuid, venueUuid);
+  }, [artistUuid, venueUuid]);
+
+  return useNetworkBackedBehavior(behavior);
+}
+
+export const useArtistVenueShows = (artistUuid: string, venueUuid: string) => {
+  const artistResults = useArtist(artistUuid);
+  const venueResults = useVenueShows(artistUuid, venueUuid);
+
+  const results = useMemo(() => {
+    return mergeNetworkBackedResults({
+      venues: venueResults,
+      artist: artistResults,
+    });
+  }, [venueResults, artistResults]);
+
+  return results;
+};

--- a/relisten/realm/models/venue_shows_repo.ts
+++ b/relisten/realm/models/venue_shows_repo.ts
@@ -37,7 +37,7 @@ class VenueShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
     return api.venue(this.artistUuid, this.venueUuid);
   }
 
-  fetchFromLocal(): VenueShows {
+  useFetchFromLocal(): VenueShows {
     const venue = useObject(Venue, this.venueUuid) || null;
     const shows = useQuery(Show, (query) => query.filtered('venueUuid == $0', this.venueUuid), [
       this.venueUuid,

--- a/relisten/realm/models/venue_shows_repo.ts
+++ b/relisten/realm/models/venue_shows_repo.ts
@@ -114,7 +114,7 @@ export const useArtistVenueShows = (artistUuid: string, venueUuid: string) => {
 
   const results = useMemo(() => {
     return mergeNetworkBackedResults({
-      venues: venueResults,
+      venue: venueResults,
       artist: artistResults,
     });
   }, [venueResults, artistResults]);


### PR DESCRIPTION
Currently routing is set up to navigate from artist venue screen to this new screen. A query has also been set up to get the shows and should work as soon as the API is upgraded. Once that is done the `ShowList` will just need to be populated with the relevant data.