### PR TITLE
Fix venue upsert when show venue UUID changes

### DIFF
--- a/relisten/realm/models/show_repo.ts
+++ b/relisten/realm/models/show_repo.ts
@@ -150,10 +150,16 @@ class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBackedBeh
       }
 
       if (localData.show && apiData.venue) {
+        let venueToUpdate = localData.show.venue;
+
+        if (venueToUpdate && venueToUpdate.uuid !== apiData.venue.uuid) {
+          venueToUpdate = undefined;
+        }
+
         const { createdModels: createdVenues, updatedModels: updatedVenues } = venueRepo.upsert(
           realm,
           apiData.venue,
-          localData.show.venue,
+          venueToUpdate,
           true
         );
 


### PR DESCRIPTION
## Summary
- avoid passing a stale Venue object when upserting a show's venue

## Testing
- `yarn lint` *(fails: 95 errors)*
- `yarn ts:check` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841ebef398c8332a607df09c88f6bbc