### PR TITLE
Share numeric source id in deep links instead of uuid

### DIFF
--- a/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/index.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/index.tsx
@@ -192,7 +192,7 @@ export default function Page() {
     }
 
     const [year, month, day] = selectedSource.displayDate.split('-');
-    const url = `https://relisten.net/${artist?.slug}/${year}/${month}/${day}?source=${selectedSource.uuid}`;
+    const url = `https://relisten.net/${artist?.slug}/${year}/${month}/${day}?source=${selectedSource.sourceId ?? selectedSource.uuid}`;
 
     void Share.share({
       message: `Check out ${show.displayDate} (${show.venue?.name ?? ''}) by ${artist?.name} on @relistenapp${Platform.OS === 'ios' ? '' : `: ${url}`}`,
@@ -505,7 +505,7 @@ export const SourceHeader = ({
           textClassName="text-l"
           onPress={() => {
             const [year, month, day] = show.displayDate.split('-');
-            const url = `https://relisten.net/${artist?.slug}/${year}/${month}/${day}?source=${source.uuid}`;
+            const url = `https://relisten.net/${artist?.slug}/${year}/${month}/${day}?source=${source.sourceId ?? source.uuid}`;
             Share.share({
               message: `Check out ${show.displayDate} (${show.venue?.name ?? ''}) by ${artist?.name} on @relistenapp${Platform.OS === 'ios' ? '' : `: ${url}`}`,
               url: url,

--- a/relisten/player/ui/player_screen.tsx
+++ b/relisten/player/ui/player_screen.tsx
@@ -187,7 +187,7 @@ function CurrentTrackInfo({ dismissOnNavigate }: CurrentTrackInfoProps) {
 
   const onShare = () => {
     const [year, month, day] = show.displayDate.split('-');
-    const url = `https://relisten.net/${artist.slug}/${year}/${month}/${day}/${track.slug}?source=${source.uuid}`;
+    const url = `https://relisten.net/${artist.slug}/${year}/${month}/${day}/${track.slug}?source=${source.sourceId ?? source.uuid}`;
     Share.share({
       message: `Check out ${track.title} (${track.humanizedDuration}) by ${artist.name} (${show.displayDate}) on @relistenapp${Platform.OS === 'ios' ? '' : `: ${url}`}`,
       url: url,

--- a/relisten/player/ui/source_track_actions_menu.tsx
+++ b/relisten/player/ui/source_track_actions_menu.tsx
@@ -119,7 +119,7 @@ export function SourceTrackActionsMenu({ playShow, sourceTrack }: SourceTrackAct
           break;
         case ACTION_IDS.share: {
           const [year, month, day] = sourceTrack.show.displayDate.split('-');
-          const url = `https://relisten.net/${sourceTrack.artist.slug}/${year}/${month}/${day}/${sourceTrack.slug}?source=${sourceTrack.source.uuid}`;
+          const url = `https://relisten.net/${sourceTrack.artist.slug}/${year}/${month}/${day}/${sourceTrack.slug}?source=${sourceTrack.source.sourceId ?? sourceTrack.source.uuid}`;
 
           await Share.share({
             message: `Check out ${sourceTrack.title} (${sourceTrack.humanizedDuration}) from ${sourceTrack.show.displayDate} by ${sourceTrack.artist?.name} on @relistenapp${Platform.OS === 'ios' ? '' : `: ${url}`}`,

--- a/relisten/realm/models/source.ts
+++ b/relisten/realm/models/source.ts
@@ -11,6 +11,7 @@ import { checkIfOfflineSourceTrackExists } from '@/relisten/realm/realm_filters'
 import type { LibraryIndex } from '@/relisten/realm/library_index';
 
 export interface SourceRequiredProperties extends RelistenObjectRequiredProperties {
+  sourceId?: number;
   artistUuid: string;
   venueUuid?: string;
   displayDate: string;
@@ -44,6 +45,7 @@ export class Source
     primaryKey: 'uuid',
     properties: {
       uuid: 'string',
+      sourceId: 'int?',
       createdAt: 'date',
       updatedAt: 'date',
       artistUuid: { type: 'string', indexed: true },
@@ -83,6 +85,7 @@ export class Source
   };
 
   uuid!: string;
+  sourceId?: number;
   createdAt!: Date;
   updatedAt!: Date;
   artistUuid!: string;
@@ -156,6 +159,7 @@ export class Source
   static propertiesFromApi(relistenObj: SourceFull): SourceRequiredProperties {
     return {
       uuid: relistenObj.uuid,
+      sourceId: relistenObj.id != null ? Number(relistenObj.id) : undefined,
       createdAt: dayjs(relistenObj.created_at).toDate(),
       updatedAt: dayjs(relistenObj.updated_at).toDate(),
       artistUuid: relistenObj.artist_uuid,

--- a/relisten/realm/schema.ts
+++ b/relisten/realm/schema.ts
@@ -57,7 +57,7 @@ const realmConfig: Realm.Configuration = {
     PopularityWindow,
     PopularityWindows,
   ],
-  schemaVersion: 12,
+  schemaVersion: 13,
   // As to not conflict with the prior versions default.realm that isn't readable with this version of the SDK
   path: './relisten.realm',
 };


### PR DESCRIPTION
## Problem

Share buttons in the mobile app generated deep links like `https://relisten.net/phish/2004/06/26/boogie-on-reggae-woman-21978?source=32ee904b-2edb-…` — a **source UUID**. But relisten.net resolves the `source` query param by **numeric id** (`Number(source)` in `useSourceData`). `Number("<uuid>")` is `NaN`, so shared links silently fell back to the show's *first* source rather than the tape that was actually shared.

## Fix

The API already returns a numeric source `id` (marked "only used for deep-linking"), but the Realm `Source` model was dropping it. This change:

- Persists it as `Source.sourceId` (added to the interface, class field, schema as `int?`, and `propertiesFromApi`), and bumps the Realm `schemaVersion` 12 → 13 (additive optional property — Realm migrates automatically).
- Updates all four share sites to emit `sourceId`, falling back to `uuid` only if the id isn't populated yet (so we never emit `?source=undefined`):
  - `player_screen.tsx`
  - `source_track_actions_menu.tsx`
  - `source/[sourceUuid]/index.tsx` (×2)

New links look like `…?source=2173898`, which the web resolves correctly.

## Notes

- **Transition gap:** cached sources won't have `sourceId` until re-fetched from the API; until then the `?? uuid` fallback emits a uuid. It self-heals as soon as the show/source loads online.
- **Pre-existing uuid links** (already posted publicly) still won't resolve on web, since relisten-web only matches on numeric id. A follow-up on the web side could also match on uuid to rescue those — not included here since id is the preferred format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)