### PR TITLE
refactor all of the NetworkBackedBehaviors to not use react hooks

### DIFF
--- a/app/relisten/tabs/_layout.tsx
+++ b/app/relisten/tabs/_layout.tsx
@@ -77,7 +77,8 @@ export default function TabLayout() {
           }}
         />
 
-        <Tabs.Screen name="(relisten)" options={{ title: 'Relisten', lazy: false }} />
+        {/* This one should be lazy to prevent the hits to the fs to check storage */}
+        <Tabs.Screen name="(relisten)" options={{ title: 'Relisten', lazy: true }} />
       </Tabs>
       <PlayerBottomBar />
     </>

--- a/relisten/api/client.ts
+++ b/relisten/api/client.ts
@@ -437,8 +437,11 @@ export class RelistenApiClient {
     );
   }
 
-  public todayShows(options?: RelistenApiRequestOptions): Promise<RelistenApiResponse<Show[]>> {
-    const now = new Date();
+  public todayShows(
+    asOf?: Date,
+    options?: RelistenApiRequestOptions
+  ): Promise<RelistenApiResponse<Show[]>> {
+    const now = asOf ?? new Date();
     return this.getJson(
       `/v2/shows/today?month=${now.getMonth() + 1}&day=${now.getDate()}`,
       options

--- a/relisten/pages/legacy_migration.tsx
+++ b/relisten/pages/legacy_migration.tsx
@@ -1,0 +1,577 @@
+import React, { useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  ActivityIndicator,
+  Image,
+  Modal,
+  ModalProps,
+  Platform,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { DownloadManager } from '@/relisten/offline/download_manager';
+import Flex from '@/relisten/components/flex';
+import { RelistenText } from '@/relisten/components/relisten_text';
+import { RelistenButton } from '@/relisten/components/relisten_button';
+import { log } from '@/relisten/util/logging';
+import {
+  FavoritedSource,
+  isLegacyDatabaseEmpty,
+  LegacyDatabaseContents,
+  loadLegacyDatabaseContents,
+  OfflineTrack,
+} from '@/relisten/realm/old_ios_schema';
+import { useShouldMakeNetworkRequests } from '@/relisten/util/netinfo';
+import { errorDisplayString, RelistenApiClient } from '@/relisten/api/client';
+import { Realm } from '@realm/react';
+import { artistsNetworkBackedBehavior } from '@/relisten/realm/models/artist_repo';
+import { groupByUuid } from '@/relisten/util/group_by';
+import { ShowWithFullSourcesNetworkBackedBehavior } from '@/relisten/realm/models/show_repo';
+import { CryptoDigestAlgorithm, digestStringAsync } from 'expo-crypto';
+import * as fs from 'expo-file-system';
+import { realm, useRealm } from '@/relisten/realm/schema';
+import {
+  SourceTrackOfflineInfo,
+  SourceTrackOfflineInfoStatus,
+  SourceTrackOfflineInfoType,
+} from '@/relisten/realm/models/source_track_offline_info';
+import { OFFLINE_DIRECTORY } from '@/relisten/realm/models/source_track';
+import { NetworkBackedBehaviorExecutor } from '@/relisten/realm/network_backed_behavior';
+import { useRelistenApi } from '@/relisten/api/context';
+
+const logger = log.extend('LegacyDataMigrationModal');
+
+export const SEEN_MODAL_KEY = '@relistenapp/seen-v6-migration-modal';
+
+export interface LegacyDataMigrationResult {
+  type: 'artist' | 'offline_track' | 'source' | 'show';
+  identifier: string;
+  success: boolean;
+  migrated: boolean;
+  message?: string;
+}
+
+export class LegacyDataMigrator {
+  constructor(
+    private api: RelistenApiClient,
+    private realm: Realm
+  ) {}
+
+  public async migrateOfflineTrack(
+    sourceUuid: string,
+    offlineTracks: ReadonlyArray<OfflineTrack>,
+    allOfflineFiles: string[]
+  ): Promise<LegacyDataMigrationResult[]> {
+    const sourceBehavior = new ShowWithFullSourcesNetworkBackedBehavior(
+      this.realm,
+      undefined,
+      sourceUuid
+    );
+    const result = await NetworkBackedBehaviorExecutor.executeUntilMatches(
+      sourceBehavior,
+      this.api,
+      (result) => {
+        return (result.errors?.length ?? 0) > 0 || sourceBehavior.isLocalDataShowable(result.data);
+      }
+    );
+
+    if (result.errors && result.errors.length > 0) {
+      return offlineTracks.map((t) => {
+        return {
+          type: 'offline_track',
+          identifier: t.track_uuid,
+          success: false,
+          migrated: false,
+          message: result.errors?.map((e) => errorDisplayString(e))?.join(', '),
+        };
+      });
+    }
+
+    const sources = result.data.sources.filter((s) => s.uuid === sourceUuid);
+
+    if (sources.length === 0) {
+      return offlineTracks.map((t) => {
+        return {
+          type: 'offline_track',
+          identifier: t.track_uuid,
+          success: false,
+          migrated: false,
+          message: 'Source not found',
+        };
+      });
+    }
+
+    const source = sources[0];
+
+    const sourceTracksByUuid = groupByUuid(source.allSourceTracks());
+    const results: LegacyDataMigrationResult[] = [];
+
+    for (const offlineTrack of offlineTracks) {
+      const sourceTrack = sourceTracksByUuid[offlineTrack.track_uuid];
+
+      if (!sourceTrack) {
+        results.push({
+          type: 'offline_track',
+          identifier: offlineTrack.track_uuid,
+          success: false,
+          migrated: false,
+          message: 'Source track not found',
+        });
+        continue;
+      }
+
+      if (sourceTrack.offlineInfo) {
+        // if there's already an offline info, don't do anything
+        results.push({
+          type: 'offline_track',
+          identifier: offlineTrack.track_uuid,
+          success: true,
+          migrated: false,
+        });
+        continue;
+      }
+
+      const mp3urlMD5 = await digestStringAsync(CryptoDigestAlgorithm.MD5, sourceTrack.mp3Url);
+      const expectedLegacyFilename = `${mp3urlMD5}.mp3`;
+
+      for (const filename of allOfflineFiles) {
+        if (filename.includes(expectedLegacyFilename)) {
+          const info = await fs.getInfoAsync(filename, { size: true });
+
+          if (!info.exists) {
+            continue;
+          }
+
+          try {
+            await fs.makeDirectoryAsync(OFFLINE_DIRECTORY);
+          } catch {
+            /* no extra work to do */
+          }
+
+          // Move the file first so that we don't show offline UI when it isn't available
+          await fs.moveAsync({ from: filename, to: sourceTrack.downloadedFileLocation() });
+
+          this.realm.write(() => {
+            const newOfflineInfo = new SourceTrackOfflineInfo(realm!, {
+              sourceTrackUuid: sourceTrack.uuid,
+              queuedAt: new Date(),
+              startedAt: new Date(),
+              completedAt: new Date(),
+              downloadedBytes: info.size,
+              totalBytes: info.size,
+              percent: 1.0,
+              status: SourceTrackOfflineInfoStatus.Succeeded,
+              type: SourceTrackOfflineInfoType.UserInitiated,
+            });
+
+            sourceTrack.offlineInfo = newOfflineInfo;
+          });
+
+          results.push({
+            type: 'offline_track',
+            identifier: offlineTrack.track_uuid,
+            success: true,
+            migrated: true,
+            message: `${sourceTrack.artist.name} - ${sourceTrack.title}`,
+          });
+
+          break;
+        }
+      }
+    }
+
+    return results;
+  }
+
+  public async migrateFavoriteShow(showUuid: string): Promise<LegacyDataMigrationResult> {
+    const showBehavior = new ShowWithFullSourcesNetworkBackedBehavior(this.realm, showUuid);
+    const result = await NetworkBackedBehaviorExecutor.executeUntilMatches(
+      showBehavior,
+      this.api,
+      (result) => {
+        return (result.errors?.length ?? 0) > 0 || showBehavior.isLocalDataShowable(result.data);
+      }
+    );
+
+    const show = result.data.show;
+
+    if (show) {
+      const alreadyMigrated = show.isFavorite === true;
+
+      if (!alreadyMigrated) {
+        this.realm.write(() => {
+          show.isFavorite = true;
+        });
+      }
+
+      return {
+        type: 'show',
+        identifier: showUuid,
+        success: true,
+        migrated: !alreadyMigrated,
+        message: `${show.artist.name} - ${show.displayDate}`,
+      };
+    }
+
+    if (result.errors && result.errors.length > 0) {
+      return {
+        type: 'show',
+        identifier: showUuid,
+        success: false,
+        migrated: false,
+        message: result.errors.map((e) => errorDisplayString(e)).join(', '),
+      };
+    }
+
+    return {
+      type: 'show',
+      identifier: showUuid,
+      success: false,
+      migrated: false,
+      message: 'Unknown error. No show or errors.',
+    };
+  }
+
+  public async migrateFavoriteSource(
+    legacySource: FavoritedSource
+  ): Promise<LegacyDataMigrationResult> {
+    const sourceUuid = legacySource.uuid;
+    const sourceBehavior = new ShowWithFullSourcesNetworkBackedBehavior(
+      this.realm,
+      legacySource.show_uuid,
+      sourceUuid
+    );
+    const result = await NetworkBackedBehaviorExecutor.executeUntilMatches(
+      sourceBehavior,
+      this.api,
+      (result) => {
+        return (result.errors?.length ?? 0) > 0 || sourceBehavior.isLocalDataShowable(result.data);
+      }
+    );
+
+    if (result.errors && result.errors.length > 0) {
+      return {
+        type: 'source',
+        identifier: sourceUuid,
+        success: false,
+        migrated: false,
+        message: result.errors.map((e) => errorDisplayString(e)).join(', '),
+      };
+    }
+
+    const show = result.data.show;
+    const sources = result.data.sources.filter((s) => s.uuid === sourceUuid);
+
+    if (sources.length === 0) {
+      return {
+        type: 'source',
+        identifier: sourceUuid,
+        success: false,
+        migrated: false,
+        message: 'Source not found',
+      };
+    }
+
+    const source = sources[0];
+
+    if (show && source) {
+      const alreadyMigrated = source.isFavorite === true;
+
+      if (!alreadyMigrated) {
+        this.realm.write(() => {
+          show.isFavorite = true;
+          source.isFavorite = true;
+        });
+      }
+
+      return {
+        type: 'source',
+        identifier: sourceUuid,
+        success: true,
+        migrated: !alreadyMigrated,
+        message: `${source.artist.name} - ${source.displayDate}`,
+      };
+    }
+
+    return {
+      type: 'source',
+      identifier: sourceUuid,
+      success: false,
+      migrated: false,
+      message: 'Unknown error. No show, sources  or errors.',
+    };
+  }
+
+  public async migrateFavoriteArtists(artistUuids: string[]): Promise<LegacyDataMigrationResult[]> {
+    const artistsBehavior = artistsNetworkBackedBehavior(this.realm, false);
+    const { data: artists } = await NetworkBackedBehaviorExecutor.executeToFirstShowableData(
+      artistsBehavior,
+      this.api
+    );
+
+    const artistByUuid = groupByUuid([...artists]);
+
+    const results: LegacyDataMigrationResult[] = this.realm.write(() => {
+      return artistUuids.map((uuid) => {
+        const artist = artistByUuid[uuid];
+
+        if (artist) {
+          const alreadyMigrated = artist.isFavorite === true;
+          artist.isFavorite = true;
+
+          return {
+            type: 'artist',
+            identifier: artist.uuid,
+            success: true,
+            migrated: !alreadyMigrated,
+            message: artist.name,
+          };
+        } else {
+          return {
+            type: 'artist',
+            identifier: uuid,
+            success: false,
+            migrated: false,
+            message: 'Artist not found',
+          };
+        }
+      });
+    });
+
+    return results;
+  }
+}
+
+export function LegacyDataMigrationModal({
+  forceShow = false,
+  ...props
+}: { forceShow?: boolean } & ModalProps) {
+  const [modalVisible, setModalVisible] = useState(forceShow);
+  const [seenModalBefore, setSeenModalBefore] = useState(false);
+  const [migrating, setMigrating] = useState(false);
+  const [legacyData, setLegacyData] = useState<LegacyDatabaseContents | undefined>(undefined);
+  const [migrationProgress, setMigrationProgress] = useState<string>('');
+  const shouldMakeNetworkRequests = useShouldMakeNetworkRequests();
+  const { apiClient } = useRelistenApi();
+  const realm = useRealm();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const value = await AsyncStorage.getItem(SEEN_MODAL_KEY);
+        console.log(`SEEN_MODAL_KEY=${SEEN_MODAL_KEY}, value=${value}`);
+        setSeenModalBefore(value === 'true');
+      } catch {
+        setSeenModalBefore(false);
+      }
+    })();
+  }, [setSeenModalBefore, forceShow]);
+
+  useEffect(() => {
+    if (seenModalBefore) {
+      return;
+    }
+
+    (async () => {
+      setLegacyData(await loadLegacyDatabaseContents());
+    })();
+  }, [seenModalBefore, setLegacyData]);
+
+  useEffect(() => {
+    if (legacyData) {
+      const hasNotDismissed = !seenModalBefore;
+      const eligibleForModal = hasNotDismissed && Platform.OS === 'ios';
+      const hasLegacyData = !isLegacyDatabaseEmpty(legacyData);
+
+      logger.debug(
+        `seenModalBefore=${seenModalBefore}, eligibleForModal=${eligibleForModal}, hasLegacyData=${hasLegacyData}`
+      );
+
+      if (eligibleForModal && hasLegacyData && shouldMakeNetworkRequests) {
+        setModalVisible(true);
+      }
+    }
+  }, [legacyData, setModalVisible, seenModalBefore]);
+
+  const clearModal = ({ markAsSeen }: { markAsSeen: boolean }) => {
+    if (markAsSeen) {
+      (async function () {
+        try {
+          await AsyncStorage.setItem(SEEN_MODAL_KEY, 'true');
+        } catch (e) {
+          logger.error(`Error setting ${SEEN_MODAL_KEY}: ${e}`);
+        }
+      })();
+    }
+    setModalVisible(false);
+  };
+
+  const migrateLegacyData = async () => {
+    if (!legacyData) {
+      return;
+    }
+
+    setMigrating(true);
+
+    const progress: string[] = [];
+
+    function addProgress(message: string) {
+      progress.push(message);
+      setMigrationProgress(progress.join('\n'));
+    }
+
+    function addResult(result: LegacyDataMigrationResult) {
+      addProgress(
+        `${result.type}: ${result.success ? '' : 'ERROR: '}${result.message ?? 'Unknown error'}`
+      );
+    }
+
+    addProgress('Starting migration');
+    const migrator = new LegacyDataMigrator(apiClient, realm);
+
+    if (legacyData.artistUuids.length > 0) {
+      addProgress('Migrating artists...');
+      const results = await migrator.migrateFavoriteArtists(legacyData.artistUuids);
+
+      results.forEach(addResult);
+    }
+
+    if (legacyData.showUuids.length > 0) {
+      addProgress('Migrating shows...');
+
+      for (const showUuid of legacyData.showUuids) {
+        const result = await migrator.migrateFavoriteShow(showUuid);
+
+        addResult(result);
+      }
+    }
+
+    if (legacyData.sources.length > 0) {
+      addProgress('Migrating sources...');
+
+      for (const source of legacyData.sources) {
+        const result = await migrator.migrateFavoriteSource(source);
+
+        addResult(result);
+      }
+    }
+
+    if (Object.entries(legacyData.offlineTracksBySource).length > 0) {
+      addProgress('Migrating offline tracks...');
+
+      for (const [sourceUuid, offlineTracks] of Object.entries(legacyData.offlineTracksBySource)) {
+        const results = await migrator.migrateOfflineTrack(
+          sourceUuid,
+          offlineTracks,
+          legacyData.offlineFilenames
+        );
+
+        results.forEach(addResult);
+      }
+    }
+
+    addProgress('Migration complete!');
+
+    setMigrating(false);
+
+    setTimeout(() => {
+      clearModal({ markAsSeen: true });
+    }, 5000);
+  };
+
+  return (
+    <>
+      <Modal
+        animationType="slide"
+        transparent={true}
+        visible={modalVisible}
+        onRequestClose={() => {
+          setModalVisible(false);
+        }}
+        {...props}
+      >
+        <Flex
+          className="flex-1 items-center justify-center"
+          style={{ backgroundColor: 'rgba(0,0,0,0.75)' }}
+        >
+          <Flex
+            column
+            className="h-5/6 w-10/12 rounded-lg border-2 border-relisten-blue-700 bg-relisten-blue-900 p-4"
+          >
+            <Image
+              source={require('@/assets/Relisten White.png')}
+              resizeMode="contain"
+              className="mb-2 h-[28] w-full"
+            />
+            <ScrollView className="grow">
+              {legacyData ? (
+                <>
+                  <RelistenText className="mb-2">
+                    <Text className="font-bold">
+                      You can now migrate your favorites and offlined shows from the previous
+                      version of the app!
+                    </Text>
+                  </RelistenText>
+                  <RelistenText className="mb-4">
+                    By pressing the &ldquo;Migrate data&rdquo; button below, all your prior
+                    favorites will be migrated and joined in with any existing favorites you&apos;ve
+                    made in the new app.{' '}
+                    <RelistenText className="font-bold">
+                      You need an Internet connection to perform this migration.
+                    </RelistenText>{' '}
+                    If you don&apos;t have an Internet connection, you can still use the app, just
+                    press the &ldquo;Later&rdquo; button below to dismiss this message and migrate
+                    later from the Relisten tab.
+                  </RelistenText>
+                  <RelistenText className="font-bold">
+                    Legacy data that will be migrated
+                  </RelistenText>
+                  <RelistenText>{legacyData.artistUuids.length} Favorited artists</RelistenText>
+                  <RelistenText>{legacyData.showUuids.length} Favorited shows</RelistenText>
+                  <RelistenText>{legacyData.sources.length} Favorited sources</RelistenText>
+                  <RelistenText>
+                    {legacyData.offlineFilenames.length} Downloaded tracks
+                  </RelistenText>
+                  {migrationProgress.length > 0 && (
+                    <>
+                      <RelistenText className="mt-4 font-bold">Migration progress</RelistenText>
+                      <RelistenText className="whitespace-pre-wrap">
+                        {migrationProgress}
+                      </RelistenText>
+                    </>
+                  )}
+                </>
+              ) : (
+                <View className="flex-1 items-center justify-center">
+                  <ActivityIndicator size="large" color="white" />
+                </View>
+              )}
+            </ScrollView>
+            <View className="pt-4">
+              <Flex className="w-full justify-stretch pt-4">
+                <View className="basis-1/2 pr-1">
+                  <RelistenButton
+                    onPress={() => clearModal({ markAsSeen: true })}
+                    disabled={migrating}
+                  >
+                    Later
+                  </RelistenButton>
+                </View>
+                <View className="flex basis-1/2 flex-row items-stretch justify-stretch pl-1">
+                  <RelistenButton
+                    onPress={() => migrateLegacyData()}
+                    className="flex-1 bg-green-600"
+                    disabled={migrating}
+                  >
+                    Migrate data
+                  </RelistenButton>
+                </View>
+              </Flex>
+            </View>
+          </Flex>
+        </Flex>
+      </Modal>
+    </>
+  );
+}

--- a/relisten/realm/models/shows/today_shows_repo.ts
+++ b/relisten/realm/models/shows/today_shows_repo.ts
@@ -2,82 +2,64 @@ import { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
 import { Show as ApiShow } from '@/relisten/api/models/show';
 import { Show } from '@/relisten/realm/models/show';
 import { ShowsWithVenueNetworkBackedBehavior } from '@/relisten/realm/models/shows/show_with_venues_behavior';
-import * as R from 'remeda';
 
 import {
   NetworkBackedBehaviorFetchStrategy,
   NetworkBackedBehaviorOptions,
 } from '@/relisten/realm/network_backed_behavior';
 import { useNetworkBackedBehavior } from '@/relisten/realm/network_backed_behavior_hooks';
-import { useQuery } from '@/relisten/realm/schema';
-import { useEffect, useMemo, useState } from 'react';
+import { useRealm } from '@/relisten/realm/schema';
+import { useMemo } from 'react';
 import Realm from 'realm';
-import { showRepo } from '../show_repo';
-import { venueRepo } from '../venue_repo';
-import { Venue } from '../venue';
 import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
-import { upsertShowList } from '@/relisten/realm/models/repo_utils';
+import { RealmQueryValueStream } from '@/relisten/realm/value_streams';
 
 class TodayShowsNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBehavior {
   private emitter = new EventEmitter();
+  private asOf = new Date();
 
   constructor(
+    public realm: Realm.Realm,
     public artistUuids?: string[],
     options?: NetworkBackedBehaviorOptions
   ) {
-    super(options);
+    super(realm, options);
   }
 
   fetchFromApi(
     api: RelistenApiClient,
     forcedRefresh: boolean
   ): Promise<RelistenApiResponse<ApiShow[] | undefined>> {
-    const refreshOptions = api.refreshOptions(forcedRefresh) || {};
-
-    return api.todayShows({
-      bypassRateLimit: true,
-      bypassEtagCaching: true,
-      ...refreshOptions,
-    });
+    return api.todayShows(this.asOf, api.refreshOptions(forcedRefresh));
   }
 
-  useFetchFromLocal(): Realm.Results<Show> {
-    const [showUuids, setState] = useState<string[]>([]);
+  override createLocalUpdatingResults(): RealmQueryValueStream<Show> {
+    const now = new Date();
+    const formattedMonth = (now.getMonth() + 1).toFixed(0).padStart(2, '0');
+    const formattedDay = now.getDate().toFixed(0).padStart(2, '0');
 
-    useEffect(() => {
-      const onChange = (data: string[]) => setState(data);
-      const sub = this.emitter.addListener('onChange', onChange);
-      return () => sub.remove();
-    }, []);
+    let query = this.realm
+      .objects(Show)
+      .filtered('displayDate ENDSWITH $0', `-${formattedMonth}-${formattedDay}`);
 
-    return useQuery(
-      Show,
-      (query) =>
-        this.artistUuids
-          ? query.filtered('uuid in $0', showUuids).filtered('artistUuid in $0', this.artistUuids)
-          : query.filtered('uuid in $0', showUuids),
-      [this.artistUuids, showUuids]
-    );
-  }
+    if (this.artistUuids) {
+      query = query.filtered('artistUuid in $0', this.artistUuids);
+    }
 
-  override upsert(realm: Realm, localData: Realm.Results<Show>, apiData: ApiShow[]): void {
-    this.emitter.emit(
-      'onChange',
-      apiData.map((x) => x.uuid)
-    );
+    query = query.sorted('displayDate', true);
 
-    realm.write(() => {
-      upsertShowList(realm, apiData, localData, { performDeletes: false, queryForModel: true });
-    });
+    return new RealmQueryValueStream<Show>(this.realm, query);
   }
 }
 
 export const useTodayShows = (...artistUuids: string[]) => {
+  const realm = useRealm();
+
   const behavior = useMemo(() => {
-    return new TodayShowsNetworkBackedBehavior(artistUuids, {
+    return new TodayShowsNetworkBackedBehavior(realm, artistUuids, {
       fetchStrategy: NetworkBackedBehaviorFetchStrategy.NetworkAlwaysFirst,
     });
-  }, [...artistUuids]);
+  }, [realm, JSON.stringify(artistUuids)]);
 
   return useNetworkBackedBehavior(behavior);
 };

--- a/relisten/realm/models/song_repo.ts
+++ b/relisten/realm/models/song_repo.ts
@@ -1,28 +1,30 @@
 import { useMemo } from 'react';
-import { createNetworkBackedModelArrayHook } from '../network_backed_behavior_hooks';
+import { useNetworkBackedBehavior } from '../network_backed_behavior_hooks';
 import { mergeNetworkBackedResults } from '../network_backed_results';
 import { Repository } from '../repository';
-import { useQuery } from '../schema';
+import { useRealm } from '../schema';
 import { useArtist } from './artist_repo';
 import { Song } from './song';
+import { NetworkBackedBehaviorOptions } from '@/relisten/realm/network_backed_behavior';
+import { NetworkBackedModelArrayBehavior } from '@/relisten/realm/network_backed_model_array_behavior';
 
 export const songRepo = new Repository(Song);
 
-export const useSongs = (artistUuid: string) => {
-  return createNetworkBackedModelArrayHook(
-    songRepo,
-    () => {
-      const artistQuery = useQuery(
-        Song,
-        (query) => query.filtered('artistUuid == $0', artistUuid),
-        [artistUuid]
-      );
+export function useSongs(artistUuid: string, options?: NetworkBackedBehaviorOptions) {
+  const realm = useRealm();
 
-      return artistQuery;
-    },
-    (api) => api.songs(artistUuid)
-  )();
-};
+  const behavior = useMemo(() => {
+    return new NetworkBackedModelArrayBehavior(
+      realm,
+      songRepo,
+      (realm) => realm.objects(Song).filtered('artistUuid == $0', artistUuid),
+      (api) => api.songs(artistUuid),
+      options
+    );
+  }, [realm, artistUuid, options]);
+
+  return useNetworkBackedBehavior(behavior);
+}
 
 export const useArtistSongs = (artistUuid: string) => {
   const artistResults = useArtist(artistUuid);

--- a/relisten/realm/network_backed_behavior.ts
+++ b/relisten/realm/network_backed_behavior.ts
@@ -143,7 +143,7 @@ export class NetworkBackedBehaviorExecutor<TLocalData, TApiData> {
     api: RelistenApiClient,
     matcher: (results: NetworkBackedResults<TLocalData>) => boolean
   ): Promise<NetworkBackedResults<TLocalData>> {
-    const executor = new NetworkBackedBehaviorExecutor(behavior, api);
+    const executor = behavior.sharedExecutor(api);
     const result = await executor.start().firstMatch(matcher);
 
     executor.tearDown();

--- a/relisten/realm/network_backed_behavior.ts
+++ b/relisten/realm/network_backed_behavior.ts
@@ -1,8 +1,14 @@
-import { RelistenApiUpdatableObject, Repository } from './repository';
-import { RelistenObjectRequiredProperties } from './relisten_object';
-import { RelistenApiClient, RelistenApiResponse } from '../api/client';
+import {
+  RelistenApiClient,
+  RelistenApiClientError,
+  RelistenApiResponse,
+  RelistenApiResponseType,
+} from '../api/client';
 import dayjs from 'dayjs';
-import Realm from 'realm';
+import { useEffect, useMemo, useState } from 'react';
+import { NetworkBackedResults } from '@/relisten/realm/network_backed_results';
+import { log } from '@/relisten/util/logging';
+import { EmittableValueStream, ValueStream } from '@/relisten/realm/value_streams';
 
 export enum NetworkBackedBehaviorFetchStrategy {
   UNKNOWN,
@@ -12,69 +18,37 @@ export enum NetworkBackedBehaviorFetchStrategy {
   NetworkOnlyIfLocalIsNotShowable,
 }
 
-export interface NetworkBackedBehavior<TLocalData, TApiData> {
-  fetchStrategy: NetworkBackedBehaviorFetchStrategy;
+export abstract class NetworkBackedBehavior<TLocalData, TApiData> {
+  abstract fetchStrategy: NetworkBackedBehaviorFetchStrategy;
 
-  useFetchFromLocal(): TLocalData;
+  abstract createLocalUpdatingResults(): ValueStream<TLocalData>;
 
-  fetchFromApi(
-    api: RelistenApiClient,
-    forcedRefresh: boolean
-  ): Promise<RelistenApiResponse<TApiData | undefined>>;
+  useFetchFromLocal(): TLocalData {
+    const updatingResults = useMemo(() => {
+      return this.createLocalUpdatingResults();
+    }, []);
+    const [localData, setLocalData] = useState<TLocalData>(updatingResults.currentValue);
 
-  shouldPerformNetworkRequest(
-    lastRequestAt: dayjs.Dayjs | undefined,
-    localData: TLocalData
-  ): boolean;
+    useEffect(() => {
+      updatingResults.addListener((newLocalData) => {
+        setLocalData(newLocalData);
+      });
 
-  isLocalDataShowable(localData: TLocalData): boolean;
+      return () => {
+        updatingResults.tearDown();
+      };
+    }, [updatingResults, setLocalData]);
 
-  upsert(realm: Realm, localData: TLocalData | null, apiData: TApiData): void;
-}
-
-export interface NetworkBackedBehaviorOptions {
-  minTimeBetweenRequestsSeconds?: number;
-  fetchStrategy?: NetworkBackedBehaviorFetchStrategy;
-}
-
-export abstract class ThrottledNetworkBackedBehavior<TLocalData, TApiData>
-  implements NetworkBackedBehavior<TLocalData, TApiData>
-{
-  protected lastRequestAt: dayjs.Dayjs | undefined;
-  protected minTimeBetweenRequestsSeconds: number;
-  public readonly fetchStrategy: NetworkBackedBehaviorFetchStrategy;
-
-  protected constructor(options?: NetworkBackedBehaviorOptions) {
-    this.minTimeBetweenRequestsSeconds = 60 * 15;
-    this.fetchStrategy =
-      options?.fetchStrategy || NetworkBackedBehaviorFetchStrategy.StaleWhileRevalidate;
-
-    if (options?.minTimeBetweenRequestsSeconds !== undefined) {
-      this.minTimeBetweenRequestsSeconds = options.minTimeBetweenRequestsSeconds;
-    }
+    return localData;
   }
 
-  shouldPerformNetworkRequest(
-    lastRequestAt: dayjs.Dayjs | undefined,
-    localData: TLocalData
-  ): boolean {
-    if (
-      this.fetchStrategy === NetworkBackedBehaviorFetchStrategy.LocalOnly ||
-      (this.fetchStrategy === NetworkBackedBehaviorFetchStrategy.NetworkOnlyIfLocalIsNotShowable &&
-        this.isLocalDataShowable(localData))
-    ) {
-      return false;
+  private _sharedExecutor: NetworkBackedBehaviorExecutor<TLocalData, TApiData> | undefined;
+  sharedExecutor(api: RelistenApiClient) {
+    if (!this._sharedExecutor) {
+      this._sharedExecutor = new NetworkBackedBehaviorExecutor(this, api);
     }
 
-    if (!lastRequestAt) {
-      return true;
-    }
-
-    this.lastRequestAt = lastRequestAt;
-
-    const msSinceLastRequest = dayjs().diff(lastRequestAt, 'milliseconds');
-
-    return msSinceLastRequest >= this.minTimeBetweenRequestsSeconds * 1000;
+    return this._sharedExecutor;
   }
 
   abstract fetchFromApi(
@@ -82,82 +56,148 @@ export abstract class ThrottledNetworkBackedBehavior<TLocalData, TApiData>
     forcedRefresh: boolean
   ): Promise<RelistenApiResponse<TApiData | undefined>>;
 
-  abstract useFetchFromLocal(): TLocalData;
+  abstract shouldPerformNetworkRequest(
+    lastRequestAt: dayjs.Dayjs | undefined,
+    localData: TLocalData
+  ): boolean;
 
   abstract isLocalDataShowable(localData: TLocalData): boolean;
 
-  abstract upsert(realm: Realm, localData: TLocalData, apiData: TApiData): void;
+  abstract upsert(localData: TLocalData | null, apiData: TApiData): void;
 }
 
-export class NetworkBackedModelArrayBehavior<
-  TModel extends RequiredProperties & RequiredRelationships,
-  TApi extends RelistenApiUpdatableObject,
-  RequiredProperties extends RelistenObjectRequiredProperties,
-  RequiredRelationships extends object,
-> extends ThrottledNetworkBackedBehavior<Realm.Results<TModel>, TApi[]> {
+export interface NetworkBackedBehaviorOptions {
+  minTimeBetweenRequestsSeconds?: number;
+  fetchStrategy?: NetworkBackedBehaviorFetchStrategy;
+}
+
+const logger = log.extend('NetworkBackedBehaviorExecutor');
+
+export const defaultNetworkLoadingValue = (
+  fetchStrategy: NetworkBackedBehaviorFetchStrategy,
+  dataExists: boolean
+) => {
+  return fetchStrategy === NetworkBackedBehaviorFetchStrategy.NetworkAlwaysFirst || !dataExists;
+};
+
+export class NetworkBackedResultValueStream<TLocalData> extends EmittableValueStream<
+  NetworkBackedResults<TLocalData>
+> {
+  firstMatch(
+    matcher: (result: NetworkBackedResults<TLocalData>) => boolean
+  ): Promise<NetworkBackedResults<TLocalData>> {
+    return new Promise((resolve) => {
+      const tearDown = this.addListener((newResults) => {
+        if (matcher(newResults)) {
+          setImmediate(() => tearDown());
+          resolve(newResults);
+        }
+      });
+    });
+  }
+}
+
+export class NetworkBackedBehaviorExecutor<TLocalData, TApiData> {
+  private isNetworkLoading: boolean;
+  private isNetworkLoadingDefault: boolean;
+  private errors: RelistenApiClientError[] | undefined = undefined;
+  private localData: ValueStream<TLocalData>;
+  private output: NetworkBackedResultValueStream<TLocalData>;
+
   constructor(
-    public repository: Repository<TModel, TApi, RequiredProperties, RequiredRelationships>,
-    public fetchFromRealm: () => Realm.Results<TModel>,
-    public apiCall: (
-      api: RelistenApiClient,
-      forcedRefresh: boolean
-    ) => Promise<RelistenApiResponse<TApi[]>>,
-    options?: NetworkBackedBehaviorOptions
+    private behavior: NetworkBackedBehavior<TLocalData, TApiData>,
+    private api: RelistenApiClient
   ) {
-    super(options);
+    this.localData = this.behavior.createLocalUpdatingResults();
+
+    const dataExists = this.behavior.isLocalDataShowable(this.localData.currentValue);
+    this.isNetworkLoadingDefault = defaultNetworkLoadingValue(
+      this.behavior.fetchStrategy,
+      dataExists
+    );
+
+    this.isNetworkLoading = this.isNetworkLoadingDefault;
+
+    this.output = new NetworkBackedResultValueStream<TLocalData>(this.buildResult());
+
+    this.localData.addListener(() => {
+      // If the local data changes, emit another output event
+      this.buildAndEmit();
+    });
   }
 
-  fetchFromApi(
+  currentResults(): NetworkBackedResults<TLocalData> {
+    return this.output.currentValue;
+  }
+
+  start(): NetworkBackedResultValueStream<TLocalData> {
+    this.refresh(this.isNetworkLoadingDefault).catch((e) => {
+      logger.error(e);
+    });
+
+    return this.output;
+  }
+
+  static async executeUntilMatches<TLocalData, TApiData>(
+    behavior: NetworkBackedBehavior<TLocalData, TApiData>,
     api: RelistenApiClient,
-    forcedRefresh: boolean
-  ): Promise<RelistenApiResponse<TApi[]>> {
-    return this.apiCall(api, forcedRefresh);
+    matcher: (results: NetworkBackedResults<TLocalData>) => boolean
+  ): Promise<NetworkBackedResults<TLocalData>> {
+    const executor = new NetworkBackedBehaviorExecutor(behavior, api);
+    const result = await executor.start().firstMatch(matcher);
+
+    executor.tearDown();
+
+    return result;
   }
 
-  useFetchFromLocal(): Realm.Results<TModel> {
-    return this.fetchFromRealm();
+  static executeToFirstShowableData<TLocalData, TApiData>(
+    behavior: NetworkBackedBehavior<TLocalData, TApiData>,
+    api: RelistenApiClient
+  ): Promise<NetworkBackedResults<TLocalData>> {
+    return this.executeUntilMatches(behavior, api, (result) => {
+      return behavior.isLocalDataShowable(result.data);
+    });
   }
 
-  isLocalDataShowable(localData: Realm.Results<TModel>): boolean {
-    return localData.length > 0;
+  public tearDown() {
+    this.output.tearDown();
+    this.localData.tearDown();
   }
 
-  upsert(realm: Realm, localData: Realm.Results<TModel>, apiData: TApi[]): void {
-    this.repository.upsertMultiple(realm, apiData, localData, true, true);
-  }
-}
-
-export class NetworkBackedModelBehavior<
-  TModel extends RequiredProperties & RequiredRelationships,
-  TApi extends RelistenApiUpdatableObject,
-  RequiredProperties extends RelistenObjectRequiredProperties,
-  RequiredRelationships extends object,
-> extends ThrottledNetworkBackedBehavior<TModel | null, TApi> {
-  constructor(
-    public repository: Repository<TModel, TApi, RequiredProperties, RequiredRelationships>,
-    public fetchFromRealm: () => TModel | null,
-    public apiCall: (
-      api: RelistenApiClient,
-      forcedRefresh: boolean
-    ) => Promise<RelistenApiResponse<TApi>>,
-    options?: NetworkBackedBehaviorOptions
-  ) {
-    super(options);
+  private buildResult(): NetworkBackedResults<TLocalData> {
+    // It is important that all of these have stable values and only change identities
+    // when there has been a semantic change for React compatiblity.
+    return {
+      isNetworkLoading: this.isNetworkLoading,
+      data: this.localData.currentValue,
+      refresh: this.refresh,
+      errors: this.errors,
+    };
   }
 
-  fetchFromApi(api: RelistenApiClient, forcedRefresh: boolean): Promise<RelistenApiResponse<TApi>> {
-    return this.apiCall(api, forcedRefresh);
+  private buildAndEmit() {
+    this.output.emit(this.buildResult());
   }
 
-  useFetchFromLocal(): TModel | null {
-    return this.fetchFromRealm();
-  }
+  refresh = async (shouldForceLoadingSpinner: boolean = false) => {
+    if (shouldForceLoadingSpinner) {
+      this.isNetworkLoading = true;
+      this.buildAndEmit();
+    }
+    const apiData = await this.behavior.fetchFromApi(this.api, shouldForceLoadingSpinner);
 
-  isLocalDataShowable(localData: TModel | null): boolean {
-    return localData !== null;
-  }
+    if (apiData?.type == RelistenApiResponseType.OnlineRequestCompleted) {
+      if (apiData?.data) {
+        this.behavior.upsert(this.localData.currentValue, apiData.data);
+      }
 
-  upsert(realm: Realm, localData: TModel, apiData: TApi): void {
-    this.repository.upsert(realm, apiData, localData);
-  }
+      if (apiData?.error) {
+        this.errors = [apiData?.error];
+      }
+    }
+
+    this.isNetworkLoading = false;
+    this.buildAndEmit();
+  };
 }

--- a/relisten/realm/network_backed_model_array_behavior.ts
+++ b/relisten/realm/network_backed_model_array_behavior.ts
@@ -1,0 +1,46 @@
+import Realm, { AnyRealmObject } from 'realm';
+import { RelistenApiUpdatableObject, Repository } from '@/relisten/realm/repository';
+import { RelistenObjectRequiredProperties } from '@/relisten/realm/relisten_object';
+import { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
+import { RealmQueryValueStream, ValueStream } from '@/relisten/realm/value_streams';
+import { NetworkBackedBehaviorOptions } from '@/relisten/realm/network_backed_behavior';
+import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_network_backed_behavior';
+
+export class NetworkBackedModelArrayBehavior<
+  TModel extends AnyRealmObject & RequiredProperties & RequiredRelationships,
+  TApi extends RelistenApiUpdatableObject,
+  RequiredProperties extends RelistenObjectRequiredProperties,
+  RequiredRelationships extends object,
+> extends ThrottledNetworkBackedBehavior<Realm.Results<TModel>, TApi[]> {
+  constructor(
+    public realm: Realm.Realm,
+    public repository: Repository<TModel, TApi, RequiredProperties, RequiredRelationships>,
+    public fetchFromRealm: (realm: Realm.Realm) => Realm.Results<TModel>,
+    public apiCall: (
+      api: RelistenApiClient,
+      forcedRefresh: boolean
+    ) => Promise<RelistenApiResponse<TApi[]>>,
+    options?: NetworkBackedBehaviorOptions
+  ) {
+    super(realm, options);
+  }
+
+  override createLocalUpdatingResults(): ValueStream<Realm.Results<TModel>> {
+    return new RealmQueryValueStream<TModel>(this.realm, this.fetchFromRealm(this.realm));
+  }
+
+  fetchFromApi(
+    api: RelistenApiClient,
+    forcedRefresh: boolean
+  ): Promise<RelistenApiResponse<TApi[]>> {
+    return this.apiCall(api, forcedRefresh);
+  }
+
+  isLocalDataShowable(localData: Realm.Results<TModel>): boolean {
+    return localData.length > 0;
+  }
+
+  override upsert(localData: Realm.Results<TModel>, apiData: TApi[]): void {
+    this.repository.upsertMultiple(this.realm, apiData, localData, true, true);
+  }
+}

--- a/relisten/realm/network_backed_model_behavior.ts
+++ b/relisten/realm/network_backed_model_behavior.ts
@@ -1,0 +1,47 @@
+import Realm, { AnyRealmObject } from 'realm';
+import { RelistenApiUpdatableObject, Repository } from '@/relisten/realm/repository';
+import { RelistenObjectRequiredProperties } from '@/relisten/realm/relisten_object';
+import { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
+import { RealmObjectValueStream, ValueStream } from '@/relisten/realm/value_streams';
+import { NetworkBackedBehaviorOptions } from '@/relisten/realm/network_backed_behavior';
+import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_network_backed_behavior';
+
+export class NetworkBackedModelBehavior<
+  TModel extends AnyRealmObject & RequiredProperties & RequiredRelationships,
+  TApi extends RelistenApiUpdatableObject,
+  RequiredProperties extends RelistenObjectRequiredProperties,
+  RequiredRelationships extends object,
+> extends ThrottledNetworkBackedBehavior<TModel | null, TApi> {
+  constructor(
+    public realm: Realm.Realm,
+    public repository: Repository<TModel, TApi, RequiredProperties, RequiredRelationships>,
+    public fetchFromRealm: () => [
+      type: string | (new (...args: unknown[]) => TModel),
+      primaryKey: TModel[keyof TModel],
+    ],
+    public apiCall: (
+      api: RelistenApiClient,
+      forcedRefresh: boolean
+    ) => Promise<RelistenApiResponse<TApi>>,
+    options?: NetworkBackedBehaviorOptions
+  ) {
+    super(realm, options);
+  }
+
+  fetchFromApi(api: RelistenApiClient, forcedRefresh: boolean): Promise<RelistenApiResponse<TApi>> {
+    return this.apiCall(api, forcedRefresh);
+  }
+
+  override createLocalUpdatingResults(): ValueStream<TModel | null> {
+    const [type, primaryKey] = this.fetchFromRealm();
+    return new RealmObjectValueStream<TModel>(this.realm, type, primaryKey);
+  }
+
+  isLocalDataShowable(localData: TModel | null): boolean {
+    return localData !== null;
+  }
+
+  override upsert(localData: TModel, apiData: TApi): void {
+    this.repository.upsert(this.realm, apiData, localData);
+  }
+}

--- a/relisten/realm/realm_filters.ts
+++ b/relisten/realm/realm_filters.ts
@@ -25,22 +25,24 @@ export const useRealmTabsFilter = <T extends RelistenObject>(items: Realm.Result
   return items;
 };
 
+export interface UserFilters {
+  isFavorite?: boolean | null;
+  isPlayableOffline?: boolean | null;
+  operator?: 'AND' | 'OR';
+}
+
 export function filterForUser<T extends RelistenObject & FavoritableObject>(
   query: Realm.Results<T>,
-  {
-    isFavorite = true,
-    isPlayableOffline = true,
-    operator = 'OR',
-  }: { isFavorite?: boolean; isPlayableOffline?: boolean; operator?: 'AND' | 'OR' }
+  { isFavorite = true, isPlayableOffline = true, operator = 'OR' }: UserFilters
 ): Realm.Results<T> {
   const filters: string[] = [];
   const args: unknown[] = [];
 
-  if (isFavorite !== undefined) {
+  if (isFavorite !== null) {
     filters.push(`isFavorite == $${args.length}`);
     args.push(isFavorite);
   }
-  if (isPlayableOffline !== undefined) {
+  if (isPlayableOffline !== null) {
     filters.push(
       `SUBQUERY(sourceTracks, $item, $item.offlineInfo.status == ${SourceTrackOfflineInfoStatus.Succeeded}).@count ${isPlayableOffline ? '>' : '='} 0`
     );

--- a/relisten/realm/throttled_network_backed_behavior.ts
+++ b/relisten/realm/throttled_network_backed_behavior.ts
@@ -1,0 +1,64 @@
+import dayjs from 'dayjs';
+import Realm from 'realm';
+import { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
+import {
+  NetworkBackedBehavior,
+  NetworkBackedBehaviorFetchStrategy,
+  NetworkBackedBehaviorOptions,
+} from '@/relisten/realm/network_backed_behavior';
+
+export abstract class ThrottledNetworkBackedBehavior<
+  TLocalData,
+  TApiData,
+> extends NetworkBackedBehavior<TLocalData, TApiData> {
+  protected lastRequestAt: dayjs.Dayjs | undefined;
+  protected minTimeBetweenRequestsSeconds: number;
+  public readonly fetchStrategy: NetworkBackedBehaviorFetchStrategy;
+
+  protected constructor(
+    public realm: Realm.Realm,
+    options?: NetworkBackedBehaviorOptions
+  ) {
+    super();
+
+    this.minTimeBetweenRequestsSeconds = 60 * 15;
+    this.fetchStrategy =
+      options?.fetchStrategy || NetworkBackedBehaviorFetchStrategy.StaleWhileRevalidate;
+
+    if (options?.minTimeBetweenRequestsSeconds !== undefined) {
+      this.minTimeBetweenRequestsSeconds = options.minTimeBetweenRequestsSeconds;
+    }
+  }
+
+  shouldPerformNetworkRequest(
+    lastRequestAt: dayjs.Dayjs | undefined,
+    localData: TLocalData
+  ): boolean {
+    if (
+      this.fetchStrategy === NetworkBackedBehaviorFetchStrategy.LocalOnly ||
+      (this.fetchStrategy === NetworkBackedBehaviorFetchStrategy.NetworkOnlyIfLocalIsNotShowable &&
+        this.isLocalDataShowable(localData))
+    ) {
+      return false;
+    }
+
+    if (!lastRequestAt) {
+      return true;
+    }
+
+    this.lastRequestAt = lastRequestAt;
+
+    const msSinceLastRequest = dayjs().diff(lastRequestAt, 'milliseconds');
+
+    return msSinceLastRequest >= this.minTimeBetweenRequestsSeconds * 1000;
+  }
+
+  abstract fetchFromApi(
+    api: RelistenApiClient,
+    forcedRefresh: boolean
+  ): Promise<RelistenApiResponse<TApiData | undefined>>;
+
+  abstract isLocalDataShowable(localData: TLocalData): boolean;
+
+  abstract upsert(localData: TLocalData, apiData: TApiData): void;
+}

--- a/relisten/realm/value_streams.ts
+++ b/relisten/realm/value_streams.ts
@@ -1,0 +1,228 @@
+import Realm, { AnyRealmObject } from 'realm';
+import { CollectionCallback } from '@realm/react/src/helpers';
+import { createCachedObject } from '@realm/react/src/cachedObject';
+import { createCachedCollection } from '@realm/react/src/cachedCollection';
+
+export abstract class ValueStream<T> {
+  protected listeners: ((nextValue: T) => void)[] = [];
+  public abstract currentValue: T;
+
+  protected emitCurrentValue() {
+    for (const listener of this.listeners) {
+      listener(this.currentValue);
+    }
+  }
+
+  tearDown() {
+    this.listeners = [];
+  }
+
+  addListener(listener: (nextValue: T) => void): () => void {
+    this.listeners.push(listener);
+
+    // Should this be synchronous?
+    listener(this.currentValue);
+
+    return () => {
+      this.listeners = this.listeners.splice(this.listeners.indexOf(listener), 1);
+    };
+  }
+}
+
+export class EmittableValueStream<T> extends ValueStream<T> {
+  public currentValue: T;
+
+  public constructor(firstValue: T) {
+    super();
+
+    this.currentValue = firstValue;
+  }
+
+  public emit(newValue: T) {
+    this.currentValue = newValue;
+    this.emitCurrentValue();
+  }
+}
+
+export class CombinedValueStream<T, A, B> extends ValueStream<T> {
+  public currentValue!: T;
+
+  constructor(
+    private resultsA: ValueStream<A>,
+    private resultsB: ValueStream<B>,
+    private transform: (a: A, b: B) => T
+  ) {
+    super();
+
+    this.resultsA.addListener(() => this.executeTransform());
+    this.resultsB.addListener(() => this.executeTransform());
+
+    this.executeTransform();
+  }
+
+  private executeTransform() {
+    this.currentValue = this.transform(this.resultsA.currentValue, this.resultsB.currentValue);
+    this.emitCurrentValue();
+  }
+}
+
+export class RealmQueryValueStream<T extends AnyRealmObject> extends ValueStream<Realm.Results<T>> {
+  private readonly cachedCollectionTearDown: () => void;
+  public currentValue: Realm.Results<T>;
+
+  constructor(
+    realm: Realm.Realm,
+    private collection: Realm.Results<T>
+  ) {
+    super();
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const that = this;
+
+    const { collection: cachedCollection, tearDown } = createCachedCollection<T>({
+      collection,
+      realm,
+      // Re-emit the same value without changes when only a sub-object changed
+      updateCallback: () => this.emitCurrentValue(),
+      updatedRef: {
+        set current(newValue) {
+          if (newValue) {
+            // create a new proxy when necessary
+            that.currentValue = new Proxy(that.collection, {});
+            that.emitCurrentValue();
+          }
+        },
+        get current() {
+          // creating the new reference is always immediate
+          return false;
+        },
+      },
+    });
+
+    this.cachedCollectionTearDown = tearDown;
+    this.currentValue = new Proxy(cachedCollection as Realm.Results<T>, {});
+    this.emitCurrentValue();
+  }
+
+  tearDown() {
+    super.tearDown();
+    this.cachedCollectionTearDown();
+  }
+}
+
+// Source: https://github.com/realm/realm-js/blob/8ccb12092fbe22480e4039ca125f43c5199b2a2e/packages/realm-react/src/useObject.tsx#L213
+// Apache License 2.0
+function arePrimaryKeysIdentical(a: unknown, b: unknown): boolean {
+  // This is a helper function that determines if two primary keys are equal.  It will also handle the case where the primary key is an ObjectId or UUID
+  if (typeof a !== typeof b) {
+    return false;
+  }
+  if (typeof a === 'string' || typeof a === 'number') {
+    return a === b;
+  }
+  if (a instanceof Realm.BSON.ObjectId && b instanceof Realm.BSON.ObjectId) {
+    return a.toHexString() === b.toHexString();
+  }
+  if (a instanceof Realm.BSON.UUID && b instanceof Realm.BSON.UUID) {
+    return a.toHexString() === b.toHexString();
+  }
+  return false;
+}
+
+export class RealmObjectValueStream<T extends AnyRealmObject> extends ValueStream<T | null> {
+  private cachedObjectTearDown: (() => void) | undefined = undefined;
+  private collectionListenerTearDown: (() => void) | undefined = undefined;
+  public currentValue: T | null = null;
+
+  constructor(
+    private realm: Realm.Realm,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private type: string | (new (...args: any) => T),
+    private primaryKey: T[keyof T]
+  ) {
+    super();
+
+    const originalObject = realm.objectForPrimaryKey<T>(type as never, primaryKey);
+
+    if (originalObject) {
+      this.setupCachedObject(originalObject);
+    } else {
+      this.setupCollectionListener();
+    }
+  }
+
+  private setupCollectionListener() {
+    const collection = this.realm.objects(this.type as never);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const collectionListener: CollectionCallback = (_, changes) => {
+      const primaryKeyProperty = collection?.[0]?.objectSchema()?.primaryKey;
+
+      for (const index of changes.insertions) {
+        const object = collection[index];
+        if (primaryKeyProperty) {
+          const insertedPrimaryKey = object[primaryKeyProperty];
+          if (arePrimaryKeysIdentical(insertedPrimaryKey, this.primaryKey)) {
+            this.currentValue = object as T;
+            this.setupCachedObject(object as T);
+
+            this.emitCurrentValue();
+
+            collection.removeListener(collectionListener);
+            break;
+          }
+        }
+      }
+
+      collection.addListener(collectionListener);
+
+      this.collectionListenerTearDown = () => {
+        // If the app is closing, the realm will be closed and the listener does not need to be removed if
+        if (!this.realm.isClosed && collection) {
+          collection.removeListener(collectionListener);
+        }
+      };
+    };
+  }
+
+  private setupCachedObject(originalObject: T) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const that = this;
+
+    const { object: cachedObject, tearDown } = createCachedObject({
+      object: originalObject,
+      realm: this.realm,
+      // Re-emit the same value without changes when only a sub-object changed
+      updateCallback: () => this.emitCurrentValue(),
+      updatedRef: {
+        set current(newValue) {
+          if (newValue) {
+            // create a new proxy when necessary
+            that.currentValue = new Proxy(originalObject, {});
+            that.emitCurrentValue();
+          }
+        },
+        get current() {
+          // creating the new reference is always immediate
+          return false;
+        },
+      },
+    });
+
+    this.cachedObjectTearDown = tearDown;
+    this.currentValue = new Proxy(cachedObject as T, {});
+    this.emitCurrentValue();
+  }
+
+  tearDown() {
+    super.tearDown();
+
+    if (this.cachedObjectTearDown) {
+      this.cachedObjectTearDown();
+    }
+
+    if (this.collectionListenerTearDown) {
+      this.collectionListenerTearDown();
+    }
+  }
+}


### PR DESCRIPTION
The local data components relied on being mounted in components to work at all. This refactors everything to use vanilla JS (as event streams) and then wrap them in hooks. This allows for usage outside of hooks (e.g. CarPlay, legacy migration, etc)