### PR TITLE
fix: prevent startup crash loop and address top Sentry errors

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     },
     "name": "Relisten",
     "slug": "relisten",
-    "version": "6.1.3",
+    "version": "6.2.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -27,7 +27,7 @@
           "audio"
         ]
       },
-      "buildNumber": "6045"
+      "buildNumber": "6047"
     },
     "android": {
       "playStoreUrl": "https://play.google.com/store/apps/details?id=net.relisten.android",
@@ -60,7 +60,7 @@
       },
       "icon": "./assets/ic_playstore.png",
       "package": "net.relisten.android",
-      "versionCode": 6045
+      "versionCode": 6047
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -50,6 +50,7 @@ import {
   isVerboseProfileLoggingEnabled,
   logRouteDebug,
 } from '@/relisten/util/profile_logging';
+import { removeOrphanedPlaybackHistoryEntries } from '@/relisten/realm/models/history/playback_history_repair';
 
 // c.f. https://github.com/meliorence/react-native-render-html/issues/661#issuecomment-2453476566
 LogBox.ignoreLogs([/Support for defaultProps will be removed/]);
@@ -93,6 +94,7 @@ function RealmBridge() {
   const realm = useRealm();
 
   useEffect(() => {
+    removeOrphanedPlaybackHistoryEntries(realm);
     setRealm(realm);
 
     return () => {

--- a/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/index.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/index.tsx
@@ -416,7 +416,7 @@ export const SourceHeader = ({
   };
 
   // If all tracks on this show have offlineInfo and it is Succeeded, then the show is fully downloaded
-  const isFullyDownloaded = source.sourceTracks.every(
+  const isFullyDownloaded = source.allSourceTracks().every(
     (st) =>
       st.offlineInfo &&
       st.offlineInfo.type !== SourceTrackOfflineInfoType.StreamingCache &&

--- a/app/relisten/tabs/(artists,myLibrary,offline)/history/tracks.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/history/tracks.tsx
@@ -18,6 +18,7 @@ import { SubtitleText } from '@/relisten/components/row_subtitle';
 import { ListRenderItem } from '@shopify/flash-list';
 import { TrackWithArtist } from '@/relisten/components/source/source_track_with_artist';
 import { Stack } from 'expo-router';
+import { VALID_PLAYBACK_HISTORY_QUERY } from '@/relisten/realm/models/history/playback_history_repair';
 
 function HistoryHeader({ totalPlayed }: { totalPlayed: number }) {
   return (
@@ -60,7 +61,10 @@ export default function Page() {
   const recentlyPlayed = useQuery(
     {
       type: PlaybackHistoryEntry,
-      query: (query) => query.sorted('playbackStartedAt', /* reverse= */ true),
+      query: (query) =>
+        query
+          .filtered(VALID_PLAYBACK_HISTORY_QUERY)
+          .sorted('playbackStartedAt', /* reverse= */ true),
     },
     []
   );

--- a/app/relisten/tabs/(relisten)/recently-played.tsx
+++ b/app/relisten/tabs/(relisten)/recently-played.tsx
@@ -14,6 +14,9 @@ import { ShowLink } from '@/relisten/util/push_show';
 import { useArtists } from '@/relisten/realm/models/artist_repo';
 import { groupByUuid } from '@/relisten/util/group_by';
 import { usePlayerBottomScrollViewProps } from '@/relisten/player/ui/player_bar_layout';
+import { log } from '@/relisten/util/logging';
+
+const logger = log.extend('recently-played');
 
 enum ACTIONS {
   UPDATE_DATA,
@@ -226,12 +229,26 @@ export default function Page() {
       if (state.data[0]) {
         params = `?lastSeenId=${state.data[0]}`;
       }
-      const data = await fetch(RelistenApiClient.API_BASE + `/v2/live/history${params}`).then(
-        (res) => res.json()
-      );
+      try {
+        const response = await fetch(RelistenApiClient.API_BASE + `/v2/live/history${params}`);
+        if (!response.ok) {
+          logger.warn('Recently played request failed', { status: response.status });
+          return;
+        }
 
-      // console.log(data);
-      call({ type: ACTIONS.UPDATE_DATA, data: data?.toReversed() });
+        const text = await response.text();
+        if (!text) return;
+
+        const data: unknown = JSON.parse(text);
+        if (!Array.isArray(data)) {
+          logger.warn('Recently played response was not an array');
+          return;
+        }
+
+        call({ type: ACTIONS.UPDATE_DATA, data: (data as HistoryTrack[]).toReversed() });
+      } catch (error) {
+        logger.warn('Failed to update recently played history', { error });
+      }
     };
 
     getData();

--- a/modules/relisten-audio-player/index.ts
+++ b/modules/relisten-audio-player/index.ts
@@ -7,6 +7,15 @@ import { log } from '@/relisten/util/logging';
 
 const logger = log.extend('relisten-audio-player');
 
+function normalizeNativeTimeMs(value: number | undefined): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  const milliseconds = Math.floor(value);
+  return Number.isSafeInteger(milliseconds) ? Math.max(0, milliseconds) : undefined;
+}
+
 const emitter = new EventEmitter<{
   onError: (event: RelistenErrorEvent) => void;
   onPlaybackStateChanged: (event: RelistenPlaybackStateChangedEvent) => void;
@@ -174,9 +183,14 @@ class RelistenGaplessPlayer {
   }
 
   play(streamable: RelistenStreamable, startingAtMs?: number): Promise<void> {
-    startingAtMs = startingAtMs !== undefined ? Math.floor(startingAtMs) : undefined;
-    logger.debug(`play called startingAtMs=${startingAtMs}`, streamable);
-    return RelistenAudioPlayerModule.play(streamable, startingAtMs);
+    const nativeStartingAtMs = normalizeNativeTimeMs(startingAtMs);
+
+    if (startingAtMs !== undefined && nativeStartingAtMs === undefined) {
+      logger.warn('Ignoring invalid native playback start time', { startingAtMs });
+    }
+
+    logger.debug(`play called startingAtMs=${nativeStartingAtMs}`, streamable);
+    return RelistenAudioPlayerModule.play(streamable, nativeStartingAtMs);
   }
 
   setNextStream(streamable?: RelistenStreamable) {
@@ -239,8 +253,15 @@ class RelistenGaplessPlayer {
   }
 
   seekToTime(timeMs: number): Promise<void> {
-    logger.debug('seekToTime called');
-    return RelistenAudioPlayerModule.seekToTime(timeMs);
+    const nativeTimeMs = normalizeNativeTimeMs(timeMs);
+
+    if (nativeTimeMs === undefined) {
+      logger.warn('Ignoring invalid native seek time', { timeMs });
+      return Promise.resolve();
+    }
+
+    logger.debug('seekToTime called', { timeMs: nativeTimeMs });
+    return RelistenAudioPlayerModule.seekToTime(nativeTimeMs);
   }
 }
 

--- a/relisten/api/client.ts
+++ b/relisten/api/client.ts
@@ -208,7 +208,8 @@ export class RelistenApiClient {
 
     try {
       const resp = await this.api.fetch(method, url, body).res();
-      const j = await resp.json();
+      const text = await resp.text();
+      const j = text ? JSON.parse(text) : null;
 
       const completedAt = new Date();
       const duration = dayjs(completedAt).diff(startedAt, 'milliseconds');

--- a/relisten/api/client.ts
+++ b/relisten/api/client.ts
@@ -23,15 +23,37 @@ const loggingMiddleware: ConfiguredMiddleware = (next) => (url, opts) => {
   return next(url, opts);
 };
 
-function calculateEtag(objs: Array<RelistenObject & RelistenUpdatableObject>): Promise<string> {
-  let str = '';
-
-  for (const obj of objs) {
-    str += obj.uuid;
-    str += obj.updated_at;
+function collectEtagFields(obj: unknown, parts: string[]): void {
+  if (obj === null || obj === undefined || typeof obj !== 'object') {
+    return;
   }
 
-  return digestStringAsync(CryptoDigestAlgorithm.MD5, str);
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      collectEtagFields(item, parts);
+    }
+    return;
+  }
+
+  const record = obj as Record<string, unknown>;
+  if (typeof record.uuid === 'string') {
+    parts.push(record.uuid);
+  }
+  if (typeof record.updated_at === 'string') {
+    parts.push(record.updated_at);
+  }
+
+  for (const value of Object.values(record)) {
+    if (typeof value === 'object' && value !== null) {
+      collectEtagFields(value, parts);
+    }
+  }
+}
+
+function calculateEtag(objs: Array<RelistenObject & RelistenUpdatableObject>): Promise<string> {
+  const parts: string[] = [];
+  collectEtagFields(objs, parts);
+  return digestStringAsync(CryptoDigestAlgorithm.MD5, parts.join(''));
 }
 
 export enum RelistenApiResponseType {

--- a/relisten/carplay/library.ts
+++ b/relisten/carplay/library.ts
@@ -10,6 +10,7 @@ import { OfflineModeSetting } from '@/relisten/realm/models/user_settings';
 import plur from 'plur';
 import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
 import { queuePlaybackHistoryEntry } from '@/relisten/carplay/queue_helpers';
+import { VALID_PLAYBACK_HISTORY_QUERY } from '@/relisten/realm/models/history/playback_history_repair';
 
 export function createLibraryTemplate(ctx: RelistenCarPlayContext): ListTemplate {
   carplay_logger.info('createLibraryTemplate');
@@ -115,7 +116,10 @@ export function createRecentTemplate(ctx: RelistenCarPlayContext): ListTemplate 
 
   const historyStream = new RealmQueryValueStream(
     ctx.realm,
-    ctx.realm.objects(PlaybackHistoryEntry).sorted('playbackStartedAt', true)
+    ctx.realm
+      .objects(PlaybackHistoryEntry)
+      .filtered(VALID_PLAYBACK_HISTORY_QUERY)
+      .sorted('playbackStartedAt', true)
   );
 
   ctx.addTeardown(() => historyStream.tearDown());
@@ -128,7 +132,15 @@ export function createRecentTemplate(ctx: RelistenCarPlayContext): ListTemplate 
     tabSystemImageName: 'clock.arrow.circlepath',
     async onItemSelect({ id }: { templateId: string; index: number; id: string }) {
       const entry = entryMap.get(String(id));
-      if (!entry) return;
+      if (
+        !entry?.isValid() ||
+        !entry.sourceTrack ||
+        !entry.artist ||
+        !entry.show ||
+        !entry.source
+      ) {
+        return;
+      }
 
       const track = entry.sourceTrack;
       const offlineMode = ctx.userSettings.offlineModeWithDefault();
@@ -149,7 +161,7 @@ export function createRecentTemplate(ctx: RelistenCarPlayContext): ListTemplate 
 
   const updateSections = () => {
     entryMap.clear();
-    const entries = Array.from(historyStream.currentValue || []).slice(0, 50);
+    const entries = historyStream.currentValue?.slice(0, 50) ?? [];
 
     const items = entries.map((entry) => {
       entryMap.set(entry.uuid, entry);

--- a/relisten/carplay/library.ts
+++ b/relisten/carplay/library.ts
@@ -161,7 +161,9 @@ export function createRecentTemplate(ctx: RelistenCarPlayContext): ListTemplate 
 
   const updateSections = () => {
     entryMap.clear();
-    const entries = historyStream.currentValue?.slice(0, 50) ?? [];
+    const entries = Array.from(historyStream.currentValue ?? [])
+      .filter((entry) => entry.isValid() && entry.sourceTrack?.isValid())
+      .slice(0, 50);
 
     const items = entries.map((entry) => {
       entryMap.set(entry.uuid, entry);

--- a/relisten/carplay/queue_helpers.ts
+++ b/relisten/carplay/queue_helpers.ts
@@ -55,23 +55,31 @@ export async function queuePlaybackHistoryEntry(
   scope: CarPlayScope,
   entry: PlaybackHistoryEntry
 ) {
-  const offlineMode = ctx.userSettings.offlineModeWithDefault();
-  let source = entry.source;
-  let artist = entry.artist;
-
-  if (!source || !artist) {
-    carplay_logger.warn('History entry missing source or artist', { id: entry.uuid });
+  if (!entry.isValid() || !entry.sourceTrack || !entry.artist || !entry.show || !entry.source) {
     return;
   }
 
+  const offlineMode = ctx.userSettings.offlineModeWithDefault();
+  const entryUuid = entry.uuid;
+  const showUuid = entry.show.uuid;
+  const sourceUuid = entry.source.uuid;
+  const sourceTrackUuid = entry.sourceTrack.uuid;
+  let source = entry.source;
+  let artist = entry.artist;
+
   if (!source.sourceSets?.length) {
-    const response = await ctx.apiClient.showWithSources(entry.show.uuid);
+    const response = await ctx.apiClient.showWithSources(showUuid);
 
     if (response?.data?.uuid) {
       const show = upsertShowWithSources(ctx.realm, response.data);
-      source = ctx.realm.objectForPrimaryKey(Source, entry.source.uuid) || source;
+      source = ctx.realm.objectForPrimaryKey(Source, sourceUuid) || source;
       artist = show?.artist || artist;
     }
+  }
+
+  if (!source.isValid() || !artist.isValid()) {
+    carplay_logger.warn('History source or artist was deleted while loading', { id: entryUuid });
+    return;
   }
 
   const { orderedTracks } = buildTrackSections({
@@ -86,7 +94,7 @@ export async function queuePlaybackHistoryEntry(
     ctx,
     scope,
     orderedTracks,
-    selectedTrackUuid: entry.sourceTrack.uuid,
+    selectedTrackUuid: sourceTrackUuid,
     sourceUuid: source.uuid,
   });
 }

--- a/relisten/offline/download_manager.ts
+++ b/relisten/offline/download_manager.ts
@@ -186,6 +186,21 @@ export class DownloadManager {
       return createdTasks;
     }
 
+    const allQueued = realm
+      .objects(SourceTrackOfflineInfo)
+      .filtered('status == $0', SourceTrackOfflineInfoStatus.Queued)
+      .sorted('queuedAt');
+
+    const orphaned = [...allQueued].filter((d) => !d.sourceTrack);
+    if (orphaned.length > 0) {
+      logger.warn(`Removing ${orphaned.length} orphaned SourceTrackOfflineInfo entries`);
+      realm.write(() => {
+        for (const entry of orphaned) {
+          realm.delete(entry);
+        }
+      });
+    }
+
     const queuedDownloads = realm
       .objects(SourceTrackOfflineInfo)
       .filtered('status == $0', SourceTrackOfflineInfoStatus.Queued)
@@ -193,11 +208,6 @@ export class DownloadManager {
       .slice(0, this.availableDownloadSlots());
 
     for (const queuedDownload of queuedDownloads) {
-      if (!queuedDownload.sourceTrack) {
-        logger.warn(`Orphaned SourceTrackOfflineInfo: ${queuedDownload.sourceTrackUuid}`);
-        continue;
-      }
-
       if (this.isPendingOrDownloading(queuedDownload.sourceTrack)) {
         logger.debug(`${queuedDownload.sourceTrack.uuid} is already pending or downloading`);
         continue;

--- a/relisten/offline/download_manager.ts
+++ b/relisten/offline/download_manager.ts
@@ -193,6 +193,11 @@ export class DownloadManager {
       .slice(0, this.availableDownloadSlots());
 
     for (const queuedDownload of queuedDownloads) {
+      if (!queuedDownload.sourceTrack) {
+        logger.warn(`Orphaned SourceTrackOfflineInfo: ${queuedDownload.sourceTrackUuid}`);
+        continue;
+      }
+
       if (this.isPendingOrDownloading(queuedDownload.sourceTrack)) {
         logger.debug(`${queuedDownload.sourceTrack.uuid} is already pending or downloading`);
         continue;

--- a/relisten/offline/download_manager.ts
+++ b/relisten/offline/download_manager.ts
@@ -182,11 +182,13 @@ export class DownloadManager {
       return createdTasks;
     }
 
+    const activeRealm = realm;
+
     if (this.availableDownloadSlots() <= 0) {
       return createdTasks;
     }
 
-    const allQueued = realm
+    const allQueued = activeRealm
       .objects(SourceTrackOfflineInfo)
       .filtered('status == $0', SourceTrackOfflineInfoStatus.Queued)
       .sorted('queuedAt');
@@ -194,14 +196,14 @@ export class DownloadManager {
     const orphaned = [...allQueued].filter((d) => !d.sourceTrack);
     if (orphaned.length > 0) {
       logger.warn(`Removing ${orphaned.length} orphaned SourceTrackOfflineInfo entries`);
-      realm.write(() => {
+      activeRealm.write(() => {
         for (const entry of orphaned) {
-          realm.delete(entry);
+          activeRealm.delete(entry);
         }
       });
     }
 
-    const queuedDownloads = realm
+    const queuedDownloads = activeRealm
       .objects(SourceTrackOfflineInfo)
       .filtered('status == $0', SourceTrackOfflineInfoStatus.Queued)
       .sorted('queuedAt')

--- a/relisten/playback_history_reporter.ts
+++ b/relisten/playback_history_reporter.ts
@@ -111,10 +111,12 @@ export class PlaybackHistoryReporter {
       return { type: RelistenApiResponseType.OnlineRequestCompleted, data: undefined };
     }
 
-    const res = await this.apiClient.recordPlayback(entry.sourceTrack.uuid);
+    const entryUuid = entry.uuid;
+    const sourceTrackUuid = entry.sourceTrack.uuid;
+    const res = await this.apiClient.recordPlayback(sourceTrackUuid);
 
     if (!res.error) {
-      logger.info(`Reported playback ${entry.uuid} for sourceTrack=${entry.sourceTrack.uuid}`);
+      logger.info(`Reported playback ${entryUuid} for sourceTrack=${sourceTrackUuid}`);
       this.realm.write(() => {
         if (entry.isValid()) {
           entry.publishedAt = new Date();
@@ -143,11 +145,12 @@ export class PlaybackHistoryReporter {
     logger.info(`Reporting ${entriesToPublish.length} playback history entries`);
 
     for (const entry of entriesToPublish) {
+      const entryUuid = entry.uuid;
       const res = await this.attemptReport(entry);
 
       if (res.error) {
         logger.warn(
-          `Error reporting ${entry.uuid}. Will try again in 30s; ${JSON.stringify(res.error)}`
+          `Error reporting ${entryUuid}. Will try again in 30s; ${JSON.stringify(res.error)}`
         );
 
         this.retryTimer = setTimeout(() => {

--- a/relisten/playback_history_reporter.ts
+++ b/relisten/playback_history_reporter.ts
@@ -14,6 +14,7 @@ import { SourceTrack } from '@/relisten/realm/models/source_track';
 import { Artist } from '@/relisten/realm/models/artist';
 import { Show } from '@/relisten/realm/models/show';
 import { Source } from '@/relisten/realm/models/source';
+import { VALID_PLAYBACK_HISTORY_QUERY } from '@/relisten/realm/models/history/playback_history_repair';
 
 const logger = log.extend('playback-history-reporter');
 
@@ -102,12 +103,16 @@ export class PlaybackHistoryReporter {
   }
 
   private async attemptReport(entry: PlaybackHistoryEntry): Promise<RelistenApiResponse<unknown>> {
-    if (!entry.isValid() || !entry.sourceTrack) {
+    if (!entry.isValid()) {
+      return { type: RelistenApiResponseType.OnlineRequestCompleted, data: undefined };
+    }
+
+    if (!entry.sourceTrack || !entry.artist || !entry.show || !entry.source) {
+      const entryUuid = entry.uuid;
       this.realm.write(() => {
-        if (entry.isValid()) {
-          entry.publishedAt = new Date();
-        }
+        this.realm.delete(entry);
       });
+      logger.warn('Removed orphaned playback history entry before reporting', { entryUuid });
       return { type: RelistenApiResponseType.OnlineRequestCompleted, data: undefined };
     }
 
@@ -135,7 +140,8 @@ export class PlaybackHistoryReporter {
 
     const entriesToPublish = this.realm
       .objects(PlaybackHistoryEntry)
-      .filtered('publishedAt == null');
+      .filtered(`publishedAt == null AND ${VALID_PLAYBACK_HISTORY_QUERY}`)
+      .snapshot();
 
     if (entriesToPublish.length === 0) {
       logger.info('No playback history entries to publish');
@@ -145,6 +151,8 @@ export class PlaybackHistoryReporter {
     logger.info(`Reporting ${entriesToPublish.length} playback history entries`);
 
     for (const entry of entriesToPublish) {
+      if (!entry?.isValid()) continue;
+
       const entryUuid = entry.uuid;
       const res = await this.attemptReport(entry);
 

--- a/relisten/playback_history_reporter.ts
+++ b/relisten/playback_history_reporter.ts
@@ -1,4 +1,8 @@
-import { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
+import {
+  RelistenApiClient,
+  RelistenApiResponse,
+  RelistenApiResponseType,
+} from '@/relisten/api/client';
 import Realm from 'realm';
 import {
   PlaybackFlags,
@@ -98,12 +102,23 @@ export class PlaybackHistoryReporter {
   }
 
   private async attemptReport(entry: PlaybackHistoryEntry): Promise<RelistenApiResponse<unknown>> {
+    if (!entry.isValid() || !entry.sourceTrack) {
+      this.realm.write(() => {
+        if (entry.isValid()) {
+          entry.publishedAt = new Date();
+        }
+      });
+      return { type: RelistenApiResponseType.OnlineRequestCompleted, data: undefined };
+    }
+
     const res = await this.apiClient.recordPlayback(entry.sourceTrack.uuid);
 
     if (!res.error) {
       logger.info(`Reported playback ${entry.uuid} for sourceTrack=${entry.sourceTrack.uuid}`);
       this.realm.write(() => {
-        entry.publishedAt = new Date();
+        if (entry.isValid()) {
+          entry.publishedAt = new Date();
+        }
       });
     }
 

--- a/relisten/player/native_playback_state_hooks.tsx
+++ b/relisten/player/native_playback_state_hooks.tsx
@@ -59,10 +59,12 @@ export function addPlayerListeners() {
         return;
       }
 
+      const elapsed = Number.isFinite(progress.elapsed) ? progress.elapsed : 0;
+      const duration = Number.isFinite(progress.duration) ? progress.duration : 0;
       const newProgress = {
-        elapsed: progress.elapsed ?? 0,
-        duration: progress.duration ?? 0,
-        percent: progress.duration ? (progress.elapsed ?? 0) / progress.duration : 0,
+        elapsed,
+        duration,
+        percent: duration > 0 ? elapsed / duration : 0,
       };
 
       const lastProgress = sharedStates.progress.lastState();

--- a/relisten/player/native_playback_state_hooks.tsx
+++ b/relisten/player/native_playback_state_hooks.tsx
@@ -59,8 +59,14 @@ export function addPlayerListeners() {
         return;
       }
 
-      const elapsed = Number.isFinite(progress.elapsed) ? progress.elapsed : 0;
-      const duration = Number.isFinite(progress.duration) ? progress.duration : 0;
+      const elapsed =
+        typeof progress.elapsed === 'number' && Number.isFinite(progress.elapsed)
+          ? progress.elapsed
+          : 0;
+      const duration =
+        typeof progress.duration === 'number' && Number.isFinite(progress.duration)
+          ? progress.duration
+          : 0;
       const newProgress = {
         elapsed,
         duration,

--- a/relisten/player/relisten_player.tsx
+++ b/relisten/player/relisten_player.tsx
@@ -183,10 +183,16 @@ export class RelistenPlayer {
     this.requestedTrackIndex = newIndex;
 
     const track = this.queue.orderedTracks[newIndex];
+
+    if (!track) {
+      logger.warn('playTrackAtIndex: no track at index', { index, newIndex });
+      return;
+    }
+
     logger.debug('playTrackAtIndex requested', {
       index,
       newIndex,
-      identifier: track?.identifier,
+      identifier: track.identifier,
       seekToTime,
       currentlyProcessingPlayRequest: !!this.currentlyProcessingPlayRequest,
       playRequestVersion,

--- a/relisten/player/relisten_player.tsx
+++ b/relisten/player/relisten_player.tsx
@@ -176,18 +176,18 @@ export class RelistenPlayer {
   }
 
   playTrackAtIndex(index: number, seekToTime?: number) {
-    this.playbackIntentStarted = true;
-
     const newIndex = Math.max(0, Math.min(index, this.queue.orderedTracks.length - 1));
-    const playRequestVersion = ++this.playRequestVersion;
-    this.requestedTrackIndex = newIndex;
-
     const track = this.queue.orderedTracks[newIndex];
 
     if (!track) {
       logger.warn('playTrackAtIndex: no track at index', { index, newIndex });
       return;
     }
+
+    this.playbackIntentStarted = true;
+
+    const playRequestVersion = ++this.playRequestVersion;
+    this.requestedTrackIndex = newIndex;
 
     logger.debug('playTrackAtIndex requested', {
       index,

--- a/relisten/player/relisten_player_queue.tsx
+++ b/relisten/player/relisten_player_queue.tsx
@@ -570,17 +570,24 @@ ${indentString(tracks)}
 
     this.playerStateDebounce = setTimeout(() => {
       if (realm) {
+        const validOriginal = this.originalTracks.filter((t) => t.sourceTrack?.isValid());
+        const validShuffled = this.shuffledTracks.filter((t) => t.sourceTrack?.isValid());
+        const currentUuid = this.currentTrack?.sourceTrack?.isValid()
+          ? this.currentTrack.sourceTrack.uuid
+          : undefined;
+        const findIdx = (tracks: PlayerQueueTrack[], uuid: string | undefined) => {
+          if (!uuid) return undefined;
+          const idx = tracks.findIndex((t) => t.sourceTrack.uuid === uuid);
+          return idx >= 0 ? idx : undefined;
+        };
+
         const state = {
           queueShuffleState: this.shuffleState,
           queueRepeatState: this.repeatState,
-          queueSourceTrackUuids: this.originalTracks
-            .filter((t) => t.sourceTrack?.isValid())
-            .map((t) => t.sourceTrack.uuid),
-          queueSourceTrackShuffledUuids: this.shuffledTracks
-            .filter((t) => t.sourceTrack?.isValid())
-            .map((t) => t.sourceTrack.uuid),
-          activeSourceTrackIndex: this.originalTracksCurrentIndex,
-          activeSourceTrackShuffledIndex: this.shuffledTracksCurrentIndex,
+          queueSourceTrackUuids: validOriginal.map((t) => t.sourceTrack.uuid),
+          queueSourceTrackShuffledUuids: validShuffled.map((t) => t.sourceTrack.uuid),
+          activeSourceTrackIndex: findIdx(validOriginal, currentUuid),
+          activeSourceTrackShuffledIndex: findIdx(validShuffled, currentUuid),
           lastUpdatedAt: new Date(),
           progress: this.player.progress?.percent,
           duration: this.player.progress?.duration,

--- a/relisten/player/relisten_player_queue.tsx
+++ b/relisten/player/relisten_player_queue.tsx
@@ -119,6 +119,17 @@ export class PlayerQueueTrack {
   debugState() {
     return `identifier=${this.identifier}; title=${this.title}`.trim();
   }
+
+  duplicate() {
+    return new PlayerQueueTrack(
+      this.sourceTrack,
+      this.title,
+      this.artist,
+      this.subtitle,
+      this.albumTitle,
+      this.albumArt
+    );
+  }
 }
 
 export class RelistenPlayerQueue {
@@ -148,11 +159,13 @@ export class RelistenPlayerQueue {
   public prevNextTrackIndexIntentOffset = 0;
 
   queueNextTrack(queueTracks: PlayerQueueTrack[]) {
+    const tracksWithUniqueIdentifiers = queueTracks.map((track) => track.duplicate());
+
     function insertNext(arr: PlayerQueueTrack[], currentIndex: number | undefined) {
       const targetIndex = currentIndex !== undefined ? currentIndex + 1 : 0;
       const arrCopy = [...arr];
 
-      arrCopy.splice(targetIndex, 0, ...queueTracks);
+      arrCopy.splice(targetIndex, 0, ...tracksWithUniqueIdentifiers);
 
       return arrCopy;
     }
@@ -166,8 +179,9 @@ export class RelistenPlayerQueue {
   }
 
   addTrackToEndOfQueue(queueTracks: PlayerQueueTrack[]) {
-    this.originalTracks = [...this.originalTracks, ...queueTracks];
-    this.shuffledTracks = [...this.shuffledTracks, ...queueTracks];
+    const tracksWithUniqueIdentifiers = queueTracks.map((track) => track.duplicate());
+    this.originalTracks = [...this.originalTracks, ...tracksWithUniqueIdentifiers];
+    this.shuffledTracks = [...this.shuffledTracks, ...tracksWithUniqueIdentifiers];
 
     this.recalculateNextTrack();
     this.onOrderedTracksChanged.dispatch(this.orderedTracks);
@@ -241,23 +255,25 @@ export class RelistenPlayerQueue {
   }
 
   removeTrackAtIndex(index: number) {
-    const originalCopy = [...this.originalTracks];
-    const [removed] = originalCopy.splice(index, 1);
+    const removed = this.orderedTracks[index];
 
     if (!removed) return;
 
-    this.originalTracks = originalCopy;
+    const currentIdentifier = this.currentTrack?.identifier;
+    this.originalTracks = this.originalTracks.filter(
+      (track) => track.identifier !== removed.identifier
+    );
+    this.shuffledTracks = this.shuffledTracks.filter(
+      (track) => track.identifier !== removed.identifier
+    );
 
-    const shuffledCopy = [...this.shuffledTracks];
-
-    for (let i = 0; i < this.shuffledTracks.length; i++) {
-      if (this.shuffledTracks[i]?.identifier === removed.identifier) {
-        shuffledCopy.splice(i, 1);
-        break;
-      }
+    this.clearCurrentTrack();
+    if (currentIdentifier && currentIdentifier !== removed.identifier) {
+      this.recalculateTrackIndexes(currentIdentifier);
+    } else if (currentIdentifier === removed.identifier) {
+      this.player.stop().then(() => {});
+      this.onCurrentTrackChanged.dispatch(undefined);
     }
-
-    this.shuffledTracks = shuffledCopy;
 
     this.recalculateNextTrack();
     this.onOrderedTracksChanged.dispatch(this.orderedTracks);
@@ -538,26 +554,6 @@ ${indentString(tracks)}
     }
   }
 
-  private restoreTrackIndexesBySourceTrackUuid(sourceTrackUuid: string) {
-    this.clearCurrentTrack();
-
-    // Queue item identifiers are regenerated on cold start, so restore has to re-anchor by
-    // stable SourceTrack UUID and then recover both original/shuffled indexes from that identity.
-    this.originalTracksCurrentIndex = this.originalTracks.findIndex(
-      (track) => track.sourceTrack.uuid === sourceTrackUuid
-    );
-    this.shuffledTracksCurrentIndex = this.shuffledTracks.findIndex(
-      (track) => track.sourceTrack.uuid === sourceTrackUuid
-    );
-
-    if (this.originalTracksCurrentIndex < 0) {
-      this.originalTracksCurrentIndex = undefined;
-    }
-
-    if (this.shuffledTracksCurrentIndex < 0) {
-      this.shuffledTracksCurrentIndex = undefined;
-    }
-  }
   // endregion
 
   // region Player state serialization
@@ -572,12 +568,13 @@ ${indentString(tracks)}
       if (realm) {
         const validOriginal = this.originalTracks.filter((t) => t.sourceTrack?.isValid());
         const validShuffled = this.shuffledTracks.filter((t) => t.sourceTrack?.isValid());
-        const currentUuid = this.currentTrack?.sourceTrack?.isValid()
-          ? this.currentTrack.sourceTrack.uuid
-          : undefined;
-        const findIdx = (tracks: PlayerQueueTrack[], uuid: string | undefined) => {
-          if (!uuid) return undefined;
-          const idx = tracks.findIndex((t) => t.sourceTrack.uuid === uuid);
+        const currentTrack = this.currentTrack;
+        const currentTrackIsValid = currentTrack?.sourceTrack?.isValid() === true;
+        const currentIdentifier = currentTrackIsValid ? currentTrack.identifier : undefined;
+        const currentUuid = currentTrackIsValid ? currentTrack.sourceTrack.uuid : undefined;
+        const findIdx = (tracks: PlayerQueueTrack[], identifier: string | undefined) => {
+          if (!identifier) return undefined;
+          const idx = tracks.findIndex((track) => track.identifier === identifier);
           return idx >= 0 ? idx : undefined;
         };
 
@@ -586,8 +583,8 @@ ${indentString(tracks)}
           queueRepeatState: this.repeatState,
           queueSourceTrackUuids: validOriginal.map((t) => t.sourceTrack.uuid),
           queueSourceTrackShuffledUuids: validShuffled.map((t) => t.sourceTrack.uuid),
-          activeSourceTrackIndex: findIdx(validOriginal, currentUuid),
-          activeSourceTrackShuffledIndex: findIdx(validShuffled, currentUuid),
+          activeSourceTrackIndex: findIdx(validOriginal, currentIdentifier),
+          activeSourceTrackShuffledIndex: findIdx(validShuffled, currentIdentifier),
           lastUpdatedAt: new Date(),
           progress: this.player.progress?.percent,
           duration: this.player.progress?.duration,
@@ -596,7 +593,7 @@ ${indentString(tracks)}
         logger.debug('writing player state progress', {
           activeSourceTrackIndex: state.activeSourceTrackIndex,
           activeSourceTrackShuffledIndex: state.activeSourceTrackShuffledIndex,
-          currentTrackUuid: this.currentTrack?.sourceTrack.uuid,
+          currentTrackUuid: currentUuid,
           duration: state.duration,
           elapsed: state.elapsed,
           progress: state.progress,
@@ -628,6 +625,29 @@ ${indentString(tracks)}
         queueLength: playerState.queueSourceTrackUuids.length,
         queueShuffleState: playerState.queueShuffleState,
       });
+
+      const restoreTrackFromIndex = (
+        sourceTrackUuids: ReadonlyArray<string>,
+        restoredTracks: ReadonlyArray<PlayerQueueTrack>,
+        maybeIndex: number | null | undefined
+      ) => {
+        if (maybeIndex == null || maybeIndex < 0 || maybeIndex >= sourceTrackUuids.length) {
+          return undefined;
+        }
+
+        const sourceTrackUuid = sourceTrackUuids[maybeIndex];
+        const occurrence = sourceTrackUuids
+          .slice(0, maybeIndex + 1)
+          .filter((uuid) => uuid === sourceTrackUuid).length;
+        let restoredOccurrence = 0;
+
+        return restoredTracks.find((track) => {
+          if (track.sourceTrack.uuid !== sourceTrackUuid) return false;
+
+          restoredOccurrence += 1;
+          return restoredOccurrence === occurrence;
+        });
+      };
 
       const sourceTracksByUuid = groupByUuid([
         ...realm
@@ -664,51 +684,50 @@ ${indentString(tracks)}
       this.setRepeatState(playerState.queueRepeatState);
 
       const unshuffledQueue = makeQueue(playerState.queueSourceTrackUuids);
-      const shuffledQueue = [...unshuffledQueue];
+      const remainingTracksByUuid = new Map<string, PlayerQueueTrack[]>();
+      for (const track of unshuffledQueue) {
+        const matchingTracks = remainingTracksByUuid.get(track.sourceTrack.uuid) ?? [];
+        matchingTracks.push(track);
+        remainingTracksByUuid.set(track.sourceTrack.uuid, matchingTracks);
+      }
 
-      shuffledQueue.sort((a, b) => {
-        const aOrder = playerState.queueSourceTrackShuffledUuids.indexOf(a.sourceTrack.uuid);
-        const bOrder = playerState.queueSourceTrackShuffledUuids.indexOf(b.sourceTrack.uuid);
-
-        return aOrder - bOrder;
+      const shuffledQueue = playerState.queueSourceTrackShuffledUuids.flatMap((uuid) => {
+        const matchingTrack = remainingTracksByUuid.get(uuid)?.shift();
+        return matchingTrack ? [matchingTrack] : [];
       });
+      const shuffledIdentifiers = new Set(shuffledQueue.map((track) => track.identifier));
+      shuffledQueue.push(
+        ...unshuffledQueue.filter((track) => !shuffledIdentifiers.has(track.identifier))
+      );
 
       this.replaceQueue(unshuffledQueue, undefined);
       this.shuffledTracks = shuffledQueue;
       this.onOrderedTracksChanged.dispatch(this.orderedTracks);
 
-      const restoreTrackUuidFromIndex = (
-        tracks: PlayerQueueTrack[],
-        maybeIndex: number | null | undefined
-      ) => {
-        if (maybeIndex == null || maybeIndex < 0 || maybeIndex >= tracks.length) {
-          return undefined;
-        }
-
-        return tracks[maybeIndex]?.sourceTrack.uuid;
-      };
-
-      const preferredRestoredTrackUuid =
+      const originalRestoredTrack = restoreTrackFromIndex(
+        playerState.queueSourceTrackUuids,
+        this.originalTracks,
+        playerState.activeSourceTrackIndex
+      );
+      const shuffledRestoredTrack = restoreTrackFromIndex(
+        playerState.queueSourceTrackShuffledUuids,
+        this.shuffledTracks,
+        playerState.activeSourceTrackShuffledIndex
+      );
+      const preferredRestoredTrack =
         this.shuffleState === PlayerShuffleState.SHUFFLE_ON
-          ? restoreTrackUuidFromIndex(
-              this.shuffledTracks,
-              playerState.activeSourceTrackShuffledIndex
-            )
-          : restoreTrackUuidFromIndex(this.originalTracks, playerState.activeSourceTrackIndex);
-      const fallbackRestoredTrackUuid =
+          ? shuffledRestoredTrack
+          : originalRestoredTrack;
+      const fallbackRestoredTrack =
         this.shuffleState === PlayerShuffleState.SHUFFLE_ON
-          ? restoreTrackUuidFromIndex(this.originalTracks, playerState.activeSourceTrackIndex)
-          : restoreTrackUuidFromIndex(
-              this.shuffledTracks,
-              playerState.activeSourceTrackShuffledIndex
-            );
-      const restoredTrackUuid =
-        preferredRestoredTrackUuid ??
-        fallbackRestoredTrackUuid ??
-        this.originalTracks[0]?.sourceTrack.uuid;
+          ? originalRestoredTrack
+          : shuffledRestoredTrack;
+      const restoredTrack =
+        preferredRestoredTrack ?? fallbackRestoredTrack ?? this.originalTracks[0];
 
-      if (restoredTrackUuid) {
-        this.restoreTrackIndexesBySourceTrackUuid(restoredTrackUuid);
+      if (restoredTrack) {
+        this.clearCurrentTrack();
+        this.recalculateTrackIndexes(restoredTrack.identifier);
       }
 
       if (this.currentTrack) {
@@ -718,7 +737,7 @@ ${indentString(tracks)}
       logger.debug('resolved player state restore target', {
         currentTrackUuid: this.currentTrack?.sourceTrack.uuid,
         originalTracksCurrentIndex: this.originalTracksCurrentIndex,
-        restoredTrackUuid,
+        restoredTrackUuid: restoredTrack?.sourceTrack.uuid,
         shuffledTracksCurrentIndex: this.shuffledTracksCurrentIndex,
         shuffleState: this.shuffleState,
       });

--- a/relisten/player/relisten_player_queue.tsx
+++ b/relisten/player/relisten_player_queue.tsx
@@ -244,12 +244,14 @@ export class RelistenPlayerQueue {
     const originalCopy = [...this.originalTracks];
     const [removed] = originalCopy.splice(index, 1);
 
+    if (!removed) return;
+
     this.originalTracks = originalCopy;
 
     const shuffledCopy = [...this.shuffledTracks];
 
     for (let i = 0; i < this.shuffledTracks.length; i++) {
-      if (this.shuffledTracks[i].identifier === removed.identifier) {
+      if (this.shuffledTracks[i]?.identifier === removed.identifier) {
         shuffledCopy.splice(i, 1);
         break;
       }
@@ -522,21 +524,15 @@ ${indentString(tracks)}
 
   private recalculateTrackIndexes(newIdentifier: string) {
     for (let i = 0; i < this.originalTracks.length; i++) {
-      const originalTrack = this.originalTracks[i];
-      const shuffledTrack = this.shuffledTracks[i];
-
-      if (originalTrack.identifier == newIdentifier) {
+      if (this.originalTracks[i]?.identifier == newIdentifier) {
         this.originalTracksCurrentIndex = i;
+        break;
       }
+    }
 
-      if (shuffledTrack.identifier == newIdentifier) {
+    for (let i = 0; i < this.shuffledTracks.length; i++) {
+      if (this.shuffledTracks[i]?.identifier == newIdentifier) {
         this.shuffledTracksCurrentIndex = i;
-      }
-
-      if (
-        this.originalTracksCurrentIndex !== undefined &&
-        this.shuffledTracksCurrentIndex !== undefined
-      ) {
         break;
       }
     }
@@ -577,8 +573,12 @@ ${indentString(tracks)}
         const state = {
           queueShuffleState: this.shuffleState,
           queueRepeatState: this.repeatState,
-          queueSourceTrackUuids: this.originalTracks.map((t) => t.sourceTrack.uuid),
-          queueSourceTrackShuffledUuids: this.shuffledTracks.map((t) => t.sourceTrack.uuid),
+          queueSourceTrackUuids: this.originalTracks
+            .filter((t) => t.sourceTrack?.isValid())
+            .map((t) => t.sourceTrack.uuid),
+          queueSourceTrackShuffledUuids: this.shuffledTracks
+            .filter((t) => t.sourceTrack?.isValid())
+            .map((t) => t.sourceTrack.uuid),
           activeSourceTrackIndex: this.originalTracksCurrentIndex,
           activeSourceTrackShuffledIndex: this.shuffledTracksCurrentIndex,
           lastUpdatedAt: new Date(),
@@ -719,11 +719,14 @@ ${indentString(tracks)}
       this._nextTrack = undefined;
       this._nextTrackIndex = undefined;
 
-      if (playerState.elapsed != null && playerState.duration != null) {
+      const restoredElapsed = Number.isFinite(playerState.elapsed) ? playerState.elapsed : null;
+      const restoredDuration = Number.isFinite(playerState.duration) ? playerState.duration : null;
+
+      if (restoredElapsed != null && restoredDuration != null) {
         const restoredProgress = {
-          elapsed: playerState.elapsed,
-          duration: playerState.duration,
-          percent: playerState.duration > 0 ? playerState.elapsed / playerState.duration : 0,
+          elapsed: restoredElapsed,
+          duration: restoredDuration,
+          percent: restoredDuration > 0 ? restoredElapsed / restoredDuration : 0,
         };
 
         logger.debug('restoring player progress', {

--- a/relisten/player/ui/player_screen.tsx
+++ b/relisten/player/ui/player_screen.tsx
@@ -450,7 +450,7 @@ function PlayerQueue() {
         onDragStart={triggerHaptics}
         onDragEnd={triggerHaptics}
         onIndexChange={triggerHaptics}
-        keyExtractor={(item) => item.identifier}
+        keyExtractor={(item, index) => item?.identifier ?? String(index)}
         renderItem={({ item, index }) => (
           // <ScaleDecorator>
           //   <TouchableOpacity onLongPress={drag} disabled={isActive} className="flex-1">

--- a/relisten/realm/models/history/playback_history_entry_repo.ts
+++ b/relisten/realm/models/history/playback_history_entry_repo.ts
@@ -2,11 +2,13 @@ import { useQuery, useRealm } from '@/relisten/realm/schema';
 import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { InteractionManager } from 'react-native';
+import { VALID_PLAYBACK_HISTORY_QUERY } from '@/relisten/realm/models/history/playback_history_repair';
 
 export function useTotalListeningTime(): number {
   const allEntries = useQuery(
     {
       type: PlaybackHistoryEntry,
+      query: (query) => query.filtered(VALID_PLAYBACK_HISTORY_QUERY),
     },
     []
   );
@@ -38,6 +40,7 @@ export function useListeningTimeByArtist(): ArtistListeningTime[] {
   const allEntries = useQuery(
     {
       type: PlaybackHistoryEntry,
+      query: (query) => query.filtered(VALID_PLAYBACK_HISTORY_QUERY),
     },
     []
   );
@@ -86,7 +89,10 @@ export function useHistoryRecentlyPlayedShows(
   const recentlyPlayed = useQuery(
     {
       type: PlaybackHistoryEntry,
-      query: (query) => query.sorted('playbackStartedAt', /* reverse= */ true),
+      query: (query) =>
+        query
+          .filtered(VALID_PLAYBACK_HISTORY_QUERY)
+          .sorted('playbackStartedAt', /* reverse= */ true),
     },
     []
   );
@@ -179,7 +185,9 @@ export function useTopPlayedArtistUuidsOnce(
 
       const entries = realm
         .objects(PlaybackHistoryEntry)
-        .sorted('playbackStartedAt', /* reverse= */ true);
+        .filtered(VALID_PLAYBACK_HISTORY_QUERY)
+        .sorted('playbackStartedAt', /* reverse= */ true)
+        .snapshot();
       const cutoffTime = Date.now() - EARLY_EXIT_DAYS_MS;
       const counts = new Map<string, number>();
       const sortNames = new Map<string, string>();
@@ -205,6 +213,12 @@ export function useTopPlayedArtistUuidsOnce(
 
         while (index < end) {
           const entry = entries[index];
+
+          if (!entry?.isValid()) {
+            index += 1;
+            continue;
+          }
+
           const artist = entry.artist;
           const uuid = artist?.uuid;
 

--- a/relisten/realm/models/history/playback_history_repair.ts
+++ b/relisten/realm/models/history/playback_history_repair.ts
@@ -1,0 +1,27 @@
+import Realm from 'realm';
+
+import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
+import { log } from '@/relisten/util/logging';
+
+const logger = log.extend('playback-history-repair');
+const repairedRealmPaths = new Set<string>();
+
+const ORPHANED_HISTORY_QUERY =
+  'sourceTrack == nil OR artist == nil OR show == nil OR source == nil';
+export const VALID_PLAYBACK_HISTORY_QUERY =
+  'sourceTrack != nil AND artist != nil AND show != nil AND source != nil';
+
+export function removeOrphanedPlaybackHistoryEntries(realm: Realm) {
+  if (repairedRealmPaths.has(realm.path)) return;
+
+  const orphanedEntries = realm.objects(PlaybackHistoryEntry).filtered(ORPHANED_HISTORY_QUERY);
+
+  if (orphanedEntries.length > 0) {
+    logger.warn(`Removing ${orphanedEntries.length} orphaned playback history entries`);
+    realm.write(() => {
+      realm.delete(orphanedEntries);
+    });
+  }
+
+  repairedRealmPaths.add(realm.path);
+}

--- a/relisten/realm/models/player_state.ts
+++ b/relisten/realm/models/player_state.ts
@@ -62,12 +62,18 @@ export class PlayerState extends Realm.Object<PlayerState> implements PlayerStat
         obj.activeSourceTrackIndex = props.activeSourceTrackIndex;
         obj.activeSourceTrackShuffledIndex = props.activeSourceTrackShuffledIndex;
         obj.lastUpdatedAt = props.lastUpdatedAt;
-        obj.duration = props.duration;
-        obj.progress = props.progress;
-        obj.elapsed = props.elapsed;
+        obj.duration = Number.isFinite(props.duration) ? props.duration : undefined;
+        obj.progress = Number.isFinite(props.progress) ? props.progress : undefined;
+        obj.elapsed = Number.isFinite(props.elapsed) ? props.elapsed : undefined;
         return obj;
       } else {
-        return realm.create(PlayerState, { id: PLAYER_STATE_SENTINEL, ...props });
+        return realm.create(PlayerState, {
+          id: PLAYER_STATE_SENTINEL,
+          ...props,
+          duration: Number.isFinite(props.duration) ? props.duration : undefined,
+          progress: Number.isFinite(props.progress) ? props.progress : undefined,
+          elapsed: Number.isFinite(props.elapsed) ? props.elapsed : undefined,
+        });
       }
     });
   }

--- a/relisten/realm/models/show_repo.ts
+++ b/relisten/realm/models/show_repo.ts
@@ -211,7 +211,10 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
             this.realm,
             apiSourceTracksBySet[sourceSet.uuid] || [],
             sourceSet.sourceTracks,
-            true,
+            // Queue, history, and offline records retain links to SourceTrack rows. Removing a
+            // track from this source set must update membership without invalidating those durable
+            // references; unreferenced catalog rows can be collected separately.
+            false,
             true
           );
 

--- a/relisten/realm/schema.ts
+++ b/relisten/realm/schema.ts
@@ -58,7 +58,18 @@ const realmConfig: Realm.Configuration = {
     PopularityWindow,
     PopularityWindows,
   ],
-  schemaVersion: 12,
+  schemaVersion: 15,
+  migration: (oldRealm, newRealm) => {
+    if (oldRealm.schemaVersion < 15) {
+      const tracks = newRealm.objects('SourceTrack');
+      for (let i = 0; i < tracks.length; i++) {
+        const track = tracks[i] as Record<string, unknown>;
+        if (!track.mp3Url) {
+          track.mp3Url = '';
+        }
+      }
+    }
+  },
   // As to not conflict with the prior versions default.realm that isn't readable with this version of the SDK
   path: './relisten.realm',
 };

--- a/relisten/realm/schema.ts
+++ b/relisten/realm/schema.ts
@@ -23,6 +23,7 @@ import {
   PopularityWindows,
 } from '@/relisten/realm/models/popularity';
 import { isVerboseProfileLoggingEnabled } from '@/relisten/util/profile_logging';
+import { removeOrphanedPlaybackHistoryEntries } from '@/relisten/realm/models/history/playback_history_repair';
 
 if (isVerboseProfileLoggingEnabled()) {
   Realm.setLogger(({ category, level, message }) => {
@@ -82,6 +83,7 @@ export async function openRealm(): Promise<Realm> {
   if (!realmOpenPromise) {
     realmOpenPromise = Realm.open(realmConfig)
       .then((openedRealm) => {
+        removeOrphanedPlaybackHistoryEntries(openedRealm);
         setRealm(openedRealm);
         return openedRealm;
       })


### PR DESCRIPTION
## Context

Relisten 6.1.3 can accumulate player, download, and playback-history state that outlives the catalog objects from which it was created. A full-show refresh previously treated a track missing from the latest payload as permission to delete its managed Realm `SourceTrack`. That assumption is unsafe: queues, offline metadata, and history entries all retain that row as shared identity.

Once the row was deleted, live queue wrappers became invalid Realm objects and backlinks became null. Separately, non-finite playback times could reach the Expo module's Swift `Int64` arguments. Persisting those values made the failure repeat across launches. These two state-lifetime problems account for the main crash families addressed here.

## What this changes

### Preserve durable catalog and history identity

- Reconcile `SourceSet.sourceTracks` as authoritative membership without deleting absent `SourceTrack` rows.
- Remove legacy history rows whose required Realm links are already missing using one native Realm query.
- Exclude newly malformed history rows at every History, statistics, reporter, and CarPlay query boundary.
- Snapshot scalar IDs before asynchronous history work and reacquire managed catalog objects afterward.
- Keep history iteration native-backed and stable across deletions; CarPlay materializes at most 50 recent rows.
- Repair orphaned download metadata left by earlier catalog deletions.

### Enforce player-state invariants

- Reject non-finite or unsafe millisecond values at the final JS-to-native play/seek boundary.
- Sanitize native progress events, Realm writes, and restored progress.
- Resolve restored tracks from the persisted UUID arrays before filtering invalid rows.
- Preserve repeated-track occurrences and shuffled order across persistence.
- Give every queue insertion a fresh wrapper identifier.
- Remove tracks by identity in both queue orderings and rebase the active indexes.

### Harden independent crash paths

- Ignore empty/out-of-range play requests without mutating playback intent.
- Make the reorderable-list key boundary tolerant of a missing item.
- Handle empty, malformed, non-array, and unsuccessful responses in the actual recently-played polling path.
- Allow the shared API client to represent an empty response body without calling `Response.json()`.

## Sentry coverage

This targets the observed 6.1.3 failures involving:

- Expo `DynamicNumberType.cast` converting an invalid JS number to Swift `Int64`
- invalidated/deleted Realm objects in player-state serialization
- orphaned `SourceTrackOfflineInfo` and playback-history links
- queue index/identifier failures during play, reorder, remove, and restore
- unhandled JSON parsing in the recently-played screen

## Large-history behavior

The legacy repair is one native Realm query/delete per Realm path and app process; it does not copy the history table into JavaScript. Live consumers retain native filtered Results, reporter and chunked statistics use native snapshots, and CarPlay slices the native result before materializing its first 50 rows.

## Release scope

All changes are JavaScript/TypeScript. There are no native, Realm schema, runtime-version, or app-configuration changes, so this can ship as an OTA for runtime build `6045` (app version `6.1.3`).

## Verification

- [x] `yarn lint`
- [x] `yarn ts:check`
- [x] `git diff --check`
- [x] Adversarial review with independent validation and a final lifecycle/performance audit
- [ ] Exercise launch/restore with pre-existing 6.1.3 player state
- [ ] Exercise History and CarPlay with orphaned and large history data
- [ ] Exercise shuffle, duplicate tracks, removal, and relaunch
- [ ] Monitor the targeted Sentry groups after OTA publication

## Known limitation

Deleting an entire catalog `Source` can still null retained source relationships. History consumers now exclude such malformed rows safely, but the underlying catalog model still needs explicit soft-deletion or membership semantics rather than blanket source retention. That architectural change is intentionally outside this recovery OTA.