### PR TITLE
Fix disabled iOS media controls

### DIFF
--- a/modules/relisten-audio-player/ios/RelistenGaplessAudioPlayer/AudioSession.swift
+++ b/modules/relisten-audio-player/ios/RelistenGaplessAudioPlayer/AudioSession.swift
@@ -84,6 +84,8 @@ extension RelistenGaplessAudioPlayer {
             DispatchQueue.main.async {
                 UIApplication.shared.endReceivingRemoteControlEvents()
             }
+
+            audioSessionObserversSetUp = false
         }
     }
 


### PR DESCRIPTION
## Summary
- keep track of whether the command center listeners are active
- reset that flag when tearing down the audio session

## Testing
- `yarn install`
- `yarn lint` *(fails: 94 problems)*

------
https://chatgpt.com/codex/tasks/task_e_685e2a57227c8332ba47530d1d0912aa