### PR TITLE
[codex] Fix MP3 CBR seek regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ fabric.properties
 modules/relisten-audio-player/android/build
 modules/relisten-audio-player/.build/
 modules/relisten-audio-player/tools/GaplessMP3PlayerHarness/.build/
+modules/relisten-audio-player/tools/GaplessMP3PlayerHarness/E2EFixtures/
 /builds
 
 .vscode/*

--- a/modules/relisten-audio-player/ios/GaplessMP3Player/API/TrackMetadata.swift
+++ b/modules/relisten-audio-player/ios/GaplessMP3Player/API/TrackMetadata.swift
@@ -77,6 +77,17 @@ public struct MP3TrackMetadata: Codable, Equatable, Sendable {
         case vbri
     }
 
+    /// Indicates whether approximate byte seeking is safe when no seek table is usable.
+    ///
+    /// A duration plus a first-frame bitrate is not enough evidence on its own: many
+    /// VBR files still expose those fields, but their byte positions do not scale
+    /// linearly with time. The parser sets this only after it has enough frame-level
+    /// evidence that bitrate-derived byte positions are defensible.
+    public enum ApproximateSeekStrategy: String, Codable, Sendable {
+        case unavailable
+        case constantBitrate
+    }
+
     public var sourceID: String
     public var sourceURL: URL
     public var cacheKey: String
@@ -90,6 +101,7 @@ public struct MP3TrackMetadata: Codable, Equatable, Sendable {
     public var samplesPerFrame: Int
     public var firstFrameByteLength: Int
     public var estimatedBitrate: Int?
+    public var approximateSeekStrategy: ApproximateSeekStrategy
     public var durationUs: Int64?
     public var encoderDelayFrames: Int
     public var encoderPaddingFrames: Int
@@ -110,6 +122,7 @@ public struct MP3TrackMetadata: Codable, Equatable, Sendable {
         samplesPerFrame: Int,
         firstFrameByteLength: Int = 0,
         estimatedBitrate: Int? = nil,
+        approximateSeekStrategy: ApproximateSeekStrategy = .unavailable,
         durationUs: Int64?,
         encoderDelayFrames: Int,
         encoderPaddingFrames: Int,
@@ -129,6 +142,7 @@ public struct MP3TrackMetadata: Codable, Equatable, Sendable {
         self.samplesPerFrame = samplesPerFrame
         self.firstFrameByteLength = firstFrameByteLength
         self.estimatedBitrate = estimatedBitrate
+        self.approximateSeekStrategy = approximateSeekStrategy
         self.durationUs = durationUs
         self.encoderDelayFrames = encoderDelayFrames
         self.encoderPaddingFrames = encoderPaddingFrames

--- a/modules/relisten-audio-player/ios/GaplessMP3Player/Metadata/MP3GaplessMetadataParser.swift
+++ b/modules/relisten-audio-player/ios/GaplessMP3Player/Metadata/MP3GaplessMetadataParser.swift
@@ -3,6 +3,11 @@ import Foundation
 struct MP3GaplessMetadataParser {
     private static let maxSyncSearchBytes = 131_072
     private static let headerMatchMask: UInt32 = 0xFFFE0C00
+    // 64 MPEG-1 Layer III frames are about 1.7 seconds of audio and under 100 KB
+    // even at high MP3 bitrates. That is enough to catch common VBR intros that
+    // hold one bitrate briefly, while staying inside the metadata prefix we already
+    // fetched and avoiding a whole-file scan during preparation.
+    private static let cbrConfidenceFrameSampleCount = 64
 
     struct ParsedID3Info {
         var encoderDelay: Int?
@@ -54,11 +59,39 @@ struct MP3GaplessMetadataParser {
 
         let delay = id3Info.encoderDelay ?? seekHeader.encoderDelay ?? 0
         let padding = id3Info.encoderPadding ?? seekHeader.encoderPadding ?? 0
+
+        // Xing/Info/VBRI headers may report the audio payload size. If they do not,
+        // a trusted HTTP/file content length still lets us bound CBR tracks without
+        // reading the whole file during metadata preparation.
+        let seekHeaderDataSize = seekHeader.dataSize
+            .map(Int64.init)
+            .flatMap { $0 > 0 ? $0 : nil }
+        let fallbackDataSize = fingerprint.contentLength
+            .map { max($0 - Int64(firstFrameOffset), 0) }
+            .flatMap { $0 > 0 ? $0 : nil }
+        let dataSize = seekHeaderDataSize ?? fallbackDataSize
+
+        // For true CBR, duration is linear: bytes * 8 / bitrate. That shortcut is
+        // wrong for VBR files, including Xing/VBRI files whose seek tables are absent
+        // or unusable, so parser-verified CBR is the only path that enables it.
+        let allowsCBRDurationFallback =
+            (seekHeader.kind == .info || seekHeader.kind == .none) &&
+            isLikelyCBR(
+                data: data,
+                firstFrameOffset: firstFrameOffset,
+                firstHeader: header,
+                knownContentLength: fingerprint.contentLength
+            )
+        let approximateSeekStrategy: MP3TrackMetadata.ApproximateSeekStrategy =
+            allowsCBRDurationFallback ? .constantBitrate : .unavailable
+        let fallbackDurationUs = allowsCBRDurationFallback ? dataSize.map {
+            ($0 * 8 * 1_000_000) / Int64(header.bitrate)
+        } : nil
         let durationUs = seekHeader.frameCount.map {
             let totalSamples = max(Int64($0 * header.samplesPerFrame) - 1, 0)
             return (totalSamples * 1_000_000) / Int64(header.sampleRate)
-        }
-        let dataEndOffset = seekHeader.dataSize.map { Int64(firstFrameOffset + $0 - 1) }
+        } ?? fallbackDurationUs
+        let dataEndOffset = dataSize.map { Int64(firstFrameOffset) + $0 - 1 }
 
         return MP3TrackMetadata(
             sourceID: source.id,
@@ -74,6 +107,7 @@ struct MP3GaplessMetadataParser {
             samplesPerFrame: header.samplesPerFrame,
             firstFrameByteLength: header.frameSize,
             estimatedBitrate: header.bitrate,
+            approximateSeekStrategy: approximateSeekStrategy,
             durationUs: durationUs,
             encoderDelayFrames: delay,
             encoderPaddingFrames: padding,
@@ -177,6 +211,9 @@ struct MP3GaplessMetadataParser {
                 continue
             }
 
+            // MPEG sync words are short enough to appear inside ID3/artwork bytes.
+            // Require several structurally compatible frames in a row before treating
+            // an offset as the start of audio.
             if validateConsecutiveFrames(data: data, startOffset: offset, firstHeader: header) {
                 return offset
             }
@@ -192,6 +229,8 @@ struct MP3GaplessMetadataParser {
         let targetMask = firstHeader.rawValue & Self.headerMatchMask
         for index in 0 ..< 4 {
             guard let header = try? parseHeader(at: offset, in: data) else { return false }
+            // This validates the stream shape, not constant bitrate. Bitrate and
+            // padding may legitimately vary; CBR confidence is established later.
             if (header.rawValue & Self.headerMatchMask) != targetMask {
                 return false
             }
@@ -251,6 +290,9 @@ struct MP3GaplessMetadataParser {
             throw GaplessMP3PlayerError.invalidMP3("Unsupported bitrate or sample rate")
         }
 
+        // Layer III stores a fixed number of decoded samples per frame. The byte
+        // length is derived from bitrate/sample-rate plus an optional one-byte
+        // padding bit, which is why CBR frames can alternate between two sizes.
         let samplesPerFrame = versionBits == 0b11 ? 1_152 : 576
         let bitrate = bitrateKbps * 1_000
         let frameSize = versionBits == 0b11
@@ -272,6 +314,45 @@ struct MP3GaplessMetadataParser {
             frameSize: frameSize,
             channelModeBits: channelModeBits
         )
+    }
+
+    private func isLikelyCBR(
+        data: Data,
+        firstFrameOffset: Int,
+        firstHeader: MPEGAudioHeader,
+        knownContentLength: Int64?,
+        sampleLimit: Int = Self.cbrConfidenceFrameSampleCount
+    ) -> Bool {
+        // Metadata reads usually see only an initial prefix. To avoid calling a VBR
+        // intro "CBR", require many consecutive frames with matching bitrate unless
+        // the prefix actually reaches the known end of the file.
+        var offset = firstFrameOffset
+        var inspectedFrameCount = 0
+
+        while inspectedFrameCount < sampleLimit, offset + 4 <= data.count {
+            guard let header = try? parseHeader(at: offset, in: data) else {
+                break
+            }
+            guard header.versionBits == firstHeader.versionBits,
+                  header.layerBits == firstHeader.layerBits,
+                  header.bitrate == firstHeader.bitrate,
+                  header.sampleRate == firstHeader.sampleRate,
+                  header.channelModeBits == firstHeader.channelModeBits,
+                  header.samplesPerFrame == firstHeader.samplesPerFrame else {
+                return false
+            }
+
+            inspectedFrameCount += 1
+            offset += header.frameSize
+        }
+
+        if inspectedFrameCount >= sampleLimit {
+            return true
+        }
+        if let knownContentLength, Int64(offset) >= knownContentLength {
+            return inspectedFrameCount >= 4
+        }
+        return false
     }
 
     private func parseSeekHeader(data: Data, frameOffset: Int, header: MPEGAudioHeader) throws -> SeekHeaderInfo {
@@ -310,6 +391,10 @@ struct MP3GaplessMetadataParser {
         guard let flags = reader.readUInt32BE(at: frameOffset + 4) else {
             throw GaplessMP3PlayerError.insufficientData("Missing Xing/Info flags")
         }
+
+        // Xing/Info headers are optional metadata frames embedded in the first MPEG
+        // frame. The flags choose which fields are present; a Xing header with frame
+        // count but no TOC can give duration but still cannot support byte seeking.
         var cursor = frameOffset + 8
         var frameCount: Int?
         var dataSize: Int?

--- a/modules/relisten-audio-player/ios/GaplessMP3Player/Source/SeekMap.swift
+++ b/modules/relisten-audio-player/ios/GaplessMP3Player/Source/SeekMap.swift
@@ -40,8 +40,7 @@ struct SeekMap {
             dataStartOffset: Int64,
             dataSize: Int64?,
             samplesPerFrame: Int,
-            sampleRate: Int,
-            frameByteLength: Int
+            sampleRate: Int
         )
         case unavailable
     }
@@ -49,6 +48,10 @@ struct SeekMap {
     let mode: Mode
 
     init(metadata: MP3TrackMetadata, bitrate: Int? = nil) {
+        // Prefer seek tables because they describe the file's actual byte layout.
+        // Only fall back to bitrate math when the parser explicitly marked the
+        // stream as constant-bitrate; duration plus first-frame bitrate alone is
+        // common in VBR metadata and would seek to the wrong region.
         if let toc = metadata.xingToc,
            let durationUs = metadata.durationUs,
            let dataEndOffset = metadata.dataEndOffset {
@@ -68,15 +71,16 @@ struct SeekMap {
                 dataSize: max(dataEndOffset - metadata.dataStartOffset + 1, 0),
                 table: vbriSeekTable
             )
-        } else if let durationUs = metadata.durationUs, let bitrate {
+        } else if metadata.approximateSeekStrategy == .constantBitrate,
+                  let durationUs = metadata.durationUs,
+                  let bitrate {
             self.mode = .cbr(
                 durationUs: durationUs,
                 bitrate: bitrate,
                 dataStartOffset: metadata.dataStartOffset,
                 dataSize: metadata.dataEndOffset.map { max($0 - metadata.dataStartOffset + 1, 0) },
                 samplesPerFrame: metadata.samplesPerFrame,
-                sampleRate: metadata.sampleRate,
-                frameByteLength: max(metadata.firstFrameByteLength, 1)
+                sampleRate: metadata.sampleRate
             )
         } else {
             self.mode = .unavailable
@@ -124,17 +128,26 @@ struct SeekMap {
                 confidence: .exact,
                 anchorTimeUs: clampedTimeUs
             )
-        case .cbr(let durationUs, _, let dataStartOffset, let dataSize, let samplesPerFrame, let sampleRate, let frameByteLength):
+        case .cbr(let durationUs, let bitrate, let dataStartOffset, let dataSize, let samplesPerFrame, let sampleRate):
             guard durationUs > 0 else {
                 return SeekResolution(byteOffset: dataStartOffset, confidence: .unavailable, anchorTimeUs: 0)
             }
 
             let clampedTimeUs = max(0, min(timeUs, durationUs))
+
+            // Seek to the frame before the requested one. Decoders need to start on
+            // compressed-frame boundaries, and the trim layer removes the extra PCM
+            // after decode so the public timeline still lands on the requested time.
             let targetRawFrames = (clampedTimeUs * Int64(sampleRate)) / 1_000_000
             let targetFrameIndex = max(targetRawFrames / Int64(max(samplesPerFrame, 1)), 0)
             let anchorFrameIndex = max(targetFrameIndex - 1, 0)
             let anchorRawFrames = anchorFrameIndex * Int64(samplesPerFrame)
-            let byteOffsetWithinData = anchorFrameIndex * Int64(frameByteLength)
+
+            // Use bitrate/time for CBR byte position rather than first-frame length.
+            // CBR MP3s can still use one-byte padding, so multiplying by the first
+            // frame size drifts over long seeks.
+            let byteOffsetWithinData = (anchorRawFrames * Int64(max(bitrate, 1))) /
+                (Int64(max(sampleRate, 1)) * 8)
             let clampedByteOffset = if let dataSize {
                 max(0, min(byteOffsetWithinData, max(dataSize - 1, 0)))
             } else {
@@ -162,6 +175,10 @@ enum TrackSeekPlanner {
         let rawStartFrames = logicalStartFrames + Int64(metadata.encoderDelayFrames)
         let rawStartTimeUs = (rawStartFrames * 1_000_000) / Int64(metadata.sampleRate)
         let resolution = SeekMap(metadata: metadata, bitrate: metadata.estimatedBitrate).resolve(timeUs: rawStartTimeUs)
+
+        // The seek map anchors in raw decoded samples. Subtracting that anchor from
+        // the desired raw start gives the PCM frames to discard after the decoder
+        // starts producing audio.
         let anchorRawFrames = (resolution.anchorTimeUs * Int64(metadata.sampleRate)) / 1_000_000
         let trimStartFrames = Int(max(rawStartFrames - anchorRawFrames, 0))
 

--- a/modules/relisten-audio-player/tools/GaplessMP3PlayerHarness/Tests/GaplessMP3PlayerTests/GaplessMP3PlayerTests.swift
+++ b/modules/relisten-audio-player/tools/GaplessMP3PlayerHarness/Tests/GaplessMP3PlayerTests/GaplessMP3PlayerTests.swift
@@ -33,6 +33,160 @@ final class GaplessMP3PlayerTests: XCTestCase {
         XCTAssertEqual(report.next?.metadata.channelCount, 1)
     }
 
+    func testParserEstimatesDurationAndSeekOffsetForCBRTrackWithoutSeekHeader() throws {
+        let data = makeCBRMP3Data(frameCount: 512, bitrateKbps: 192)
+        let source = httpFixtureSource(id: "current", path: "cbr-without-seek-header.mp3", byteCount: data.count)
+
+        let metadata = try MP3GaplessMetadataParser().parse(
+            source: source,
+            data: data,
+            fingerprint: CacheFingerprint(contentLength: Int64(data.count))
+        )
+
+        XCTAssertEqual(metadata.seekHeaderKind, .none)
+        XCTAssertEqual(metadata.approximateSeekStrategy, .constantBitrate)
+        XCTAssertEqual(metadata.durationUs, (Int64(data.count) * 8 * 1_000_000) / 192_000)
+        XCTAssertEqual(metadata.dataEndOffset, Int64(data.count - 1))
+        let duration = try XCTUnwrap(metadata.durationUs).secondsFromMicroseconds
+
+        let seekPlan = TrackSeekPlanner.plan(metadata: metadata, startTime: duration * 0.5)
+        let expectedMidpointOffset = try XCTUnwrap(expectedCBRSeekByteOffset(metadata: metadata, startTime: duration * 0.5))
+        XCTAssertLessThanOrEqual(abs(seekPlan.byteOffset - expectedMidpointOffset), 8)
+    }
+
+    func testParserDoesNotEstimateDurationForNonCBRTrackWithoutSeekHeader() throws {
+        var data = try httpFixtureData(named: "gd77-s2t07-first-5s-44k1-stereo.mp3")
+        try replaceFirstASCII("Info", with: "Junk", in: &data)
+        let source = httpFixtureSource(id: "current", path: "vbr-without-seek-header.mp3", byteCount: data.count)
+
+        let metadata = try MP3GaplessMetadataParser().parse(
+            source: source,
+            data: data,
+            fingerprint: CacheFingerprint(contentLength: Int64(data.count))
+        )
+
+        XCTAssertEqual(metadata.seekHeaderKind, .none)
+        XCTAssertEqual(metadata.approximateSeekStrategy, .unavailable)
+        XCTAssertNil(metadata.durationUs)
+    }
+
+    func testParserDoesNotEstimateDurationWhenNoHeaderTrackChangesBitrateAfterIntro() throws {
+        let introBitrates = Array(repeating: 192, count: 40)
+        let laterBitrates = Array(repeating: 128, count: 32)
+        let data = makeMP3Data(frameBitratesKbps: introBitrates + laterBitrates)
+        let source = httpFixtureSource(id: "current", path: "delayed-vbr-without-seek-header.mp3", byteCount: data.count)
+
+        let metadata = try MP3GaplessMetadataParser().parse(
+            source: source,
+            data: data,
+            fingerprint: CacheFingerprint(contentLength: Int64(data.count))
+        )
+
+        XCTAssertEqual(metadata.seekHeaderKind, .none)
+        XCTAssertEqual(metadata.approximateSeekStrategy, .unavailable)
+        XCTAssertNil(metadata.durationUs)
+    }
+
+    func testParserDoesNotEstimateDurationFromXingHeaderWithoutFrameCount() throws {
+        let data = makeCBRMP3Data(frameCount: 512, bitrateKbps: 192, xingDataSizeOnly: true)
+        let source = httpFixtureSource(id: "current", path: "xing-without-frame-count.mp3", byteCount: data.count)
+
+        let metadata = try MP3GaplessMetadataParser().parse(
+            source: source,
+            data: data,
+            fingerprint: CacheFingerprint(contentLength: Int64(data.count))
+        )
+
+        XCTAssertEqual(metadata.seekHeaderKind, .xing)
+        XCTAssertEqual(metadata.approximateSeekStrategy, .unavailable)
+        XCTAssertNil(metadata.durationUs)
+        XCTAssertEqual(metadata.dataEndOffset, Int64(data.count - 1))
+    }
+
+    func testCBRSeekPlannerUsesBitrateForPaddedFrames() throws {
+        let source = phishSimple19961118Source()
+        let metadata = MP3TrackMetadata(
+            sourceID: source.id,
+            sourceURL: source.url,
+            cacheKey: source.cacheKey,
+            fingerprint: CacheFingerprint(contentLength: source.expectedContentLength),
+            firstAudioFrameOffset: 205_375,
+            dataStartOffset: 205_375,
+            dataEndOffset: 24_481_198,
+            seekHeaderKind: .none,
+            sampleRate: 44_100,
+            channelCount: 2,
+            samplesPerFrame: 1_152,
+            firstFrameByteLength: 626,
+            estimatedBitrate: 192_000,
+            approximateSeekStrategy: .constantBitrate,
+            durationUs: 1_011_492_666,
+            encoderDelayFrames: 0,
+            encoderPaddingFrames: 0
+        )
+
+        let seekPlan = TrackSeekPlanner.plan(metadata: metadata, startTime: 657)
+
+        XCTAssertLessThanOrEqual(abs(seekPlan.byteOffset - 15_972_258), 8)
+    }
+
+    func testSeekPlannerDoesNotUseCBRForXingDurationWithoutToc() {
+        let source = httpFixtureSource(id: "current", path: "xing-without-toc.mp3", byteCount: 250_000)
+        let metadata = MP3TrackMetadata(
+            sourceID: source.id,
+            sourceURL: source.url,
+            cacheKey: source.cacheKey,
+            fingerprint: CacheFingerprint(contentLength: source.expectedContentLength),
+            firstAudioFrameOffset: 1_000,
+            dataStartOffset: 1_000,
+            dataEndOffset: 249_999,
+            seekHeaderKind: .xing,
+            sampleRate: 44_100,
+            channelCount: 2,
+            samplesPerFrame: 1_152,
+            firstFrameByteLength: 626,
+            estimatedBitrate: 192_000,
+            durationUs: 10_000_000,
+            encoderDelayFrames: 0,
+            encoderPaddingFrames: 0,
+            xingToc: nil
+        )
+
+        let seekPlan = TrackSeekPlanner.plan(metadata: metadata, startTime: 5)
+
+        XCTAssertEqual(seekPlan.byteOffset, metadata.dataStartOffset)
+    }
+
+    func testE2EPhishSimple19961118FarSeekDoesNotClampToBeginning() async throws {
+        try requireLiveAudioE2E()
+        let outputGraph = TestOutputGraph()
+        let httpLogRecorder = HTTPLogRecorder()
+        let player = makeHTTPPlayer(outputGraph: outputGraph, cacheMode: .disabled)
+        player.httpLogHandler = { event in
+            httpLogRecorder.record(event)
+        }
+        let source = phishSimple19961118Source()
+        let targetTime: TimeInterval = (10 * 60) + 57
+
+        try await player.prepare(current: source, next: nil)
+
+        let report = try XCTUnwrap(player.latestPreparationReport)
+        XCTAssertEqual(report.current.metadata.seekHeaderKind, .none)
+        XCTAssertGreaterThan(report.current.trimmedDuration, targetTime)
+
+        try await player.seek(to: targetTime)
+
+        let seekedStatus = await player.status()
+        XCTAssertEqual(seekedStatus.currentTime, targetTime, accuracy: 1)
+
+        XCTAssertTrue(player.play())
+        try await waitUntil("far-seek audio schedules from live Phish Simple file", timeoutIterations: 300) {
+            outputGraph.totalScheduledDuration() > 1
+        }
+        let rangeStart = try XCTUnwrap(firstRangeRequestStart(in: httpLogRecorder.events()))
+        XCTAssertLessThanOrEqual(abs(rangeStart - 15_972_258), 2_048)
+    }
+
     func testPrepareReportsPausedPhaseSourceIdentityAndResolvedFileURLs() async throws {
         let outputGraph = TestOutputGraph()
         let player = makePlayer(outputGraph: outputGraph)
@@ -1200,6 +1354,19 @@ final class GaplessMP3PlayerTests: XCTestCase {
         )
     }
 
+    private func makeHTTPPlayer(
+        outputGraph: TestOutputGraph,
+        cacheMode: GaplessCacheMode = .enabled
+    ) -> GaplessMP3Player {
+        let cacheDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GaplessMP3PlayerHTTPPlayerTests-\(UUID().uuidString)", isDirectory: true)
+        let sourceManager = MP3SourceManager(cacheDirectory: cacheDirectory, cacheMode: cacheMode)
+        return GaplessMP3Player(
+            sourceManager: sourceManager,
+            outputGraphFactory: { _, _ in outputGraph }
+        )
+    }
+
     private func fixtureSource(id: String, fixtureName: String) -> GaplessPlaybackSource {
         let url = Bundle.module.bundleURL
             .appendingPathComponent("Fixtures")
@@ -1238,6 +1405,59 @@ final class GaplessMP3PlayerTests: XCTestCase {
             cacheKey: path,
             expectedContentLength: Int64(byteCount)
         )
+    }
+
+    private func phishSimple19961118Source() -> GaplessPlaybackSource {
+        let localFixtureURL = phishSimple19961118LocalFixtureURL()
+        let sourceURL = FileManager.default.fileExists(atPath: localFixtureURL.path)
+            ? localFixtureURL
+            : phishSimple19961118RemoteURL()
+        return GaplessPlaybackSource(
+            id: "phish-simple-1996-11-18",
+            url: sourceURL,
+            cacheKey: "phish-simple-1996-11-18-cz9b6pep6c45kajmuop522kj169k",
+            expectedContentLength: 24_481_199
+        )
+    }
+
+    private func phishSimple19961118RemoteURL() -> URL {
+        URL(string: "https://audio.relisten.net/phish.in/blob/cz9b6pep6c45kajmuop522kj169k.mp3")!
+    }
+
+    private func phishSimple19961118LocalFixtureURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("E2EFixtures", isDirectory: true)
+            .appendingPathComponent("phish-simple-1996-11-18-cz9b6pep6c45kajmuop522kj169k.mp3")
+    }
+
+    private func expectedCBRSeekByteOffset(metadata: MP3TrackMetadata, startTime: TimeInterval) -> Int64? {
+        guard let bitrate = metadata.estimatedBitrate else {
+            return nil
+        }
+        let logicalStartFrames = Int64(startTime * Double(metadata.sampleRate))
+        let rawStartFrames = logicalStartFrames + Int64(metadata.encoderDelayFrames)
+        let targetFrameIndex = max(rawStartFrames / Int64(max(metadata.samplesPerFrame, 1)), 0)
+        let anchorFrameIndex = max(targetFrameIndex - 1, 0)
+        let anchorRawFrames = anchorFrameIndex * Int64(metadata.samplesPerFrame)
+        let anchorTimeUs = (anchorRawFrames * 1_000_000) / Int64(metadata.sampleRate)
+        return metadata.dataStartOffset + (anchorTimeUs * Int64(bitrate)) / 8_000_000
+    }
+
+    private func firstRangeRequestStart(in events: [GaplessHTTPLogEvent]) -> Int64? {
+        for event in events where event.requestKind == .range && event.kind == .requestStarted {
+            guard let header = event.requestHeaders["Range"], header.hasPrefix("bytes=") else {
+                continue
+            }
+            let rawRange = header.dropFirst("bytes=".count)
+            guard let start = rawRange.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false).first else {
+                continue
+            }
+            return Int64(start)
+        }
+        return nil
     }
 
     private func httpFixtureData(named fixtureName: String) throws -> Data {
@@ -1291,6 +1511,22 @@ final class GaplessMP3PlayerTests: XCTestCase {
         XCTFail("Timed out waiting for \(description)")
     }
 
+    private func requireLiveAudioE2E() throws {
+        guard ProcessInfo.processInfo.environment["RELISTEN_AUDIO_E2E"] == "1" else {
+            let remoteURL = phishSimple19961118RemoteURL().absoluteString
+            let localPath = phishSimple19961118LocalFixtureURL().path
+            throw XCTSkip(
+                """
+                Set RELISTEN_AUDIO_E2E=1 to run live audio regression tests. \
+                This test uses Phish - Simple, 1996-11-18, \(remoteURL) \
+                (24,481,199 bytes). By default it streams that URL. For an \
+                offline local fixture, download the MP3 and place it at \(localPath). \
+                The E2EFixtures directory is gitignored.
+                """
+            )
+        }
+    }
+
     private func XCTAssertThrowsErrorAsync(
         _ expression: @autoclosure () async throws -> some Sendable,
         _ errorHandler: (Error) -> Void
@@ -1323,6 +1559,87 @@ final class GaplessMP3PlayerTests: XCTestCase {
 
     private func makeHTTPTestData(byteCount: Int) -> Data {
         Data((0..<byteCount).map { UInt8($0 % 251) })
+    }
+
+    private func makeCBRMP3Data(
+        frameCount: Int,
+        bitrateKbps: Int,
+        xingDataSizeOnly: Bool = false
+    ) -> Data {
+        makeMP3Data(
+            frameBitratesKbps: Array(repeating: bitrateKbps, count: frameCount),
+            xingDataSizeOnly: xingDataSizeOnly
+        )
+    }
+
+    private func makeMP3Data(
+        frameBitratesKbps: [Int],
+        xingDataSizeOnly: Bool = false
+    ) -> Data {
+        var data = Data()
+        for (frameIndex, bitrateKbps) in frameBitratesKbps.enumerated() {
+            let padded = frameIndex % 16 != 0
+            let frameSize = mpeg1Layer3FrameSize(bitrateKbps: bitrateKbps, padded: padded)
+            var frame = Data(repeating: 0, count: frameSize)
+            writeUInt32BE(mpeg1Layer3Header(bitrateKbps: bitrateKbps, padded: padded), to: &frame, at: 0)
+            data.append(frame)
+        }
+
+        if xingDataSizeOnly {
+            writeASCII("Xing", to: &data, at: 36)
+            writeUInt32BE(0x2, to: &data, at: 40)
+            writeUInt32BE(UInt32(data.count), to: &data, at: 44)
+        }
+
+        return data
+    }
+
+    private func mpeg1Layer3FrameSize(bitrateKbps: Int, padded: Bool) -> Int {
+        ((144 * bitrateKbps * 1_000) / 44_100) + (padded ? 1 : 0)
+    }
+
+    private func mpeg1Layer3Header(bitrateKbps: Int, padded: Bool) -> UInt32 {
+        let bitrates = [32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320]
+        guard let bitrateIndex = bitrates.firstIndex(of: bitrateKbps).map({ UInt32($0 + 1) }) else {
+            preconditionFailure("Unsupported test bitrate")
+        }
+        let versionBits: UInt32 = 0b11
+        let layerBits: UInt32 = 0b01
+        let protectionAbsent: UInt32 = 1
+        let sampleRateIndex: UInt32 = 0
+        let paddingBit: UInt32 = padded ? 1 : 0
+        let channelModeBits: UInt32 = 0b00
+        return 0xFFE0_0000 |
+            (versionBits << 19) |
+            (layerBits << 17) |
+            (protectionAbsent << 16) |
+            (bitrateIndex << 12) |
+            (sampleRateIndex << 10) |
+            (paddingBit << 9) |
+            (channelModeBits << 6)
+    }
+
+    private func writeASCII(_ value: String, to data: inout Data, at offset: Int) {
+        for (index, byte) in value.utf8.enumerated() {
+            data[offset + index] = byte
+        }
+    }
+
+    private func writeUInt32BE(_ value: UInt32, to data: inout Data, at offset: Int) {
+        data[offset] = UInt8((value >> 24) & 0xFF)
+        data[offset + 1] = UInt8((value >> 16) & 0xFF)
+        data[offset + 2] = UInt8((value >> 8) & 0xFF)
+        data[offset + 3] = UInt8(value & 0xFF)
+    }
+
+    private func replaceFirstASCII(_ needle: String, with replacement: String, in data: inout Data) throws {
+        let needleBytes = Array(needle.utf8)
+        let replacementBytes = Array(replacement.utf8)
+        XCTAssertEqual(needleBytes.count, replacementBytes.count)
+        guard let range = data.range(of: Data(needleBytes)) else {
+            throw TestFailure.missingBytes(needle)
+        }
+        data.replaceSubrange(range, with: replacementBytes)
     }
 
     private func makePreparationReport(
@@ -1584,6 +1901,13 @@ private final class StubHTTPDataLoader: HTTPDataLoading, @unchecked Sendable {
 
 private enum TestFailure: Error {
     case invalidRangeHeader(String)
+    case missingBytes(String)
+}
+
+private extension Int64 {
+    var secondsFromMicroseconds: TimeInterval {
+        TimeInterval(self) / 1_000_000
+    }
 }
 
 private final class HTTPLogRecorder: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- Gate MP3 content-length/bitrate duration fallback behind parser-verified CBR evidence.
- Keep Xing/VBRI/VBR tracks without usable seek tables from falling through to CBR byte seeking.
- Use bitrate/time CBR byte offsets instead of first-frame byte length so padded CBR frames do not drift on far seeks.
- Add focused parser/seek regressions plus an opt-in Phish `Simple` live/local E2E fixture path.

## Root Cause
Some tracks, including Phish `Simple` from 1996-11-18, have no usable Xing/VBRI seek table. The parser previously had no duration for that shape, so far seeks clamped back to the beginning. The first fix needed tighter CBR handling: VBR metadata can expose duration and bitrate without a usable seek table, and CBR MP3 frames can still vary by one padding byte, so first-frame-size seek math drifts over long seeks.

## Testing
- `RELISTEN_AUDIO_E2E=1 swift test --filter GaplessMP3PlayerTests/testE2EPhishSimple19961118FarSeekDoesNotClampToBeginning`
- `swift test --filter 'GaplessMP3PlayerTests/testParserEstimatesDurationAndSeekOffsetForCBRTrackWithoutSeekHeader|GaplessMP3PlayerTests/testParserDoesNotEstimateDurationWhenNoHeaderTrackChangesBitrateAfterIntro|GaplessMP3PlayerTests/testE2EPhishSimple19961118FarSeekDoesNotClampToBeginning'`
- `yarn lint`
- `yarn ts:check`
- `git diff --check`
