### PR TITLE
[codex] Fix review list layout

### DIFF
--- a/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/reviews.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/reviews.tsx
@@ -1,5 +1,4 @@
-import { useLocalSearchParams, useNavigation } from 'expo-router';
-import { useEffect } from 'react';
+import { Stack, useLocalSearchParams } from 'expo-router';
 import { RelistenText } from '@/relisten/components/relisten_text';
 import { View } from 'react-native';
 import { List as ListContentLoader } from 'react-content-loader/native';
@@ -7,62 +6,67 @@ import { RelistenBlue } from '@/relisten/relisten_blue';
 import { RelistenFlatList } from '@/relisten/components/relisten_flat_list';
 import { SourceReview } from '@/relisten/api/models/source';
 import { useSourceReviews } from '@/relisten/realm/models/source_repo';
-import Flex from '@/relisten/components/flex';
 import dayjs from 'dayjs';
 import { memo } from '@/relisten/util/memo';
 import { ScrollScreen } from '@/relisten/components/screens/ScrollScreen';
 
 export default function Page() {
-  const navigation = useNavigation();
   const { sourceUuid } = useLocalSearchParams();
   const { isNetworkLoading, data } = useSourceReviews(sourceUuid as string);
-
-  useEffect(() => {
-    navigation.setOptions({ title: data ? `${data.length} Reviews` : 'Reviews' });
-  }, [data]);
+  const title = data ? `${data.length} Reviews` : 'Reviews';
 
   if (isNetworkLoading || !data) {
     return (
-      <View className="w-full p-4">
-        <ListContentLoader
-          backgroundColor={RelistenBlue[800]}
-          foregroundColor={RelistenBlue[700]}
-        />
-      </View>
+      <>
+        <Stack.Screen options={{ title }} />
+        <View className="w-full p-4">
+          <ListContentLoader
+            backgroundColor={RelistenBlue[800]}
+            foregroundColor={RelistenBlue[700]}
+          />
+        </View>
+      </>
     );
   }
 
   return (
-    <ScrollScreen>
-      <RelistenFlatList
-        data={data}
-        renderItem={({ item }) => <ReviewItem review={item} />}
-        className="w-full flex-1"
-      />
-    </ScrollScreen>
+    <>
+      <Stack.Screen options={{ title }} />
+      <ScrollScreen>
+        <RelistenFlatList
+          data={data}
+          renderItem={({ item }) => <ReviewItem review={item} />}
+          className="w-full flex-1"
+        />
+      </ScrollScreen>
+    </>
   );
 }
 
 const ReviewItem = memo(({ review }: { review: SourceReview }) => {
   return (
-    <Flex className="flex-1 flex-col p-4">
+    <View className="p-4">
       {(review.rating || review.title) && (
-        <Flex className="flex-1 flex-row items-center justify-between pb-1" style={{ gap: 16 }}>
+        <View className="flex-row items-start justify-between gap-4 pb-1">
           {review.title && (
-            <RelistenText className="flex-shrink text-xl font-semibold">
+            <RelistenText className="min-w-0 flex-1 text-xl font-semibold">
               {review.title.trim()}
             </RelistenText>
           )}
-          <RelistenText selectable={false}>{review.rating ? `${review.rating}★` : ''}</RelistenText>
-        </Flex>
+          <RelistenText className="shrink-0" selectable={false}>
+            {review.rating ? `${review.rating}★` : ''}
+          </RelistenText>
+        </View>
       )}
-      <Flex className="flex-1 flex-row items-center justify-between pb-2" style={{ gap: 16 }}>
-        {review.author && <RelistenText className="italic">{review.author.trim()}</RelistenText>}
-        <RelistenText className="text-gray-400" selectable={false}>
+      <View className="flex-row items-start justify-between gap-4 pb-2">
+        {review.author && (
+          <RelistenText className="min-w-0 flex-1 italic">{review.author.trim()}</RelistenText>
+        )}
+        <RelistenText className="shrink-0 text-gray-400" selectable={false}>
           {dayjs(review.updated_at).format('LL')}
         </RelistenText>
-      </Flex>
+      </View>
       <RelistenText>{review.review.trim()}</RelistenText>
-    </Flex>
+    </View>
   );
 });

--- a/relisten/components/relisten_flat_list.tsx
+++ b/relisten/components/relisten_flat_list.tsx
@@ -29,6 +29,7 @@ export const RelistenFlatList = <T extends { uuid: string }>({
 
   return (
     <FlatList
+      contentInsetAdjustmentBehavior="automatic"
       {...props}
       data={data}
       keyExtractor={(item) => item.uuid}


### PR DESCRIPTION
## Summary

- size review rows intrinsically so long review lists do not develop oversized blank regions
- configure the review count title declaratively so the navigation header stays current
- enable native automatic content insets on the shared flat list so the final row clears the player accessory and tab bar

## Root cause

Review cells and their metadata rows used `flex-1` inside a variable-height `FlatList`, which produced invalid cell measurements on long lists. The shared list also did not opt into iOS automatic content insets even though the native player accessory path relies on them.

## User impact

Long review lists retain their titles and continuous row layout, and the final review remains fully readable above the player and tabs.

## Validation

- `yarn lint`
- `yarn ts:check`
- `git diff --check`
- cold-start iOS 26.5 smoke test on the 69-review source, scrolled through the final review