### PR TITLE
Fix temp file deletion crash

### DIFF
--- a/relisten/offline/download_manager.ts
+++ b/relisten/offline/download_manager.ts
@@ -430,8 +430,12 @@ export class DownloadManager {
           }
           await ReactNativeBlobUtil.fs.mv(path, dest);
         } finally {
-          // if we encounter an error, clean up
-          res.flush();
+          // if we encounter an error, clean up the temporary file
+          try {
+            await res.flush();
+          } catch (e) {
+            log.warn(`Failed to flush temporary download ${path}`, e);
+          }
         }
 
         const oi = refreshOfflineInfo();


### PR DESCRIPTION
## Summary
- handle flush failures in download manager

## Testing
- `yarn lint` *(fails: '@typescript-eslint/no-unused-vars' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687878d91908833282d5eb71ab07ea40