### PR TITLE
add currently downloading badge to downloads tab

### DIFF
--- a/app/relisten/(tabs)/_layout.tsx
+++ b/app/relisten/(tabs)/_layout.tsx
@@ -1,5 +1,9 @@
 import { Tabs } from 'expo-router';
-
+import { useQuery } from '@/relisten/realm/schema';
+import {
+  SourceTrackOfflineInfo,
+  SourceTrackOfflineInfoStatus,
+} from '@/relisten/realm/models/source_track_offline_info';
 import TabBar from '@/relisten/components/TabBar';
 import { PlayerBottomBar } from '@/relisten/player/ui/player_bottom_bar';
 import { RelistenBlue } from '@/relisten/relisten_blue';
@@ -9,6 +13,10 @@ import 'react-native-gesture-handler';
 import 'react-native-reanimated';
 
 export default function TabLayout() {
+  const downloads = useQuery(SourceTrackOfflineInfo, (query) =>
+    query.filtered('status != $0', SourceTrackOfflineInfoStatus.Succeeded)
+  );
+
   return (
     <>
       <Tabs
@@ -45,7 +53,7 @@ export default function TabLayout() {
         // initialRouteName="artists"
       >
         <Tabs.Screen name="(artists)" options={{ title: 'Artists' }} />
-        <Tabs.Screen name="(downloaded)" options={{ title: 'Downloaded' }} />
+        <Tabs.Screen name="(downloaded)" options={{ title: 'Downloads', tabBarBadge: downloads.length === 0 ? undefined : downloads.length }} />
 
         <Tabs.Screen name="(myLibrary)/myLibrary" options={{ title: 'My Library' }} />
         <Tabs.Screen name="(relisten)/index" options={{ title: 'Relisten' }} />


### PR DESCRIPTION
Taking a look at #42 I first tried adding some text to the bottom tab. This looked a bit cluttered and was hard to read. Instead, I added a badge which displays a number indicating how many tracks are currently downloading. It is removed once all tracks have finished downloading.

Additionally, I changed the text on the tab from "Downloaded" to "Downloads" as that made more sense to me. Happy to revert this if desired. 

## Screenshot

![image](https://github.com/user-attachments/assets/b69bbd7a-7fee-43a5-838e-d9bbfedc696b)

## Demo

Showing the final download completing
https://github.com/user-attachments/assets/5ea0e226-d8b7-4341-9a2d-546964f12fe2

