### PR TITLE
Make date the default sort when going to a year

### DIFF
--- a/relisten/components/shows_list.tsx
+++ b/relisten/components/shows_list.tsx
@@ -90,7 +90,7 @@ const SHOW_FILTERS: Filter<ShowFilterKey, Show>[] = [
     persistenceKey: ShowFilterKey.Date,
     title: 'Date',
     sortDirection: SortDirection.Ascending,
-    active: false,
+    active: true,
     isNumeric: true,
     sort: (shows) => shows.sort((a, b) => a.displayDate.localeCompare(b.displayDate)),
   },


### PR DESCRIPTION
Now when a user clicks on an artists year, the date sort chip is selected by default. This is how the page appeared to be sorted anyways, but not the chip is active.

## Screenshot

This is how a given year's page looks upon first load

<img width="584" alt="image" src="https://github.com/RelistenNet/relisten-mobile/assets/41388783/c84c003a-fd58-4c0d-af0a-c543b76ddd98">

Closes #39 
