### PR TITLE
Fix flashlist style warning

### DIFF
--- a/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/songs.tsx
+++ b/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/songs.tsx
@@ -120,7 +120,6 @@ const SongList = ({
     <FilteringProvider filters={SONG_FILTERS} options={filterOptions}>
       <FilterableList
         ListHeaderComponent={<SongHeader songs={songs} />}
-        className="w-full flex-1"
         data={[{ data: songs }]}
         renderItem={({ item }: { item: Song; index: number }) => <SongListItem song={item} />}
       />


### PR DESCRIPTION
These classes were not needed and caused a warning to be thrown from Flashlist.

## Screenshot

Songs page rendering without error and with styles unchanged.

<img width="584" alt="image" src="https://github.com/RelistenNet/relisten-mobile/assets/41388783/d4b64a96-ebb6-47ea-80fd-680318e8ba42">

Closes #33 
