### PR TITLE
Fix default sort order for venues, tours and songs

### DIFF
--- a/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/songs.tsx
+++ b/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/songs.tsx
@@ -92,7 +92,7 @@ const SONG_FILTERS: Filter<SongFilterPersistenceKey, Song>[] = [
   {
     persistenceKey: SongFilterPersistenceKey.Name,
     title: 'Name',
-    sortDirection: SortDirection.Descending,
+    sortDirection: SortDirection.Ascending,
     active: true,
     isNumeric: false,
     sort: (songs) => songs.sort((a, b) => a.name.localeCompare(b.name)),

--- a/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/tours.tsx
+++ b/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/tours.tsx
@@ -115,7 +115,7 @@ const TOUR_FILTERS: Filter<TourFilterKey, Tour>[] = [
   {
     persistenceKey: TourFilterKey.Name,
     title: 'Name',
-    sortDirection: SortDirection.Descending,
+    sortDirection: SortDirection.Ascending,
     active: true,
     isNumeric: false,
     sort: (tours) => tours.sort((a, b) => a.name.localeCompare(b.name)),

--- a/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venues.tsx
+++ b/app/relisten/(tabs)/(artists,downloaded)/[artistUuid]/venues.tsx
@@ -114,7 +114,7 @@ const VENUE_FILTERS: Filter<VenueFilterKey, Venue>[] = [
   {
     persistenceKey: VenueFilterKey.Name,
     title: 'Name',
-    sortDirection: SortDirection.Descending,
+    sortDirection: SortDirection.Ascending,
     active: true,
     isNumeric: false,
     sort: (venues) => venues.sort((a, b) => a.name.localeCompare(b.name)),


### PR DESCRIPTION
Changed the default sort order for Venues, Tours and Songs to be ascending (alphabetical order).

Closes #38 