### PR TITLE
Fix audio session queue assertion

### DIFF
--- a/modules/relisten-audio-player/ios/RelistenGaplessAudioPlayer/AudioSession.swift
+++ b/modules/relisten-audio-player/ios/RelistenGaplessAudioPlayer/AudioSession.swift
@@ -174,15 +174,11 @@ extension RelistenGaplessAudioPlayer {
     }
 
     @objc func handleMediaServicesWereReset(_: Notification) {
-        bassQueue.async { [weak self] in
-            self?.restartPlayback()
-        }
+        self?.restartPlayback()
     }
 
     @objc func handleMediaServicesWereLost(_: Notification) {
-        bassQueue.async { [weak self] in
-            self?.restartPlayback()
-        }
+        self?.restartPlayback()
     }
 
     internal func restartPlayback() {

--- a/modules/relisten-audio-player/ios/RelistenGaplessAudioPlayer/AudioSession.swift
+++ b/modules/relisten-audio-player/ios/RelistenGaplessAudioPlayer/AudioSession.swift
@@ -174,20 +174,24 @@ extension RelistenGaplessAudioPlayer {
     }
 
     @objc func handleMediaServicesWereReset(_: Notification) {
-        restartPlayback()
+        bassQueue.async { [weak self] in
+            self?.restartPlayback()
+        }
     }
 
     @objc func handleMediaServicesWereLost(_: Notification) {
-        restartPlayback()
+        bassQueue.async { [weak self] in
+            self?.restartPlayback()
+        }
     }
 
     internal func restartPlayback() {
-        tearDownAudioSession()
-        setupAudioSession(shouldActivate: true)
-
         bassQueue.async { [weak self] in
             guard let self else { return }
-            
+
+            tearDownAudioSession()
+            setupAudioSession(shouldActivate: true)
+
             let savedActiveStreamable = activeStreamIntent?.streamable
             let nextStreamable = nextStreamIntent?.streamable
             let savedElapsed = self.elapsed

--- a/modules/relisten-audio-player/ios/RelistenGaplessAudioPlayer/AudioSession.swift
+++ b/modules/relisten-audio-player/ios/RelistenGaplessAudioPlayer/AudioSession.swift
@@ -174,11 +174,11 @@ extension RelistenGaplessAudioPlayer {
     }
 
     @objc func handleMediaServicesWereReset(_: Notification) {
-        self?.restartPlayback()
+        restartPlayback()
     }
 
     @objc func handleMediaServicesWereLost(_: Notification) {
-        self?.restartPlayback()
+        restartPlayback()
     }
 
     internal func restartPlayback() {


### PR DESCRIPTION
## Summary
- ensure `restartPlayback` and notification handlers run on `bassQueue`

## Testing
- `yarn lint` *(fails: Cannot find package '@switz/eslint-config')*
- `yarn install` *(fails: network 503 errors)*


------
https://chatgpt.com/codex/tasks/task_e_684b2be18fe48332a2b059556acec6dc