### PR TITLE
fix: use (artists) as groupSegment in Recently Played songs to fix broken link clicks, update scripts for fast startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ If you are on a Mac and would like to get the app running locally on iOS simulat
   - We recommend installing nodejs 22 or more recent via nvm
   - To install yarn: `npm install --global yarn && yarn`
 2. Follow these steps https://docs.expo.dev/workflow/ios-simulator to install XCode and XCode Command Line Tools
-4. Update your cocoapods: `npx pod-install`
-3. `npx expo run:ios -d` and select which Simulator you would like to run on
+4. Update your cocoapods: `npx pod-install` (or `yarn pods`)
+3. `npx expo run:ios -d` (or `yarn ios`) and select which Simulator you would like to run on
 4. You may have to hit the `r` key once the Simulator runs, it should bundle the application and render
 
 There's some more steps - we'll update this README with more instructions as we help people onboard. If you are getting set up yourself, consider taking notes and sending a PR to improve this documentation - thanks!!

--- a/app/relisten/tabs/(relisten)/recently-played.tsx
+++ b/app/relisten/tabs/(relisten)/recently-played.tsx
@@ -288,6 +288,7 @@ export default function Page() {
                     artist,
                     showUuid: item.track.source.show.uuid,
                     sourceUuid: item.track.source.uuid,
+                    overrideGroupSegment: '(artists)',
                   }}
                   key={item.id}
                 >

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "relisten",
   "version": "1.0.0",
   "scripts": {
-    "start": "expo start --dev-client",
     "android": "expo run:android",
-    "ios": "expo run:ios",
+    "ios": "expo run:ios -d",
     "web": "expo start --web",
     "ts:check": "tsc",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "pods": "npx pod-install"
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "^4.0.1",


### PR DESCRIPTION
In Relisten > Recently Played, a bug that exists and was talked about in #58 (not the full fix to 58) is that when you click on the song itself, it leads to a broken link that leads to an error screen, and that screen actually has a link to Sitemap that shows all files - not good stuff. But also, it does not play the song.

Using this override, it means you click and it takes you to the Show / Song in the Artists tab. We discussed in the Issue and this is acceptable now to open in the Artists tab vs. the error and vs. the effort to set up Relisten tab for playback.

BEFORE:

![Screenshot 2025-04-06 at 11 53 07 AM](https://github.com/user-attachments/assets/8d222982-af38-4aa5-afa4-823c27260573)
-->
![Screenshot 2025-04-06 at 11 57 22 AM](https://github.com/user-attachments/assets/91079d6b-199a-435c-b833-300fe51030aa)
-->
![Screenshot 2025-04-06 at 11 57 34 AM](https://github.com/user-attachments/assets/d7141a63-e201-4bff-9b82-5b2b0edbcc1c)

AFTER:

![Screenshot 2025-04-06 at 11 53 07 AM](https://github.com/user-attachments/assets/8d222982-af38-4aa5-afa4-823c27260573)
-->
![Screenshot 2025-04-06 at 11 53 27 AM](https://github.com/user-attachments/assets/6edaa72d-6533-4eeb-a5df-6f9935e73eed)


I also added in here a commit to some of the `package.json` scripts to:

1. Remove `start` that started up Expo Go, which does not work
2. Update `ios` to have `-d` so it gives devices link
3. Update README to show option to use these `yarn` commands