### PR TITLE
Tombstone Realm objects and safely collect retired data

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,7 +21,7 @@ import { RelistenBlue } from '@/relisten/relisten_blue';
 import { StatusBar } from 'expo-status-bar';
 
 import '@/relisten/util/dayjs_setup';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
 import useCacheAssets from './useCacheAssets';
 
 import { RelistenPlayerProvider } from '@/relisten/player/relisten_player_hooks';
@@ -50,6 +50,7 @@ import {
   isVerboseProfileLoggingEnabled,
   logRouteDebug,
 } from '@/relisten/util/profile_logging';
+import { runRealmStartupMaintenance } from '@/relisten/realm/startup_maintenance';
 
 // c.f. https://github.com/meliorence/react-native-render-html/issues/661#issuecomment-2453476566
 LogBox.ignoreLogs([/Support for defaultProps will be removed/]);
@@ -89,11 +90,14 @@ if (!__DEV__) {
   Sentry.init({});
 }
 
-function RealmBridge() {
+function RealmStartupGate({ children }: PropsWithChildren) {
   const realm = useRealm();
+  const [readyRealm, setReadyRealm] = useState<Realm | null>(null);
 
   useEffect(() => {
+    runRealmStartupMaintenance(realm);
     setRealm(realm);
+    setReadyRealm(realm);
 
     return () => {
       // React Strict Mode runs effect cleanup during the initial mount cycle in development.
@@ -104,7 +108,7 @@ function RealmBridge() {
     };
   }, [realm]);
 
-  return null;
+  return readyRealm === realm ? children : null;
 }
 
 function CarPlayBootstrap() {
@@ -196,42 +200,43 @@ function TabLayout() {
 
   return (
     <RealmProvider realmRef={realmRef} closeOnUnmount={false}>
-      <RootServicesProvider>
-        <RelistenApiProvider>
-          <RelistenPlayerProvider>
-            <RelistenCastProvider>
-              <PlaybackHistoryReporterComponent />
-              <LastFmReporterComponent />
-              <LastFmAuthListener />
-              <RealmBridge />
-              <CarPlayBootstrap />
-              <ThemeProvider
-                value={{
-                  dark: true,
-                  colors: {
-                    ...DarkTheme.colors,
-                    primary: 'rgb(0,157,193)',
-                    background: RelistenBlue[900],
-                    card: '#001114',
-                  },
-                  fonts: DefaultTheme.fonts,
-                }}
-              >
-                <RelistenPlayerBottomBarProvider>
-                  <GestureHandlerRootView style={{ flex: 1 }} onLayout={onLayoutRootView}>
-                    <SafeAreaProvider>
-                      {/* */}
-                      <StatusBar style="light" />
-                      <Slot />
-                      <FlashMessage position="top" />
-                    </SafeAreaProvider>
-                  </GestureHandlerRootView>
-                </RelistenPlayerBottomBarProvider>
-              </ThemeProvider>
-            </RelistenCastProvider>
-          </RelistenPlayerProvider>
-        </RelistenApiProvider>
-      </RootServicesProvider>
+      <RealmStartupGate>
+        <RootServicesProvider>
+          <RelistenApiProvider>
+            <RelistenPlayerProvider>
+              <RelistenCastProvider>
+                <PlaybackHistoryReporterComponent />
+                <LastFmReporterComponent />
+                <LastFmAuthListener />
+                <CarPlayBootstrap />
+                <ThemeProvider
+                  value={{
+                    dark: true,
+                    colors: {
+                      ...DarkTheme.colors,
+                      primary: 'rgb(0,157,193)',
+                      background: RelistenBlue[900],
+                      card: '#001114',
+                    },
+                    fonts: DefaultTheme.fonts,
+                  }}
+                >
+                  <RelistenPlayerBottomBarProvider>
+                    <GestureHandlerRootView style={{ flex: 1 }} onLayout={onLayoutRootView}>
+                      <SafeAreaProvider>
+                        {/* */}
+                        <StatusBar style="light" />
+                        <Slot />
+                        <FlashMessage position="top" />
+                      </SafeAreaProvider>
+                    </GestureHandlerRootView>
+                  </RelistenPlayerBottomBarProvider>
+                </ThemeProvider>
+              </RelistenCastProvider>
+            </RelistenPlayerProvider>
+          </RelistenApiProvider>
+        </RootServicesProvider>
+      </RealmStartupGate>
     </RealmProvider>
   );
 }

--- a/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/index.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/index.tsx
@@ -14,7 +14,7 @@ import { RelistenBlue } from '@/relisten/relisten_blue';
 import { useForceUpdate } from '@/relisten/util/forced_update';
 import { MaterialIcons } from '@expo/vector-icons';
 import { Link, Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react';
 import { List as ListContentLoader } from 'react-content-loader/native';
 import {
   Animated,
@@ -27,7 +27,12 @@ import {
 } from 'react-native';
 import * as R from 'remeda';
 
-import { SourceSets } from '@/relisten/components/source/source_sets_component';
+import {
+  type SourceMembershipPolicy,
+  SourceSets,
+  sourceSetsForSource,
+  sourceTracksForSource,
+} from '@/relisten/components/source/source_sets_component';
 import { SourceActionsToolbar } from '@/relisten/components/source/source_actions_toolbar';
 import { useRelistenPlayer } from '@/relisten/player/relisten_player_hooks';
 import { PlayerQueueTrack } from '@/relisten/player/relisten_player_queue';
@@ -52,6 +57,12 @@ import {
   SourceTrackOfflineInfoStatus,
   SourceTrackOfflineInfoType,
 } from '@/relisten/realm/models/source_track_offline_info';
+import {
+  activeCatalogObjectForPrimaryKey,
+  readRetainedCatalogObject,
+  retainedCatalogObjectForPrimaryKey,
+} from '@/relisten/realm/catalog_retirement';
+import { useOfflineAvailabilityIndex } from '@/relisten/realm/root_services';
 
 const logger = log.extend('source screen');
 
@@ -62,11 +73,12 @@ function shouldQueueOfflineTracksOnly(isOfflineTab: boolean, offlineMode: Offlin
 function getQueueableSourceTracks(
   source: Source,
   isOfflineTab: boolean,
-  offlineMode: OfflineModeSetting
+  offlineMode: OfflineModeSetting,
+  membershipPolicy: SourceMembershipPolicy
 ) {
   const queueOfflineOnly = shouldQueueOfflineTracksOnly(isOfflineTab, offlineMode);
 
-  return source.allSourceTracks().filter((track) => {
+  return sourceTracksForSource(source, membershipPolicy).filter((track) => {
     return queueOfflineOnly ? track.playable(false) : true;
   });
 }
@@ -106,7 +118,7 @@ export const SourceList = ({ sources }: { sources: Source[] }) => {
 export default function Page() {
   const realm = useRealm();
   const player = useRelistenPlayer();
-  const { showUuid, sourceUuid, playTrackUuid } = useLocalSearchParams();
+  const { artistUuid, showUuid, sourceUuid, playTrackUuid } = useLocalSearchParams();
   const router = useRouter();
   const groupSegment = useGroupSegment();
 
@@ -115,12 +127,105 @@ export default function Page() {
   const isRemovingDownloadsRef = useRef(false);
   const userSettings = useUserSettings();
   const isOfflineTab = useIsOfflineTab();
+  const offlineAvailabilityIndex = useOfflineAvailabilityIndex();
   const offlineMode = userSettings.offlineModeWithDefault();
 
-  const { results, show, artist, selectedSource } = useFullShowWithSelectedSource(
-    String(showUuid),
-    String(sourceUuid)
+  const {
+    results,
+    artist: queriedArtist,
+    selectedSource: queriedSource,
+  } = useFullShowWithSelectedSource(String(showUuid), String(sourceUuid));
+  const retainedAccessSite =
+    groupSegment === '(offline)'
+      ? 'offline.source-screen'
+      : groupSegment === '(myLibrary)'
+        ? 'library.source-screen'
+        : undefined;
+  const membershipPolicy = useMemo<SourceMembershipPolicy>(
+    () =>
+      retainedAccessSite
+        ? { mode: 'retained', accessSite: `${retainedAccessSite}.membership` }
+        : { mode: 'active' },
+    [retainedAccessSite]
   );
+  const show = retainedAccessSite
+    ? retainedCatalogObjectForPrimaryKey(
+        realm,
+        Show,
+        String(showUuid),
+        `${retainedAccessSite}.show`
+      )
+    : activeCatalogObjectForPrimaryKey(realm, Show, String(showUuid), 'artists.source-screen.show');
+  const isInitialSource = String(sourceUuid) === 'initial';
+  const retainedSourcesForShow =
+    retainedAccessSite && isInitialSource
+      ? realm.objects(Source).filtered('showUuid == $0', String(showUuid))
+      : undefined;
+  const retainedSourceCandidates =
+    retainedSourcesForShow && retainedAccessSite
+      ? [queriedSource, ...retainedSourcesForShow]
+          .flatMap((candidate) => {
+            const source = readRetainedCatalogObject(
+              candidate,
+              `${retainedAccessSite}.initial-source-candidate`
+            );
+            return source ? [source] : [];
+          })
+          .filter(
+            (source, index, candidates) =>
+              candidates.findIndex((candidate) => candidate.uuid === source.uuid) === index
+          )
+      : [];
+  const retainedInitialSource =
+    groupSegment === '(offline)'
+      ? retainedSourceCandidates.find((source) =>
+          offlineAvailabilityIndex.sourceHasOfflineTracks(source.uuid)
+        )
+      : groupSegment === '(myLibrary)'
+        ? (retainedSourceCandidates.find(
+            (source) =>
+              source.isFavorite || offlineAvailabilityIndex.sourceHasOfflineTracks(source.uuid)
+          ) ?? (show?.isFavorite ? retainedSourceCandidates[0] : undefined))
+        : undefined;
+  const activeSourceUuid = isInitialSource ? queriedSource?.uuid : String(sourceUuid);
+  const selectedSource = retainedAccessSite
+    ? isInitialSource
+      ? readRetainedCatalogObject(retainedInitialSource, `${retainedAccessSite}.source`)
+      : retainedCatalogObjectForPrimaryKey(
+          realm,
+          Source,
+          String(sourceUuid),
+          `${retainedAccessSite}.source`
+        )
+    : activeSourceUuid
+      ? activeCatalogObjectForPrimaryKey(
+          realm,
+          Source,
+          activeSourceUuid,
+          'artists.source-screen.source'
+        )
+      : undefined;
+  const artist = retainedAccessSite
+    ? (retainedCatalogObjectForPrimaryKey(
+        realm,
+        Artist,
+        String(artistUuid),
+        `${retainedAccessSite}.artist`
+      ) ??
+      readRetainedCatalogObject(
+        show?.artist ?? selectedSource?.artist ?? queriedArtist,
+        `${retainedAccessSite}.artist-link`
+      ))
+    : activeCatalogObjectForPrimaryKey(
+        realm,
+        Artist,
+        queriedArtist?.uuid ?? String(artistUuid),
+        'artists.source-screen.artist'
+      );
+
+  if (retainedAccessSite) {
+    readRetainedCatalogObject(show?.venue, `${retainedAccessSite}.venue`);
+  }
 
   const playShow = ((sourceTrack?: SourceTrack) => {
     if (!sourceTrack || !sourceTrack.streamingUrl() || !sourceTrack.uuid || !selectedSource) {
@@ -130,10 +235,15 @@ export default function Page() {
       return;
     }
 
-    const showTracks = getQueueableSourceTracks(selectedSource, isOfflineTab, offlineMode);
+    const showTracks = getQueueableSourceTracks(
+      selectedSource,
+      isOfflineTab,
+      offlineMode,
+      membershipPolicy
+    );
 
     const trackIndex = Math.max(
-      showTracks.findIndex((st) => st.uuid === sourceTrack?.uuid),
+      showTracks.findIndex((st) => st.uuid === sourceTrack.uuid),
       0
     );
 
@@ -153,7 +263,7 @@ export default function Page() {
       );
       return;
     }
-    const showTracks = selectedSource.allSourceTracks();
+    const showTracks = sourceTracksForSource(selectedSource, membershipPolicy);
 
     showTracks.forEach((track) => {
       DownloadManager.SHARED_INSTANCE.downloadTrack(track);
@@ -173,7 +283,7 @@ export default function Page() {
       return;
     }
 
-    const showTracks = selectedSource.allSourceTracks();
+    const showTracks = sourceTracksForSource(selectedSource, membershipPolicy);
 
     isRemovingDownloadsRef.current = true;
     setIsRemovingDownloads(true);
@@ -203,7 +313,7 @@ export default function Page() {
   const playEntireShow = () => {
     playShow(
       selectedSource
-        ? getQueueableSourceTracks(selectedSource, isOfflineTab, offlineMode)[0]
+        ? getQueueableSourceTracks(selectedSource, isOfflineTab, offlineMode, membershipPolicy)[0]
         : undefined
     );
   };
@@ -237,7 +347,12 @@ export default function Page() {
       return;
     }
 
-    for (const track of getQueueableSourceTracks(selectedSource, isOfflineTab, offlineMode)) {
+    for (const track of getQueueableSourceTracks(
+      selectedSource,
+      isOfflineTab,
+      offlineMode,
+      membershipPolicy
+    )) {
       if (track.uuid === playTrackUuid) {
         playShow(track);
 
@@ -249,6 +364,7 @@ export default function Page() {
   }, [
     hasAutoplayed,
     isOfflineTab,
+    membershipPolicy,
     offlineMode,
     playTrackUuid,
     playShow,
@@ -283,6 +399,7 @@ export default function Page() {
           selectedSource={selectedSource}
           playShow={playShow}
           downloadShow={downloadShow}
+          membershipPolicy={membershipPolicy}
         />
       </RefreshContextProvider>
     </>
@@ -295,6 +412,7 @@ const SourceComponent = ({
   playShow,
   artist,
   downloadShow,
+  membershipPolicy,
   ...props
 }: {
   show: Show | undefined;
@@ -302,6 +420,7 @@ const SourceComponent = ({
   artist?: Artist;
   playShow: PlayShow;
   downloadShow: () => void;
+  membershipPolicy: SourceMembershipPolicy;
 } & ScrollViewProps) => {
   const { refreshing, errors, hasData } = useRefreshContext();
   const userSettings = useUserSettings();
@@ -342,7 +461,8 @@ const SourceComponent = ({
   const initialTrackToPlay = getQueueableSourceTracks(
     selectedSource,
     isOfflineTab,
-    userSettings.offlineModeWithDefault()
+    userSettings.offlineModeWithDefault(),
+    membershipPolicy
   )[0];
 
   return (
@@ -355,8 +475,9 @@ const SourceComponent = ({
         playShow={playShow}
         artist={artist}
         initialTrackToPlay={initialTrackToPlay}
+        membershipPolicy={membershipPolicy}
       />
-      <SourceSets source={selectedSource} playShow={playShow} />
+      <SourceSets source={selectedSource} playShow={playShow} membershipPolicy={membershipPolicy} />
       <SourceFooter source={selectedSource} />
     </Animated.ScrollView>
   );
@@ -377,6 +498,7 @@ export const SourceHeader = ({
   playShow,
   downloadShow,
   initialTrackToPlay,
+  membershipPolicy,
 }: {
   source: Source;
   show: Show;
@@ -384,22 +506,18 @@ export const SourceHeader = ({
   artist: Artist;
   downloadShow: () => void;
   initialTrackToPlay?: SourceTrack;
+  membershipPolicy: SourceMembershipPolicy;
 }) => {
   const realm = useRealm();
   const router = useRouter();
   const forceUpdate = useForceUpdate();
   const groupSegment = useGroupSegment();
   const { fontScale } = useWindowDimensions();
+  const sourceSets = sourceSetsForSource(source, membershipPolicy);
+  const sourceTracks = sourceTracksForSource(source, membershipPolicy);
 
   const secondLine = R.filter(
-    [
-      source.humanizedDuration(),
-      `${R.sumBy(
-        source.sourceSets.map((s) => s.sourceTracks.length),
-        (l) => l
-      )} tracks`,
-      artist.name,
-    ],
+    [source.humanizedDuration(), `${sourceTracks.length} tracks`, artist.name],
     R.isTruthy
   );
 
@@ -416,9 +534,10 @@ export const SourceHeader = ({
   };
 
   // If all tracks on this show have offlineInfo and it is Succeeded, then the show is fully downloaded
-  const isFullyDownloaded = source.sourceTracks.every(
+  const isFullyDownloaded = sourceTracks.every(
     (st) =>
       st.offlineInfo &&
+      !st.offlineInfo.deletedAt &&
       st.offlineInfo.type !== SourceTrackOfflineInfoType.StreamingCache &&
       st.offlineInfo.status === SourceTrackOfflineInfoStatus.Succeeded
   );
@@ -540,7 +659,7 @@ export const SourceHeader = ({
           {source.reviewCount > 0 && <SourceReviewsButton source={source} show={show} />}
         </Flex>
       )}
-      {source.sourceSets.length === 1 && <ItemSeparator />}
+      {sourceSets.length === 1 && <ItemSeparator />}
     </View>
   );
 };

--- a/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/source_details.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/source/[sourceUuid]/source_details.tsx
@@ -10,6 +10,14 @@ import { Source } from '@/relisten/realm/models/source';
 import { ScrollScreen } from '@/relisten/components/screens/ScrollScreen';
 import { SourceFooter, SourceProperty } from '@/relisten/components/source/source_components';
 import { usePlayerBottomScrollViewProps } from '@/relisten/player/ui/player_bar_layout';
+import { useRealm } from '@/relisten/realm/schema';
+import { useGroupSegment } from '@/relisten/util/routes';
+import { Show } from '@/relisten/realm/models/show';
+import {
+  activeCatalogObjectForPrimaryKey,
+  retainedCatalogObjectForPrimaryKey,
+  readRetainedCatalogObject,
+} from '@/relisten/realm/catalog_retirement';
 
 function SourceDetails({ source, ...props }: { source: Source } & ScrollViewProps) {
   const { width } = useWindowDimensions();
@@ -83,21 +91,52 @@ function SourceDetails({ source, ...props }: { source: Source } & ScrollViewProp
 }
 
 export default function Page() {
+  const realm = useRealm();
   const navigation = useNavigation();
   const { showUuid, sourceUuid } = useLocalSearchParams();
+  const groupSegment = useGroupSegment();
   const playerBottomScrollViewProps = usePlayerBottomScrollViewProps();
 
   const {
     results: { isNetworkLoading },
-    show,
-    selectedSource: source,
+    show: queriedShow,
+    selectedSource: queriedSource,
   } = useFullShowWithSelectedSource(String(showUuid), String(sourceUuid));
+  const retainedAccessSite =
+    groupSegment === '(offline)'
+      ? 'offline.source-details'
+      : groupSegment === '(myLibrary)'
+        ? 'library.source-details'
+        : undefined;
+  const show = retainedAccessSite
+    ? (retainedCatalogObjectForPrimaryKey(
+        realm,
+        Show,
+        String(showUuid),
+        `${retainedAccessSite}.show`
+      ) ?? readRetainedCatalogObject(queriedShow, `${retainedAccessSite}.show-fallback`))
+    : queriedShow;
+  const source = retainedAccessSite
+    ? (retainedCatalogObjectForPrimaryKey(
+        realm,
+        Source,
+        String(sourceUuid),
+        `${retainedAccessSite}.source`
+      ) ?? readRetainedCatalogObject(queriedSource, `${retainedAccessSite}.source-fallback`))
+    : String(sourceUuid) === 'initial'
+      ? queriedSource
+      : activeCatalogObjectForPrimaryKey(
+          realm,
+          Source,
+          String(sourceUuid),
+          'artists.source-details.source'
+        );
 
   useEffect(() => {
     navigation.setOptions({ title: show ? `${show.displayDate} Details` : 'Details' });
-  }, [show]);
+  }, [navigation, show]);
 
-  if (isNetworkLoading) {
+  if (isNetworkLoading || !source) {
     return (
       <View className="w-full p-4">
         <ListContentLoader

--- a/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/sources/index.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/[artistUuid]/show/[showUuid]/sources/index.tsx
@@ -4,8 +4,9 @@ import { RelistenButton } from '@/relisten/components/relisten_button';
 import { RelistenText } from '@/relisten/components/relisten_text';
 import { DisappearingHeaderScreen } from '@/relisten/components/screens/disappearing_title_screen';
 import { Show } from '@/relisten/realm/models/show';
-import { useFullShowWithSelectedSource } from '@/relisten/realm/models/show_repo';
+import { sortSources, useFullShowWithSelectedSource } from '@/relisten/realm/models/show_repo';
 import { Source } from '@/relisten/realm/models/source';
+import { useQuery, useRealm } from '@/relisten/realm/schema';
 import { RelistenBlue } from '@/relisten/relisten_blue';
 import { memo } from '@/relisten/util/memo';
 import { MaterialCommunityIcons, MaterialIcons } from '@expo/vector-icons';
@@ -22,30 +23,79 @@ import { SourceTrackSucceededIndicator } from '@/relisten/components/source/sour
 import { ShowLink, ShowRedirect } from '@/relisten/util/push_show';
 import { Artist } from '@/relisten/realm/models/artist';
 import dayjs from 'dayjs';
-import { useSourceHasOfflineTracks } from '@/relisten/realm/root_services';
+import {
+  useOfflineAvailabilityIndex,
+  useSourceHasOfflineTracks,
+} from '@/relisten/realm/root_services';
 import { usePlayerBottomScrollViewProps } from '@/relisten/player/ui/player_bar_layout';
+import { useGroupSegment } from '@/relisten/util/routes';
+import {
+  readRetainedCatalogObject,
+  retainedCatalogObjectForPrimaryKey,
+} from '@/relisten/realm/catalog_retirement';
 
 export default function Page() {
+  const realm = useRealm();
   const navigation = useNavigation();
-  const { showUuid } = useLocalSearchParams();
-  const { sourceUuid } = useLocalSearchParams();
+  const { artistUuid, showUuid, sourceUuid } = useLocalSearchParams();
+  const groupSegment = useGroupSegment();
+  const offlineAvailabilityIndex = useOfflineAvailabilityIndex();
 
-  const { results, show, artist, sources } = useFullShowWithSelectedSource(
-    String(showUuid),
-    'initial'
+  const {
+    results,
+    show: queriedShow,
+    artist: queriedArtist,
+    sources: queriedSources,
+  } = useFullShowWithSelectedSource(String(showUuid), 'initial');
+  const retainedSources = useQuery(
+    Source,
+    (query) => query.filtered('showUuid == $0', String(showUuid)),
+    [showUuid]
   );
+  const retainedAccessSite =
+    groupSegment === '(offline)'
+      ? 'offline.sources-screen'
+      : groupSegment === '(myLibrary)'
+        ? 'library.sources-screen'
+        : undefined;
+  const show = retainedAccessSite
+    ? retainedCatalogObjectForPrimaryKey(
+        realm,
+        Show,
+        String(showUuid),
+        `${retainedAccessSite}.show`
+      )
+    : queriedShow;
+  const sources = retainedAccessSite
+    ? sortSources(retainedSources, offlineAvailabilityIndex).flatMap((source) => {
+        const retainedSource = readRetainedCatalogObject(source, `${retainedAccessSite}.source`);
+        return retainedSource ? [retainedSource] : [];
+      })
+    : queriedSources;
+  const artist = retainedAccessSite
+    ? (retainedCatalogObjectForPrimaryKey(
+        realm,
+        Artist,
+        String(artistUuid),
+        `${retainedAccessSite}.artist`
+      ) ??
+      readRetainedCatalogObject(
+        show?.artist ?? sources[0]?.artist ?? queriedArtist,
+        `${retainedAccessSite}.artist-link`
+      ))
+    : queriedArtist;
 
   useEffect(() => {
     navigation.setOptions({
       title: show?.displayDate,
     });
-  }, [show]);
+  }, [navigation, show]);
 
-  if (sources.length === 1) {
+  if (sources.length === 1 && show && artist) {
     return (
       <ShowRedirect
         show={{
-          artist: artist!,
+          artist,
           showUuid: show.uuid,
           sourceUuid: sources[0].uuid,
         }}
@@ -65,7 +115,7 @@ export default function Page() {
         ScrollableComponent={SourcesList}
         show={show}
         sources={sources}
-        artist={artist!}
+        artist={artist}
       />
     </RefreshContextProvider>
   );
@@ -78,7 +128,7 @@ const SourcesList = ({
   ...props
 }: {
   show: Show | undefined;
-  artist: Artist;
+  artist: Artist | undefined;
   sources?: Source[];
 } & ScrollViewProps) => {
   const { refreshing } = useRefreshContext();
@@ -88,7 +138,7 @@ const SourcesList = ({
     scrollIndicatorInsets: props.scrollIndicatorInsets,
   });
 
-  if (refreshing || !show) {
+  if (refreshing || !show || !artist) {
     return (
       <View className="w-full p-4">
         <ListContentLoader

--- a/app/relisten/tabs/(artists,myLibrary,offline)/downloading.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/downloading.tsx
@@ -1,5 +1,6 @@
-import { useQuery } from '@/relisten/realm/schema';
+import { useQuery, useRealm } from '@/relisten/realm/schema';
 import {
+  ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY,
   SourceTrackOfflineInfo,
   SourceTrackOfflineInfoStatus,
 } from '@/relisten/realm/models/source_track_offline_info';
@@ -16,6 +17,8 @@ import { RelistenSectionList } from '@/relisten/components/relisten_section_list
 import { RelistenButton } from '@/relisten/components/relisten_button';
 import { View } from 'react-native';
 import { DownloadManager } from '@/relisten/offline/download_manager';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
+import { retainedCatalogObjectForPrimaryKey } from '@/relisten/realm/catalog_retirement';
 
 function failedDownloadMessage(errorInfo?: string) {
   if (!errorInfo) {
@@ -47,7 +50,12 @@ export default function Page() {
   const navigation = useNavigation();
 
   const downloads = useQuery(SourceTrackOfflineInfo, (query) =>
-    query.filtered('status != $0', SourceTrackOfflineInfoStatus.Succeeded).sorted('queuedAt')
+    query
+      .filtered(
+        `${ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY} AND status != $0`,
+        SourceTrackOfflineInfoStatus.Succeeded
+      )
+      .sorted('queuedAt')
   );
 
   useEffect(() => {
@@ -69,13 +77,24 @@ export default function Page() {
 }
 
 const DownloadListItem = ({ item }: { item: SourceTrackOfflineInfo }) => {
-  const sourceTrack = item.sourceTrack;
+  const realm = useRealm();
+  const sourceTrack = retainedCatalogObjectForPrimaryKey(
+    realm,
+    SourceTrack,
+    item.sourceTrackUuid,
+    'offline.downloading.track-lookup'
+  );
+
+  if (!sourceTrack) {
+    return null;
+  }
 
   return (
     <TrackWithArtist
       sourceTrack={sourceTrack}
       offlineIndicator={false}
       subtitleColumn={true}
+      retainedAccessSite="offline.downloading.track-row"
       indicatorComponent={<SourceTrackOfflineIndicator offlineInfo={item} />}
     >
       <DownloadStatusTime item={item} />

--- a/app/relisten/tabs/(artists,myLibrary,offline)/history/tracks.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/history/tracks.tsx
@@ -18,6 +18,11 @@ import { SubtitleText } from '@/relisten/components/row_subtitle';
 import { ListRenderItem } from '@shopify/flash-list';
 import { TrackWithArtist } from '@/relisten/components/source/source_track_with_artist';
 import { Stack } from 'expo-router';
+import {
+  ACTIVE_PLAYBACK_HISTORY_QUERY,
+  readRetainedPlaybackHistoryCatalogLinks,
+  softDeletePlaybackHistoryEntries,
+} from '@/relisten/realm/models/history/playback_history_lifecycle';
 
 function HistoryHeader({ totalPlayed }: { totalPlayed: number }) {
   return (
@@ -60,7 +65,10 @@ export default function Page() {
   const recentlyPlayed = useQuery(
     {
       type: PlaybackHistoryEntry,
-      query: (query) => query.sorted('playbackStartedAt', /* reverse= */ true),
+      query: (query) =>
+        query
+          .filtered(ACTIVE_PLAYBACK_HISTORY_QUERY)
+          .sorted('playbackStartedAt', /* reverse= */ true),
     },
     []
   );
@@ -70,13 +78,7 @@ export default function Page() {
       confirmLabel: 'Clear History',
       message: 'This will permanently delete your listening history.',
       onConfirm: () => {
-        const history = realm.objects(PlaybackHistoryEntry);
-
-        realm.write(() => {
-          for (const entry of history) {
-            realm.delete(entry);
-          }
-        });
+        softDeletePlaybackHistoryEntries(realm);
       },
       title: 'Clear Listening History?',
     });
@@ -90,7 +92,11 @@ export default function Page() {
 
     return Object.keys(byDate).map((d) => {
       const totalDuration = byDate[d]
-        .map((d) => d.sourceTrack.duration || 0)
+        .map(
+          (entry) =>
+            readRetainedPlaybackHistoryCatalogLinks(entry, 'history.screen.sectionDuration')
+              .sourceTrack.duration || 0
+        )
         .reduce((acc, curr) => acc + curr, 0);
 
       return {
@@ -101,8 +107,12 @@ export default function Page() {
   }, [recentlyPlayed]);
 
   const renderItem: ListRenderItem<PlaybackHistoryEntry> = ({ item: entry }) => {
+    const { sourceTrack } = readRetainedPlaybackHistoryCatalogLinks(
+      entry,
+      'history.screen.trackRow'
+    );
     return (
-      <TrackWithArtist sourceTrack={entry.sourceTrack}>
+      <TrackWithArtist sourceTrack={sourceTrack}>
         <SubtitleText>{entry.humanizedPlaybackStartedAt()}</SubtitleText>
       </TrackWithArtist>
     );

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios -d",
     "web": "expo start --web",
+    "test": "vitest run",
     "ts:check": "tsc",
     "lint": "eslint app relisten",
     "pods": "npx pod-install",
@@ -100,7 +101,8 @@
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "patch-package": "^8.0.1",
     "tailwindcss": "3.3.2",
-    "typescript": "~6.0.3"
+    "typescript": "~6.0.3",
+    "vitest": "^4.1.9"
   },
   "expo": {
     "doctor": {

--- a/relisten/carplay/artists.ts
+++ b/relisten/carplay/artists.ts
@@ -20,8 +20,12 @@ import { upsertShowWithSources } from '@/relisten/realm/models/show_repo';
 import { TodayShowsNetworkBackedBehavior } from '@/relisten/realm/models/shows/today_shows_repo';
 import { sample } from 'remeda';
 import plur from 'plur';
-
-type ItemMap<T extends { uuid: string }> = Map<string, T>;
+import {
+  catalogResultsForScope,
+  selectedCatalogObjectForScope,
+} from '@/relisten/carplay/catalog_scope';
+import { readRetainedCatalogObject } from '@/relisten/realm/catalog_retirement';
+import { RealmQueryValueStream } from '@/relisten/realm/value_streams';
 
 type YearShowsResults = YearShows;
 
@@ -51,9 +55,16 @@ export function createArtistsListTemplate(
 
   const results = executor.start();
   ctx.addTeardown(() => executor.tearDown());
+  const retainedArtistsStream =
+    scope === 'browse'
+      ? undefined
+      : new RealmQueryValueStream<Artist>(ctx.realm, ctx.realm.objects(Artist));
+  if (retainedArtistsStream) {
+    ctx.addTeardown(() => retainedArtistsStream.tearDown());
+  }
 
-  const artistMap: ItemMap<Artist> = new Map();
-  let favoriteArtists: Artist[] = [];
+  const artistUuids = new Set<string>();
+  let favoriteArtistUuids: string[] = [];
 
   const template = new ListTemplate({
     title: SCOPE_META[scope].title,
@@ -61,26 +72,44 @@ export function createArtistsListTemplate(
     tabSystemImageName: 'music.pages.fill',
     async onItemSelect({ id }: { templateId: string; index: number; id: string }) {
       if (scope === 'browse') {
-        if (id === FAVORITES_ACTION_ON_THIS_DAY && favoriteArtists.length > 0) {
+        if (id === FAVORITES_ACTION_ON_THIS_DAY && favoriteArtistUuids.length > 0) {
           const todayTemplate = createTodayShowsTemplate(
             ctx,
             scope,
-            favoriteArtists,
+            favoriteArtistUuids,
             'On This Day'
           );
           CarPlay.pushTemplate(todayTemplate, true);
           return;
         }
 
-        if (id === FAVORITES_ACTION_RANDOM && favoriteArtists.length > 0) {
-          const randomArtist = sample([...favoriteArtists], 1)[0]!;
-          const randomShow = await ctx.apiClient.randomShow(randomArtist.uuid);
+        if (id === FAVORITES_ACTION_RANDOM && favoriteArtistUuids.length > 0) {
+          const randomArtistUuid = sample(favoriteArtistUuids, 1)[0]!;
+          const randomShow = await ctx.apiClient.randomShow(randomArtistUuid);
 
           if (randomShow?.data?.uuid) {
-            const show = upsertShowWithSources(ctx.realm, randomShow.data);
+            const upsertedShow = upsertShowWithSources(ctx.realm, randomShow.data);
+            const show = upsertedShow
+              ? selectedCatalogObjectForScope(
+                  ctx.realm,
+                  scope,
+                  Show,
+                  upsertedShow.uuid,
+                  'carplay.artists.random-show'
+                )
+              : undefined;
+            const showArtist = show
+              ? selectedCatalogObjectForScope(
+                  ctx.realm,
+                  scope,
+                  Artist,
+                  show.artistUuid,
+                  'carplay.artists.random-show-artist'
+                )
+              : undefined;
 
-            if (show && show.artist) {
-              const sourcesTemplate = createSourcesListTemplate(ctx, scope, show.artist, show);
+            if (show && showArtist) {
+              const sourcesTemplate = createSourcesListTemplate(ctx, scope, showArtist, show);
               CarPlay.pushTemplate(sourcesTemplate, true);
             }
           }
@@ -89,9 +118,18 @@ export function createArtistsListTemplate(
       }
 
       carplay_logger.info('artist selected', { id, scope });
-      const artist = artistMap.get(String(id));
+      const artistUuid = String(id);
+      if (!artistUuids.has(artistUuid)) return;
 
-      if (!artist) return;
+      const artist = selectedCatalogObjectForScope(
+        ctx.realm,
+        scope,
+        Artist,
+        artistUuid,
+        'carplay.artists.artist-selection'
+      );
+
+      if (!artist || !includeArtistForScope(ctx, scope, artist)) return;
 
       const yearsTemplate = createYearsListTemplate(ctx, scope, artist);
       CarPlay.pushTemplate(yearsTemplate, true);
@@ -102,17 +140,15 @@ export function createArtistsListTemplate(
 
   ctx.addTeardown(() => results.tearDown());
 
-  results.addListener((nextValue) => {
-    const isLoading = nextValue.isNetworkLoading;
-    const artists = Array.from(nextValue.data || []);
-
+  let isNetworkLoading = true;
+  const updateArtists = (artists: Artist[], isLoading: boolean) => {
     const filtered = artists.filter((artist) => includeArtistForScope(ctx, scope, artist));
     const sorted = filtered.sort((a, b) => a.sortName.localeCompare(b.sortName));
 
-    artistMap.clear();
+    artistUuids.clear();
 
     for (const artist of sorted) {
-      artistMap.set(artist.uuid, artist);
+      artistUuids.add(artist.uuid);
     }
 
     const sections: ListSection[] = [];
@@ -137,7 +173,7 @@ export function createArtistsListTemplate(
 
     const favorites = sorted.filter((a) => a.isFavorite);
     const offline = sorted.filter((a) => ctx.libraryIndex.artistHasOfflineTracks(a.uuid));
-    favoriteArtists = favorites;
+    favoriteArtistUuids = favorites.map((artist) => artist.uuid);
 
     if (scope === 'browse') {
       if (favorites.length > 0) {
@@ -205,6 +241,22 @@ export function createArtistsListTemplate(
     }
 
     template.updateSections(sections);
+  };
+
+  results.addListener((nextValue) => {
+    isNetworkLoading = nextValue.isNetworkLoading;
+    const scopedResults = nextValue.data
+      ? catalogResultsForScope(scope, nextValue.data)
+      : undefined;
+    const artists =
+      scope === 'browse'
+        ? Array.from(scopedResults || [])
+        : Array.from(retainedArtistsStream?.currentValue || []);
+    updateArtists(artists, isNetworkLoading);
+  });
+
+  retainedArtistsStream?.addListener((artists) => {
+    updateArtists(Array.from(artists), isNetworkLoading);
   });
 
   return template;
@@ -215,7 +267,9 @@ function createYearsListTemplate(
   scope: CarPlayScope,
   artist: Artist
 ): ListTemplate {
-  carplay_logger.info('createYearsListTemplate', { scope, artist: artist.uuid });
+  const artistUuid = artist.uuid;
+  const artistName = artist.name;
+  carplay_logger.info('createYearsListTemplate', { scope, artist: artistUuid });
   const behaviorOptions =
     scope === 'offline'
       ? { fetchStrategy: NetworkBackedBehaviorFetchStrategy.NetworkOnlyIfLocalIsNotShowable }
@@ -224,8 +278,9 @@ function createYearsListTemplate(
   const yearsBehavior = yearsNetworkBackedModelArrayBehavior(
     ctx.realm,
     scope === 'offline',
-    artist.uuid,
-    behaviorOptions
+    artistUuid,
+    behaviorOptions,
+    scope !== 'browse'
   );
   const executor = yearsBehavior.sharedExecutor(ctx.apiClient);
   const results = executor.start();
@@ -233,10 +288,10 @@ function createYearsListTemplate(
   ctx.addTeardown(() => executor.tearDown());
   ctx.addTeardown(() => results.tearDown());
 
-  const yearMap: ItemMap<Year> = new Map();
-  const showMap: ItemMap<Show> = new Map();
+  const yearUuids = new Set<string>();
+  const showUuids = new Set<string>();
   let currentMode: 'years' | 'shows' | 'today' = 'years';
-  let selectedYear: Year | undefined;
+  let selectedYearUuid: string | undefined;
   let detailExecutorTeardown: (() => void) | undefined;
   let detailResultsTeardown: (() => void) | undefined;
 
@@ -258,10 +313,15 @@ function createYearsListTemplate(
   const showYears = () => {
     clearDetailBehavior();
     currentMode = 'years';
-    selectedYear = undefined;
-    showMap.clear();
+    selectedYearUuid = undefined;
+    showUuids.clear();
 
-    const sorted = Array.from(yearMap.values()).sort((a, b) => a.year.localeCompare(b.year));
+    const sorted = Array.from(yearUuids)
+      .map((uuid) =>
+        selectedCatalogObjectForScope(ctx.realm, scope, Year, uuid, 'carplay.years.render-year')
+      )
+      .filter((year): year is Year => year !== undefined)
+      .sort((a, b) => a.year.localeCompare(b.year));
     const items = sorted.map((year) => ({
       id: year.uuid,
       text: year.year,
@@ -276,13 +336,13 @@ function createYearsListTemplate(
           {
             id: ARTIST_ACTION_ON_THIS_DAY,
             text: 'On This Day',
-            detailText: `Shows on this day by ${artist.name}.`,
+            detailText: `Shows on this day by ${artistName}.`,
             showsDisclosureIndicator: true,
           },
           {
             id: ARTIST_ACTION_RANDOM,
             text: 'Random Show',
-            detailText: `Play a random ${artist.name} show.`,
+            detailText: `Play a random ${artistName} show.`,
             showsDisclosureIndicator: true,
           },
         ],
@@ -297,23 +357,25 @@ function createYearsListTemplate(
   };
 
   const showShows = (year: Year) => {
+    const yearUuid = year.uuid;
+    const yearLabel = year.year;
     clearDetailBehavior();
     currentMode = 'shows';
-    selectedYear = year;
-    showMap.clear();
+    selectedYearUuid = yearUuid;
+    showUuids.clear();
 
     template.updateSections([
       {
-        header: year.year,
+        header: yearLabel,
         items: [
           {
             id: ACTION_SHOW_YEARS,
             text: 'Back to Years',
-            detailText: artist.name,
+            detailText: artistName,
             showsDisclosureIndicator: false,
           },
           {
-            id: `loading-${year.uuid}`,
+            id: `loading-${yearUuid}`,
             text: 'Loading shows...',
             showsDisclosureIndicator: false,
           },
@@ -329,8 +391,8 @@ function createYearsListTemplate(
 
     const showsBehavior = createYearShowsNetworkBackedBehavior(
       ctx.realm,
-      artist.uuid,
-      year.uuid,
+      artistUuid,
+      yearUuid,
       userFilters,
       behaviorOptions
     );
@@ -341,18 +403,19 @@ function createYearsListTemplate(
     detailResultsTeardown = () => showsResults.tearDown();
 
     showsResults.addListener((nextValue) => {
-      if (currentMode !== 'shows' || selectedYear?.uuid !== year.uuid) {
+      if (currentMode !== 'shows' || selectedYearUuid !== yearUuid) {
         return;
       }
 
       const value: YearShowsResults = nextValue.data;
-      const shows = value?.shows ? Array.from(value.shows) : [];
+      const scopedShows = value?.shows ? catalogResultsForScope(scope, value.shows) : undefined;
+      const shows = scopedShows ? Array.from(scopedShows) : [];
       const filteredShows = shows.filter((show) => includeShowForScope(ctx, scope, show));
       const sortedShows = filteredShows.sort((a, b) => a.displayDate.localeCompare(b.displayDate));
 
-      showMap.clear();
+      showUuids.clear();
       for (const show of sortedShows) {
-        showMap.set(show.uuid, show);
+        showUuids.add(show.uuid);
       }
 
       template.updateSections([
@@ -362,7 +425,7 @@ function createYearsListTemplate(
             {
               id: ACTION_SHOW_YEARS,
               text: 'Back to Years',
-              detailText: year.year,
+              detailText: yearLabel,
               showsDisclosureIndicator: false,
             },
           ],
@@ -374,12 +437,12 @@ function createYearsListTemplate(
               ? sortedShows.map((show) => ({
                   id: show.uuid,
                   text: show.displayDate,
-                  detailText: formatShowDetail(show),
+                  detailText: formatShowDetail(show, scope),
                   showsDisclosureIndicator: true,
                 }))
               : [
                   {
-                    id: `empty-${year.uuid}`,
+                    id: `empty-${yearUuid}`,
                     text: 'No shows available',
                     detailText: 'Try another year.',
                     showsDisclosureIndicator: false,
@@ -393,8 +456,8 @@ function createYearsListTemplate(
   const showToday = () => {
     clearDetailBehavior();
     currentMode = 'today';
-    selectedYear = undefined;
-    showMap.clear();
+    selectedYearUuid = undefined;
+    showUuids.clear();
 
     template.updateSections([
       {
@@ -403,11 +466,11 @@ function createYearsListTemplate(
           {
             id: ACTION_SHOW_YEARS,
             text: 'Back to Years',
-            detailText: artist.name,
+            detailText: artistName,
             showsDisclosureIndicator: false,
           },
           {
-            id: `loading-today-${artist.uuid}`,
+            id: `loading-today-${artistUuid}`,
             text: 'Loading shows...',
             showsDisclosureIndicator: false,
           },
@@ -415,27 +478,40 @@ function createYearsListTemplate(
       },
     ]);
 
-    const todayBehavior = new TodayShowsNetworkBackedBehavior(ctx.realm, [artist.uuid], {
+    const todayBehavior = new TodayShowsNetworkBackedBehavior(ctx.realm, [artistUuid], {
       fetchStrategy: NetworkBackedBehaviorFetchStrategy.NetworkAlwaysFirst,
     });
     const todayExecutor = todayBehavior.sharedExecutor(ctx.apiClient);
     const todayResults = todayExecutor.start();
+    const retainedTodayStream =
+      scope === 'browse'
+        ? undefined
+        : new RealmQueryValueStream<Show>(
+            ctx.realm,
+            ctx.realm
+              .objects(Show)
+              .filtered('displayDate ENDSWITH $0', todayDisplayDateSuffix())
+              .filtered('artistUuid == $0', artistUuid)
+          );
 
     detailExecutorTeardown = () => todayExecutor.tearDown();
-    detailResultsTeardown = () => todayResults.tearDown();
+    detailResultsTeardown = () => {
+      todayResults.tearDown();
+      retainedTodayStream?.tearDown();
+    };
 
-    todayResults.addListener((nextValue) => {
+    const updateTodayShows = (nextShows: Show[]) => {
       if (currentMode !== 'today') {
         return;
       }
 
-      const shows = Array.from(nextValue.data || []).sort(
-        (a, b) => b.date.getTime() - a.date.getTime()
-      );
+      const shows = nextShows
+        .filter((show) => includeShowForScope(ctx, scope, show))
+        .sort((a, b) => b.date.getTime() - a.date.getTime());
 
-      showMap.clear();
+      showUuids.clear();
       for (const show of shows) {
-        showMap.set(show.uuid, show);
+        showUuids.add(show.uuid);
       }
 
       template.updateSections([
@@ -445,7 +521,7 @@ function createYearsListTemplate(
             {
               id: ACTION_SHOW_YEARS,
               text: 'Back to Years',
-              detailText: artist.name,
+              detailText: artistName,
               showsDisclosureIndicator: false,
             },
           ],
@@ -457,12 +533,12 @@ function createYearsListTemplate(
               ? shows.map((show) => ({
                   id: show.uuid,
                   text: show.displayDate,
-                  detailText: formatShowDetail(show),
+                  detailText: formatShowDetail(show, scope),
                   showsDisclosureIndicator: true,
                 }))
               : [
                   {
-                    id: `empty-today-${artist.uuid}`,
+                    id: `empty-today-${artistUuid}`,
                     text: 'No shows on this day',
                     detailText: 'Try another artist or check back later.',
                     showsDisclosureIndicator: false,
@@ -470,11 +546,26 @@ function createYearsListTemplate(
                 ],
         },
       ]);
+    };
+
+    todayResults.addListener((nextValue) => {
+      const scopedShows = nextValue.data
+        ? catalogResultsForScope(scope, nextValue.data)
+        : undefined;
+      const shows =
+        scope === 'browse'
+          ? Array.from(scopedShows || [])
+          : Array.from(retainedTodayStream?.currentValue || []);
+      updateTodayShows(shows);
+    });
+
+    retainedTodayStream?.addListener((shows) => {
+      updateTodayShows(Array.from(shows));
     });
   };
 
   const template = new ListTemplate({
-    title: artist.name,
+    title: artistName,
     tabTitle: SCOPE_META[scope].tabTitle,
     tabSystemImageName: 'music.pages.fill',
     async onItemSelect({ id }: { templateId: string; index: number; id: string }) {
@@ -486,14 +577,37 @@ function createYearsListTemplate(
 
         carplay_logger.info('show selected', {
           id,
-          artist: artist.uuid,
-          year: selectedYear?.uuid,
+          artist: artistUuid,
+          year: selectedYearUuid,
           scope,
         });
-        const show = showMap.get(String(id));
-        if (!show) return;
+        const showUuid = String(id);
+        if (!showUuids.has(showUuid)) return;
 
-        const sourcesTemplate = createSourcesListTemplate(ctx, scope, artist, show);
+        const show = selectedCatalogObjectForScope(
+          ctx.realm,
+          scope,
+          Show,
+          showUuid,
+          'carplay.years.show-selection'
+        );
+        const selectedArtist = selectedCatalogObjectForScope(
+          ctx.realm,
+          scope,
+          Artist,
+          artistUuid,
+          'carplay.years.show-selection-artist'
+        );
+        if (
+          !show ||
+          !selectedArtist ||
+          !includeShowForScope(ctx, scope, show) ||
+          !includeArtistForScope(ctx, scope, selectedArtist)
+        ) {
+          return;
+        }
+
+        const sourcesTemplate = createSourcesListTemplate(ctx, scope, selectedArtist, show);
         CarPlay.pushTemplate(sourcesTemplate, true);
         return;
       }
@@ -504,22 +618,49 @@ function createYearsListTemplate(
       }
 
       if (id === ARTIST_ACTION_RANDOM) {
-        const randomShow = await ctx.apiClient.randomShow(artist.uuid);
+        const randomShow = await ctx.apiClient.randomShow(artistUuid);
 
         if (randomShow?.data?.uuid) {
-          const show = upsertShowWithSources(ctx.realm, randomShow.data);
+          const upsertedShow = upsertShowWithSources(ctx.realm, randomShow.data);
+          const show = upsertedShow
+            ? selectedCatalogObjectForScope(
+                ctx.realm,
+                scope,
+                Show,
+                upsertedShow.uuid,
+                'carplay.years.random-show'
+              )
+            : undefined;
+          const showArtist = show
+            ? selectedCatalogObjectForScope(
+                ctx.realm,
+                scope,
+                Artist,
+                show.artistUuid,
+                'carplay.years.random-show-artist'
+              )
+            : undefined;
 
-          if (show && show.artist) {
-            const sourcesTemplate = createSourcesListTemplate(ctx, scope, show.artist, show);
+          if (show && showArtist) {
+            const sourcesTemplate = createSourcesListTemplate(ctx, scope, showArtist, show);
             CarPlay.pushTemplate(sourcesTemplate, true);
           }
         }
         return;
       }
 
-      carplay_logger.info('year selected', { id, artist: artist.uuid, scope });
-      const year = yearMap.get(String(id));
-      if (!year) return;
+      carplay_logger.info('year selected', { id, artist: artistUuid, scope });
+      const yearUuid = String(id);
+      if (!yearUuids.has(yearUuid)) return;
+
+      const year = selectedCatalogObjectForScope(
+        ctx.realm,
+        scope,
+        Year,
+        yearUuid,
+        'carplay.years.year-selection'
+      );
+      if (!year || !includeYearForScope(ctx, scope, year)) return;
 
       showShows(year);
     },
@@ -528,13 +669,14 @@ function createYearsListTemplate(
   });
 
   results.addListener((nextValue) => {
-    const years = Array.from(nextValue.data || []);
+    const scopedYears = nextValue.data ? catalogResultsForScope(scope, nextValue.data) : undefined;
+    const years = Array.from(scopedYears || []);
     const filtered = years.filter((year) => includeYearForScope(ctx, scope, year));
     const sorted = filtered.sort((a, b) => a.year.localeCompare(b.year));
 
-    yearMap.clear();
+    yearUuids.clear();
     for (const year of sorted) {
-      yearMap.set(year.uuid, year);
+      yearUuids.add(year.uuid);
     }
 
     if (currentMode === 'years') {
@@ -542,7 +684,7 @@ function createYearsListTemplate(
       return;
     }
 
-    if (selectedYear && !yearMap.has(selectedYear.uuid)) {
+    if (selectedYearUuid && !yearUuids.has(selectedYearUuid)) {
       showYears();
     }
   });
@@ -551,39 +693,51 @@ function createYearsListTemplate(
 }
 
 function includeArtistForScope(ctx: RelistenCarPlayContext, scope: CarPlayScope, artist: Artist) {
+  let included = true;
+
   if (scope === 'offline') {
-    return ctx.libraryIndex.artistHasOfflineTracks(artist.uuid);
+    included = ctx.libraryIndex.artistHasOfflineTracks(artist.uuid);
+  } else if (scope === 'library') {
+    included = ctx.libraryIndex.artistIsInLibrary(artist.uuid);
   }
 
-  if (scope === 'library') {
-    return ctx.libraryIndex.artistIsInLibrary(artist.uuid);
+  if (included && scope !== 'browse') {
+    readRetainedCatalogObject(artist, 'carplay.artists.scoped-artist');
   }
 
-  return true;
+  return included;
 }
 
 function includeYearForScope(ctx: RelistenCarPlayContext, scope: CarPlayScope, year: Year) {
+  let included = true;
+
   if (scope === 'offline') {
-    return ctx.libraryIndex.yearHasOfflineTracks(year.uuid);
+    included = ctx.libraryIndex.yearHasOfflineTracks(year.uuid);
+  } else if (scope === 'library') {
+    included = ctx.libraryIndex.yearIsInLibrary(year.uuid);
   }
 
-  if (scope === 'library') {
-    return ctx.libraryIndex.yearIsInLibrary(year.uuid);
+  if (included && scope !== 'browse') {
+    readRetainedCatalogObject(year, 'carplay.years.scoped-year');
   }
 
-  return true;
+  return included;
 }
 
 function includeShowForScope(ctx: RelistenCarPlayContext, scope: CarPlayScope, show: Show) {
+  let included = true;
+
   if (scope === 'offline') {
-    return ctx.libraryIndex.showHasOfflineTracks(show.uuid);
+    included = ctx.libraryIndex.showHasOfflineTracks(show.uuid);
+  } else if (scope === 'library') {
+    included = ctx.libraryIndex.showIsInLibrary(show.uuid);
   }
 
-  if (scope === 'library') {
-    return ctx.libraryIndex.showIsInLibrary(show.uuid);
+  if (included && scope !== 'browse') {
+    readRetainedCatalogObject(show, 'carplay.shows.scoped-show');
   }
 
-  return true;
+  return included;
 }
 
 function artistListItem(artist: Artist) {
@@ -593,4 +747,11 @@ function artistListItem(artist: Artist) {
     detailText: `${artist.showCount} ${plur('show', artist.showCount)} • ${artist.sourceCount} ${plur('tape', artist.sourceCount)}`,
     showsDisclosureIndicator: true,
   };
+}
+
+function todayDisplayDateSuffix() {
+  const now = new Date();
+  const month = (now.getMonth() + 1).toFixed(0).padStart(2, '0');
+  const day = now.getDate().toFixed(0).padStart(2, '0');
+  return `-${month}-${day}`;
 }

--- a/relisten/carplay/catalog_scope.ts
+++ b/relisten/carplay/catalog_scope.ts
@@ -1,0 +1,82 @@
+import Realm from 'realm';
+
+import { CarPlayScope } from '@/relisten/carplay/scope';
+import {
+  activeCatalogObjectForPrimaryKey,
+  activeCatalogResults,
+  isRetiredCatalogObject,
+  readRetainedCatalogObject,
+  retainedCatalogObjectForPrimaryKey,
+} from '@/relisten/realm/catalog_retirement';
+import {
+  reportUnexpectedRetiredCatalogAccess,
+  RetireableCatalogObject,
+} from '@/relisten/realm/catalog_access_monitor';
+
+export type CarPlayCatalogAccess = 'active' | 'retained';
+
+export function catalogAccessForScope(scope: CarPlayScope): CarPlayCatalogAccess {
+  return scope === 'browse' ? 'active' : 'retained';
+}
+
+export function catalogResultsForScope<T extends RetireableCatalogObject>(
+  scope: CarPlayScope,
+  results: Realm.Results<T>
+): Realm.Results<T> {
+  return scope === 'browse' ? activeCatalogResults(results) : results;
+}
+
+export function catalogObjectsForAccess<T extends RetireableCatalogObject>(
+  objects: Iterable<T>,
+  access: CarPlayCatalogAccess,
+  accessSite: string
+): T[] {
+  const included: T[] = [];
+
+  for (const object of objects) {
+    if (access === 'active' && isRetiredCatalogObject(object)) {
+      reportUnexpectedRetiredCatalogAccess(object, accessSite);
+      continue;
+    }
+
+    if (access === 'retained') {
+      readRetainedCatalogObject(object, accessSite);
+    }
+
+    included.push(object);
+  }
+
+  return included;
+}
+
+export function catalogObjectsForScope<T extends RetireableCatalogObject>(
+  scope: CarPlayScope,
+  objects: Iterable<T>,
+  accessSite: string
+): T[] {
+  return catalogObjectsForAccess(objects, catalogAccessForScope(scope), accessSite);
+}
+
+export function selectedCatalogObjectForScope<T extends RetireableCatalogObject>(
+  realm: Realm,
+  scope: CarPlayScope,
+  type: Realm.RealmObjectConstructor<T>,
+  uuid: string,
+  accessSite: string
+): T | undefined {
+  return scope === 'browse'
+    ? activeCatalogObjectForPrimaryKey(realm, type, uuid as T[keyof T], accessSite)
+    : retainedCatalogObjectForPrimaryKey(realm, type, uuid as T[keyof T], accessSite);
+}
+
+export function selectedCatalogObjectForAccess<T extends RetireableCatalogObject>(
+  realm: Realm,
+  access: CarPlayCatalogAccess,
+  type: Realm.RealmObjectConstructor<T>,
+  uuid: string,
+  accessSite: string
+): T | undefined {
+  return access === 'active'
+    ? activeCatalogObjectForPrimaryKey(realm, type, uuid as T[keyof T], accessSite)
+    : retainedCatalogObjectForPrimaryKey(realm, type, uuid as T[keyof T], accessSite);
+}

--- a/relisten/carplay/library.ts
+++ b/relisten/carplay/library.ts
@@ -10,6 +10,13 @@ import { OfflineModeSetting } from '@/relisten/realm/models/user_settings';
 import plur from 'plur';
 import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
 import { queuePlaybackHistoryEntry } from '@/relisten/carplay/queue_helpers';
+import {
+  ACTIVE_PLAYBACK_HISTORY_QUERY,
+  activePlaybackHistoryEntryForPrimaryKey,
+  readRetainedPlaybackHistoryCatalogLinks,
+} from '@/relisten/realm/models/history/playback_history_lifecycle';
+import { catalogObjectsForAccess } from '@/relisten/carplay/catalog_scope';
+import { readRetainedCatalogObject } from '@/relisten/realm/catalog_retirement';
 
 export function createLibraryTemplate(ctx: RelistenCarPlayContext): ListTemplate {
   carplay_logger.info('createLibraryTemplate');
@@ -32,13 +39,20 @@ export function createLibraryTemplate(ctx: RelistenCarPlayContext): ListTemplate
     tabTitle: 'Library',
     tabSystemImageName: 'star.circle',
     async onItemSelect({ id }: { templateId: string; index: number; id: string }) {
-      const show = showMap.get(String(id));
-      if (!show || !show.artist) {
+      const show = readRetainedCatalogObject(
+        showMap.get(String(id)),
+        'carplay.library.show-selection'
+      );
+      const artist = readRetainedCatalogObject(
+        show?.artist,
+        'carplay.library.show-selection-artist'
+      );
+      if (!show || !artist) {
         carplay_logger.warn('Library show selection missing data', { id });
         return;
       }
 
-      const sourcesTemplate = createSourcesListTemplate(ctx, 'library', show.artist, show);
+      const sourcesTemplate = createSourcesListTemplate(ctx, 'library', artist, show);
       CarPlay.pushTemplate(sourcesTemplate, true);
     },
     sections: [],
@@ -47,14 +61,18 @@ export function createLibraryTemplate(ctx: RelistenCarPlayContext): ListTemplate
 
   const updateSections = () => {
     showMap.clear();
-    const shows = Array.from(showsStream.currentValue || []);
+    const shows = catalogObjectsForAccess(
+      Array.from(showsStream.currentValue || []),
+      'retained',
+      'carplay.library.show'
+    );
 
     const sections: ListSection[] = [];
 
     const groupedByArtist: Map<string, Show[]> = new Map();
 
     for (const show of shows) {
-      const artist = show.artist;
+      const artist = readRetainedCatalogObject(show.artist, 'carplay.library.show-artist');
       if (!artist) continue;
 
       const existing = groupedByArtist.get(artist.uuid) || [];
@@ -115,22 +133,29 @@ export function createRecentTemplate(ctx: RelistenCarPlayContext): ListTemplate 
 
   const historyStream = new RealmQueryValueStream(
     ctx.realm,
-    ctx.realm.objects(PlaybackHistoryEntry).sorted('playbackStartedAt', true)
+    ctx.realm
+      .objects(PlaybackHistoryEntry)
+      .filtered(ACTIVE_PLAYBACK_HISTORY_QUERY)
+      .sorted('playbackStartedAt', true)
   );
 
   ctx.addTeardown(() => historyStream.tearDown());
-
-  const entryMap: Map<string, PlaybackHistoryEntry> = new Map();
 
   const template = new ListTemplate({
     title: 'Recently Played',
     tabTitle: 'Recent',
     tabSystemImageName: 'clock.arrow.circlepath',
     async onItemSelect({ id }: { templateId: string; index: number; id: string }) {
-      const entry = entryMap.get(String(id));
-      if (!entry) return;
+      const entry = activePlaybackHistoryEntryForPrimaryKey(ctx.realm, String(id));
+      if (!entry) {
+        carplay_logger.warn('History selection is no longer active', { id });
+        return;
+      }
 
-      const track = entry.sourceTrack;
+      const { sourceTrack: track } = readRetainedPlaybackHistoryCatalogLinks(
+        entry,
+        'history.carplay.selection'
+      );
       const offlineMode = ctx.userSettings.offlineModeWithDefault();
 
       if (
@@ -148,18 +173,18 @@ export function createRecentTemplate(ctx: RelistenCarPlayContext): ListTemplate 
   });
 
   const updateSections = () => {
-    entryMap.clear();
     const entries = Array.from(historyStream.currentValue || []).slice(0, 50);
 
     const items = entries.map((entry) => {
-      entryMap.set(entry.uuid, entry);
-      const show = entry.show;
-      const artist = entry.artist;
+      const { artist, show, sourceTrack } = readRetainedPlaybackHistoryCatalogLinks(
+        entry,
+        'history.carplay.recentFormatting'
+      );
       const subtitle = [artist?.name, show?.displayDate].filter(Boolean).join(' • ');
 
       return {
         id: entry.uuid,
-        text: entry.sourceTrack.title,
+        text: sourceTrack.title,
         detailText: subtitle,
         showsDisclosureIndicator: false,
       };
@@ -185,8 +210,9 @@ export function createRecentTemplate(ctx: RelistenCarPlayContext): ListTemplate 
 }
 
 function formatLibraryShowDetail(ctx: RelistenCarPlayContext, show: Show) {
-  const venue = show.venue?.name;
-  const location = show.venue?.location;
+  const showVenue = readRetainedCatalogObject(show.venue, 'carplay.library.show-venue');
+  const venue = showVenue?.name;
+  const location = showVenue?.location;
   const locationText = [venue, location].filter(Boolean).join(' • ');
   const offline = ctx.libraryIndex.showHasOfflineTracks(show.uuid) ? 'Offline' : undefined;
   const rating = show.avgRating ? `${show.humanizedAvgRating()}★` : undefined;

--- a/relisten/carplay/queue_helpers.ts
+++ b/relisten/carplay/queue_helpers.ts
@@ -7,24 +7,42 @@ import { buildTrackSections, isTrackPlayableInScope } from '@/relisten/carplay/t
 import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
 import { upsertShowWithSources } from '@/relisten/realm/models/show_repo';
 import { Source } from '@/relisten/realm/models/source';
+import { Artist } from '@/relisten/realm/models/artist';
+import {
+  CarPlayCatalogAccess,
+  catalogAccessForScope,
+  selectedCatalogObjectForAccess,
+} from '@/relisten/carplay/catalog_scope';
+import { readRetainedCatalogObject } from '@/relisten/realm/catalog_retirement';
 
 export function queueTracksFromSelection({
   ctx,
   scope,
-  orderedTracks,
+  orderedTrackUuids,
   selectedTrackUuid,
   sourceUuid,
+  catalogAccess = catalogAccessForScope(scope),
 }: {
   ctx: RelistenCarPlayContext;
   scope: CarPlayScope;
-  orderedTracks: SourceTrack[];
+  orderedTrackUuids: string[];
   selectedTrackUuid: string;
   sourceUuid?: string;
+  catalogAccess?: CarPlayCatalogAccess;
 }) {
   const offlineMode = ctx.userSettings.offlineModeWithDefault();
-  const playableTracks = orderedTracks.filter((track) =>
-    isTrackPlayableInScope(scope, offlineMode, track)
-  );
+  const playableTracks = orderedTrackUuids
+    .map((uuid) =>
+      selectedCatalogObjectForAccess(
+        ctx.realm,
+        catalogAccess,
+        SourceTrack,
+        uuid,
+        'carplay.queue.source-track-selection'
+      )
+    )
+    .filter((track): track is SourceTrack => track !== undefined)
+    .filter((track) => isTrackPlayableInScope(scope, offlineMode, track));
 
   const queueTracks = playableTracks.map((track) => PlayerQueueTrack.fromSourceTrack(track));
   const playIndex = playableTracks.findIndex((track) => track.uuid === selectedTrackUuid);
@@ -56,37 +74,64 @@ export async function queuePlaybackHistoryEntry(
   entry: PlaybackHistoryEntry
 ) {
   const offlineMode = ctx.userSettings.offlineModeWithDefault();
-  let source = entry.source;
-  let artist = entry.artist;
+  const entryUuid = entry.uuid;
+  const sourceUuid = entry.source?.uuid;
+  const artistUuid = entry.artist?.uuid;
+  const showUuid = entry.show?.uuid;
+  const selectedTrackUuid = entry.sourceTrack?.uuid;
+  let source = readRetainedCatalogObject(entry.source, 'carplay.history.initial-source');
+  let artist = readRetainedCatalogObject(entry.artist, 'carplay.history.initial-artist');
+  readRetainedCatalogObject(entry.show, 'carplay.history.initial-show');
+  readRetainedCatalogObject(entry.sourceTrack, 'carplay.history.initial-source-track');
 
-  if (!source || !artist) {
-    carplay_logger.warn('History entry missing source or artist', { id: entry.uuid });
+  if (!sourceUuid || !artistUuid || !showUuid || !selectedTrackUuid || !source || !artist) {
+    carplay_logger.warn('History entry missing source or artist', { id: entryUuid });
     return;
   }
 
   if (!source.sourceSets?.length) {
-    const response = await ctx.apiClient.showWithSources(entry.show.uuid);
+    const response = await ctx.apiClient.showWithSources(showUuid);
 
     if (response?.data?.uuid) {
-      const show = upsertShowWithSources(ctx.realm, response.data);
-      source = ctx.realm.objectForPrimaryKey(Source, entry.source.uuid) || source;
-      artist = show?.artist || artist;
+      upsertShowWithSources(ctx.realm, response.data);
+    }
+
+    source = selectedCatalogObjectForAccess(
+      ctx.realm,
+      'retained',
+      Source,
+      sourceUuid,
+      'carplay.history.source-after-refresh'
+    );
+    artist = selectedCatalogObjectForAccess(
+      ctx.realm,
+      'retained',
+      Artist,
+      artistUuid,
+      'carplay.history.artist-after-refresh'
+    );
+
+    if (!source || !artist) {
+      carplay_logger.warn('History catalog data disappeared during refresh', { id: entryUuid });
+      return;
     }
   }
 
-  const { orderedTracks } = buildTrackSections({
+  const { orderedTrackUuids } = buildTrackSections({
     source,
     artist,
     scope,
     offlineMode,
     currentTrackUuid: ctx.player.queue.currentTrack?.sourceTrack.uuid,
+    catalogAccess: 'retained',
   });
 
   queueTracksFromSelection({
     ctx,
     scope,
-    orderedTracks,
-    selectedTrackUuid: entry.sourceTrack.uuid,
+    orderedTrackUuids,
+    selectedTrackUuid,
     sourceUuid: source.uuid,
+    catalogAccess: 'retained',
   });
 }

--- a/relisten/carplay/show_formatters.ts
+++ b/relisten/carplay/show_formatters.ts
@@ -1,23 +1,34 @@
 import { Show } from '@/relisten/realm/models/show';
 import { Source } from '@/relisten/realm/models/source';
+import { CarPlayScope } from '@/relisten/carplay/scope';
+import { catalogObjectsForScope } from '@/relisten/carplay/catalog_scope';
 
-export function formatShowDetail(show: Show) {
-  const venue = show.venue?.name;
-  const location = show.venue?.location;
+export function formatShowDetail(show: Show, scope: CarPlayScope) {
+  const scopedShow = catalogObjectsForScope(scope, [show], 'carplay.formatter.show')[0];
+  if (!scopedShow) return '';
+
+  const venueObject = scopedShow.venue
+    ? catalogObjectsForScope(scope, [scopedShow.venue], 'carplay.formatter.venue')[0]
+    : undefined;
+  const venue = venueObject?.name;
+  const location = venueObject?.location;
   const locationText = [venue, location].filter(Boolean).join(' • ');
-  const rating = show.avgRating ? `${show.humanizedAvgRating()}★` : undefined;
-  const duration = show.avgDuration ? show.humanizedAvgDuration() : undefined;
+  const rating = scopedShow.avgRating ? `${scopedShow.humanizedAvgRating()}★` : undefined;
+  const duration = scopedShow.avgDuration ? scopedShow.humanizedAvgDuration() : undefined;
   const parts = [locationText, rating, duration].filter(Boolean);
 
   return parts.join(' • ');
 }
 
-export function formatSourceDetail(source: Source) {
-  const rating = source.avgRating ? `${source.humanizedAvgRating()}★` : undefined;
-  const duration = source.duration ? source.humanizedDuration() : undefined;
-  const type = source.isSoundboard ? 'SBD' : undefined;
-  const taper = source.taper;
-  const transferrer = source.transferrer;
+export function formatSourceDetail(source: Source, scope: CarPlayScope) {
+  const scopedSource = catalogObjectsForScope(scope, [source], 'carplay.formatter.source')[0];
+  if (!scopedSource) return '';
+
+  const rating = scopedSource.avgRating ? `${scopedSource.humanizedAvgRating()}★` : undefined;
+  const duration = scopedSource.duration ? scopedSource.humanizedDuration() : undefined;
+  const type = scopedSource.isSoundboard ? 'SBD' : undefined;
+  const taper = scopedSource.taper;
+  const transferrer = scopedSource.transferrer;
   const taperInfo = [taper, transferrer].filter(Boolean).join(' / ');
 
   return [type, rating, duration, taperInfo].filter(Boolean).join(' • ');

--- a/relisten/carplay/show_templates.ts
+++ b/relisten/carplay/show_templates.ts
@@ -7,16 +7,20 @@ import {
 import { Artist } from '@/relisten/realm/models/artist';
 import { Show } from '@/relisten/realm/models/show';
 import { Source } from '@/relisten/realm/models/source';
-import { SourceTrack } from '@/relisten/realm/models/source_track';
 import { carplay_logger } from '@/relisten/carplay/carplay_logger';
 import { CarPlayScope, SCOPE_META } from '@/relisten/carplay/scope';
 import { resolveSourcesForScope } from '@/relisten/carplay/source_selection';
 import { formatSourceDetail } from '@/relisten/carplay/show_formatters';
 import { buildTrackSections } from '@/relisten/carplay/track_sections';
 import { queueTracksFromSelection } from '@/relisten/carplay/queue_helpers';
+import {
+  catalogObjectsForScope,
+  catalogResultsForScope,
+  selectedCatalogObjectForScope,
+} from '@/relisten/carplay/catalog_scope';
 import plur from 'plur';
+import { RealmQueryValueStream } from '@/relisten/realm/value_streams';
 
-type ItemMap<T extends { uuid: string }> = Map<string, T>;
 const ACTION_SHOW_SOURCES = 'action:show:sources';
 
 export function createSourcesListTemplate(
@@ -25,35 +29,82 @@ export function createSourcesListTemplate(
   artist: Artist,
   show: Show
 ): ListTemplate {
-  carplay_logger.info('createSourcesListTemplate', { scope, artist: artist.uuid, show: show.uuid });
-  const behavior = new ShowWithFullSourcesNetworkBackedBehavior(ctx.realm, show.uuid);
+  const artistUuid = artist.uuid;
+  const showUuid = show.uuid;
+  const selectedArtist = selectedCatalogObjectForScope(
+    ctx.realm,
+    scope,
+    Artist,
+    artistUuid,
+    'carplay.sources.initial-artist'
+  );
+  const selectedShow = selectedCatalogObjectForScope(
+    ctx.realm,
+    scope,
+    Show,
+    showUuid,
+    'carplay.sources.initial-show'
+  );
+  const artistName = selectedArtist?.name ?? 'Artist';
+  const showDisplayDate = selectedShow?.displayDate ?? 'Show';
+  let showIsFavorite = selectedShow?.isFavorite ?? false;
+
+  carplay_logger.info('createSourcesListTemplate', { scope, artist: artistUuid, show: showUuid });
+  const behavior = new ShowWithFullSourcesNetworkBackedBehavior(ctx.realm, showUuid);
   const executor = behavior.sharedExecutor(ctx.apiClient);
   const results = executor.start();
+  const retainedSourcesStream =
+    scope === 'browse'
+      ? undefined
+      : new RealmQueryValueStream<Source>(
+          ctx.realm,
+          ctx.realm.objects(Source).filtered('showUuid == $0', showUuid)
+        );
+  const retainedShowStream =
+    scope === 'browse'
+      ? undefined
+      : new RealmQueryValueStream<Show>(
+          ctx.realm,
+          ctx.realm.objects(Show).filtered('uuid == $0', showUuid)
+        );
 
   ctx.addTeardown(() => executor.tearDown());
   ctx.addTeardown(() => results.tearDown());
+  if (retainedSourcesStream) {
+    ctx.addTeardown(() => retainedSourcesStream.tearDown());
+  }
+  if (retainedShowStream) {
+    ctx.addTeardown(() => retainedShowStream.tearDown());
+  }
 
-  const sourceMap: ItemMap<Source> = new Map();
   let currentMode: 'sources' | 'tracks' = 'sources';
-  let orderedTracks: SourceTrack[] = [];
+  let orderedTrackUuids: string[] = [];
   let activeSourceUuid: string | undefined;
-  let displaySources: Source[] = [];
+  let displaySourceUuids: string[] = [];
   const offlineMode = ctx.userSettings.offlineModeWithDefault();
 
   const showSources = () => {
     currentMode = 'sources';
-    orderedTracks = [];
+    orderedTrackUuids = [];
     activeSourceUuid = undefined;
 
-    sourceMap.clear();
-    for (const source of displaySources) {
-      sourceMap.set(source.uuid, source);
-    }
+    const displaySources = displaySourceUuids
+      .map((uuid) =>
+        selectedCatalogObjectForScope(
+          ctx.realm,
+          scope,
+          Source,
+          uuid,
+          'carplay.sources.render-source'
+        )
+      )
+      .filter((source): source is Source => source !== undefined);
+    displaySourceUuids = displaySources.map((source) => source.uuid);
 
     const items = displaySources.map((source) => ({
       id: source.uuid,
       text: source.source || 'Source',
-      detailText: formatSourceDetail(source),
+      detailText: formatSourceDetail(source, scope),
       showsDisclosureIndicator: true,
     }));
 
@@ -66,19 +117,34 @@ export function createSourcesListTemplate(
   };
 
   const showTracks = (source: Source) => {
-    const { orderedTracks: nextTracks, sections } = buildTrackSections({
+    const trackArtist = selectedCatalogObjectForScope(
+      ctx.realm,
+      scope,
+      Artist,
+      artistUuid,
+      'carplay.sources.track-artist'
+    );
+    if (!trackArtist) {
+      carplay_logger.warn('Source artist is no longer available', {
+        artist: artistUuid,
+        show: showUuid,
+      });
+      return;
+    }
+
+    const { orderedTrackUuids: nextTrackUuids, sections } = buildTrackSections({
       source,
-      artist,
+      artist: trackArtist,
       scope,
       offlineMode,
       currentTrackUuid: ctx.player.queue.currentTrack?.sourceTrack.uuid,
     });
 
     currentMode = 'tracks';
-    orderedTracks = nextTracks;
+    orderedTrackUuids = nextTrackUuids;
     activeSourceUuid = source.uuid;
 
-    if (displaySources.length > 1) {
+    if (displaySourceUuids.length > 1) {
       sections.unshift({
         header: 'Source',
         items: [
@@ -96,7 +162,7 @@ export function createSourcesListTemplate(
   };
 
   const template = new ListTemplate({
-    title: `${artist.name} • ${show.displayDate}`,
+    title: `${artistName} • ${showDisplayDate}`,
     tabTitle: SCOPE_META[scope].tabTitle,
     tabSystemImageName: 'music.pages.fill',
     async onItemSelect({ id }: { templateId: string; index: number; id: string }) {
@@ -109,16 +175,31 @@ export function createSourcesListTemplate(
         queueTracksFromSelection({
           ctx,
           scope,
-          orderedTracks,
+          orderedTrackUuids,
           selectedTrackUuid: String(id),
           sourceUuid: activeSourceUuid,
         });
         return;
       }
 
-      carplay_logger.info('source selected', { id, artist: artist.uuid, show: show.uuid });
-      const source = sourceMap.get(String(id));
+      carplay_logger.info('source selected', { id, artist: artistUuid, show: showUuid });
+      const sourceUuid = String(id);
+      if (!displaySourceUuids.includes(sourceUuid)) return;
+
+      const source = selectedCatalogObjectForScope(
+        ctx.realm,
+        scope,
+        Source,
+        sourceUuid,
+        'carplay.sources.source-selection'
+      );
       if (!source) return;
+      if (
+        !resolveSourcesForScope(scope, { isFavorite: showIsFavorite }, [source], ctx.libraryIndex)
+          .displaySources.length
+      ) {
+        return;
+      }
 
       showTracks(source);
     },
@@ -126,29 +207,37 @@ export function createSourcesListTemplate(
     emptyViewTitleVariants: ['Loading sources...'],
   });
 
-  results.addListener((nextValue) => {
-    const data = nextValue.data;
-    const sources = data?.sources ? sortSources(data.sources, ctx.libraryIndex) : [];
+  const updateSources = (sources: Source[]) => {
     const { displaySources: nextDisplaySources, autoSelectSource } = resolveSourcesForScope(
       scope,
-      show,
+      { isFavorite: showIsFavorite },
       sources,
       ctx.libraryIndex
     );
-    displaySources = nextDisplaySources;
+    const retainedOrActiveSources = catalogObjectsForScope(
+      scope,
+      nextDisplaySources,
+      'carplay.sources.display-source'
+    );
+    displaySourceUuids = retainedOrActiveSources.map((source) => source.uuid);
 
-    if (displaySources.length === 0) {
+    if (displaySourceUuids.length === 0) {
       showSources();
       return;
     }
 
     if (autoSelectSource) {
-      showTracks(autoSelectSource);
+      const selectedSource = retainedOrActiveSources.find(
+        (source) => source.uuid === autoSelectSource.uuid
+      );
+      if (selectedSource) showTracks(selectedSource);
       return;
     }
 
     if (currentMode === 'tracks' && activeSourceUuid) {
-      const activeSource = displaySources.find((source) => source.uuid === activeSourceUuid);
+      const activeSource = retainedOrActiveSources.find(
+        (source) => source.uuid === activeSourceUuid
+      );
       if (activeSource) {
         showTracks(activeSource);
         return;
@@ -156,6 +245,42 @@ export function createSourcesListTemplate(
     }
 
     showSources();
+  };
+
+  results.addListener((nextValue) => {
+    const data = nextValue.data;
+    const currentShow = data?.show
+      ? catalogObjectsForScope(scope, [data.show], 'carplay.sources.result-show')[0]
+      : undefined;
+    if (currentShow) {
+      showIsFavorite = currentShow.isFavorite;
+    }
+
+    if (scope === 'browse') {
+      const scopedSourceResults = data?.sources
+        ? catalogResultsForScope(scope, data.sources)
+        : undefined;
+      updateSources(scopedSourceResults ? sortSources(scopedSourceResults, ctx.libraryIndex) : []);
+      return;
+    }
+
+    updateSources(
+      retainedSourcesStream ? sortSources(retainedSourcesStream.currentValue, ctx.libraryIndex) : []
+    );
+  });
+
+  retainedSourcesStream?.addListener((sources) => {
+    updateSources(sortSources(sources, ctx.libraryIndex));
+  });
+
+  retainedShowStream?.addListener((shows) => {
+    const currentShow = catalogObjectsForScope(scope, shows, 'carplay.sources.retained-show')[0];
+    if (currentShow) {
+      showIsFavorite = currentShow.isFavorite;
+    }
+    updateSources(
+      retainedSourcesStream ? sortSources(retainedSourcesStream.currentValue, ctx.libraryIndex) : []
+    );
   });
 
   return template;

--- a/relisten/carplay/source_selection.ts
+++ b/relisten/carplay/source_selection.ts
@@ -5,7 +5,7 @@ import { LibraryIndex } from '@/relisten/realm/library_index';
 
 export function resolveSourcesForScope(
   scope: CarPlayScope,
-  show: Show,
+  show: Pick<Show, 'isFavorite'>,
   sources: Source[],
   libraryIndex: Pick<LibraryIndex, 'sourceHasOfflineTracks'>
 ) {

--- a/relisten/carplay/today.ts
+++ b/relisten/carplay/today.ts
@@ -10,62 +10,109 @@ import { createSourcesListTemplate } from '@/relisten/carplay/show_templates';
 import { CarPlayScope, SCOPE_META } from '@/relisten/carplay/scope';
 import { formatShowDetail } from '@/relisten/carplay/show_formatters';
 import plur from 'plur';
-
-type ItemMap<T extends { uuid: string }> = Map<string, T>;
+import {
+  catalogResultsForScope,
+  selectedCatalogObjectForScope,
+} from '@/relisten/carplay/catalog_scope';
+import { readRetainedCatalogObject } from '@/relisten/realm/catalog_retirement';
+import { RealmQueryValueStream } from '@/relisten/realm/value_streams';
 
 export function createTodayShowsTemplate(
   ctx: RelistenCarPlayContext,
   scope: CarPlayScope,
-  artists: Artist[],
+  artistUuids: string[],
   title: string
 ): ListTemplate {
-  carplay_logger.info('createTodayShowsTemplate', { scope, artistCount: artists.length });
-  const artistUuids = artists.map((artist) => artist.uuid);
+  carplay_logger.info('createTodayShowsTemplate', { scope, artistCount: artistUuids.length });
   const behavior = new TodayShowsNetworkBackedBehavior(ctx.realm, artistUuids, {
     fetchStrategy: NetworkBackedBehaviorFetchStrategy.NetworkAlwaysFirst,
   });
   const executor = behavior.sharedExecutor(ctx.apiClient);
   const results = executor.start();
+  const retainedShowsStream =
+    scope === 'browse'
+      ? undefined
+      : new RealmQueryValueStream<Show>(
+          ctx.realm,
+          ctx.realm
+            .objects(Show)
+            .filtered('displayDate ENDSWITH $0', todayDisplayDateSuffix())
+            .filtered('artistUuid IN $0', artistUuids)
+        );
 
   ctx.addTeardown(() => executor.tearDown());
   ctx.addTeardown(() => results.tearDown());
+  if (retainedShowsStream) {
+    ctx.addTeardown(() => retainedShowsStream.tearDown());
+  }
 
-  const showMap: ItemMap<Show> = new Map();
+  const showUuids = new Set<string>();
 
   const template = new ListTemplate({
     title,
     tabTitle: SCOPE_META[scope].tabTitle,
     tabSystemImageName: 'music.pages.fill',
     async onItemSelect({ id }: { templateId: string; index: number; id: string }) {
-      const show = showMap.get(String(id));
-      if (!show || !show.artist) {
+      const showUuid = String(id);
+      if (!showUuids.has(showUuid)) return;
+
+      const show = selectedCatalogObjectForScope(
+        ctx.realm,
+        scope,
+        Show,
+        showUuid,
+        'carplay.today.show-selection'
+      );
+      const artist = show
+        ? selectedCatalogObjectForScope(
+            ctx.realm,
+            scope,
+            Artist,
+            show.artistUuid,
+            'carplay.today.show-selection-artist'
+          )
+        : undefined;
+      if (!show || !artist || !includeTodayShowForScope(ctx, scope, show)) {
         carplay_logger.warn('Today show selection missing data', { id });
         return;
       }
 
-      const sourcesTemplate = createSourcesListTemplate(ctx, scope, show.artist, show);
+      const sourcesTemplate = createSourcesListTemplate(ctx, scope, artist, show);
       CarPlay.pushTemplate(sourcesTemplate, true);
     },
     sections: [],
     emptyViewTitleVariants: ['Loading shows...'],
   });
 
-  results.addListener((nextValue) => {
-    const shows = Array.from(nextValue.data || []);
+  const updateShows = (nextShows: Show[]) => {
+    const shows = nextShows.filter((show) => includeTodayShowForScope(ctx, scope, show));
 
     shows.sort((a, b) => b.date.getTime() - a.date.getTime());
 
-    showMap.clear();
+    showUuids.clear();
     for (const show of shows) {
-      showMap.set(show.uuid, show);
+      showUuids.add(show.uuid);
     }
 
-    const items = shows.map((show) => ({
-      id: show.uuid,
-      text: show.displayDate,
-      detailText: formatTodayShowDetail(show, artists.length > 1) || undefined,
-      showsDisclosureIndicator: true,
-    }));
+    const items = shows.map((show) => {
+      const artist =
+        artistUuids.length > 1
+          ? selectedCatalogObjectForScope(
+              ctx.realm,
+              scope,
+              Artist,
+              show.artistUuid,
+              'carplay.today.detail-artist'
+            )
+          : undefined;
+
+      return {
+        id: show.uuid,
+        text: show.displayDate,
+        detailText: formatTodayShowDetail(show, artist?.name, scope) || undefined,
+        showsDisclosureIndicator: true,
+      };
+    });
 
     const sections: ListSection[] = [];
 
@@ -82,14 +129,48 @@ export function createTodayShowsTemplate(
     }
 
     template.updateSections(sections);
+  };
+
+  results.addListener((nextValue) => {
+    const scopedResults = nextValue.data
+      ? catalogResultsForScope(scope, nextValue.data)
+      : undefined;
+    const shows =
+      scope === 'browse'
+        ? Array.from(scopedResults || [])
+        : Array.from(retainedShowsStream?.currentValue || []);
+    updateShows(shows);
   });
+
+  retainedShowsStream?.addListener((shows) => updateShows(Array.from(shows)));
 
   return template;
 }
 
-function formatTodayShowDetail(show: Show, includeArtist: boolean) {
-  const artistName = includeArtist ? show.artist?.name : undefined;
-  const detail = formatShowDetail(show);
+function includeTodayShowForScope(ctx: RelistenCarPlayContext, scope: CarPlayScope, show: Show) {
+  const included =
+    scope === 'offline'
+      ? ctx.libraryIndex.showHasOfflineTracks(show.uuid)
+      : scope === 'library'
+        ? ctx.libraryIndex.showIsInLibrary(show.uuid)
+        : true;
+
+  if (included && scope !== 'browse') {
+    readRetainedCatalogObject(show, 'carplay.today.scoped-show');
+  }
+
+  return included;
+}
+
+function formatTodayShowDetail(show: Show, artistName: string | undefined, scope: CarPlayScope) {
+  const detail = formatShowDetail(show, scope);
 
   return [artistName, detail].filter(Boolean).join(' • ');
+}
+
+function todayDisplayDateSuffix() {
+  const now = new Date();
+  const month = (now.getMonth() + 1).toFixed(0).padStart(2, '0');
+  const day = now.getDate().toFixed(0).padStart(2, '0');
+  return `-${month}-${day}`;
 }

--- a/relisten/carplay/track_sections.ts
+++ b/relisten/carplay/track_sections.ts
@@ -6,9 +6,14 @@ import { SourceSet } from '@/relisten/realm/models/source_set';
 import { SourceTrack } from '@/relisten/realm/models/source_track';
 import { OfflineModeSetting } from '@/relisten/realm/models/user_settings';
 import { CarPlayScope } from '@/relisten/carplay/scope';
+import {
+  CarPlayCatalogAccess,
+  catalogAccessForScope,
+  catalogObjectsForAccess,
+} from '@/relisten/carplay/catalog_scope';
 
 type TrackSectionsResult = {
-  orderedTracks: SourceTrack[];
+  orderedTrackUuids: string[];
   sections: ListSection[];
 };
 
@@ -18,15 +23,22 @@ export function buildTrackSections({
   scope,
   offlineMode,
   currentTrackUuid,
+  catalogAccess = catalogAccessForScope(scope),
 }: {
   source: Source;
   artist: Artist;
   scope: CarPlayScope;
   offlineMode: OfflineModeSetting;
   currentTrackUuid?: string;
+  catalogAccess?: CarPlayCatalogAccess;
 }): TrackSectionsResult {
-  const sortedSets = Array.from(source.sourceSets || []).sort((a, b) => a.index - b.index);
+  const sortedSets = catalogObjectsForAccess(
+    source.sourceSets || [],
+    catalogAccess,
+    'carplay.track-sections.source-set'
+  ).sort((a, b) => a.index - b.index);
   const orderedTracks: SourceTrack[] = [];
+  const orderedTrackUuids: string[] = [];
 
   if (artist.features().sets) {
     const sections: ListSection[] = [];
@@ -34,8 +46,9 @@ export function buildTrackSections({
 
     for (let index = 0; index < sortedSets.length; index++) {
       const set = sortedSets[index];
-      const setTracks = sortedTracksForSet(set);
+      const setTracks = sortedTracksForSet(set, catalogAccess);
       orderedTracks.push(...setTracks);
+      orderedTrackUuids.push(...setTracks.map((track) => track.uuid));
 
       const items = setTracks
         .filter((track) => includeTrackForScope(scope, offlineMode, track))
@@ -58,7 +71,7 @@ export function buildTrackSections({
     }
 
     return {
-      orderedTracks,
+      orderedTrackUuids,
       sections:
         sections.length > 0
           ? sections
@@ -72,7 +85,9 @@ export function buildTrackSections({
   }
 
   for (const set of sortedSets) {
-    orderedTracks.push(...sortedTracksForSet(set));
+    const setTracks = sortedTracksForSet(set, catalogAccess);
+    orderedTracks.push(...setTracks);
+    orderedTrackUuids.push(...setTracks.map((track) => track.uuid));
   }
 
   const items = orderedTracks
@@ -86,7 +101,7 @@ export function buildTrackSections({
     }));
 
   return {
-    orderedTracks,
+    orderedTrackUuids,
     sections: [
       {
         header: `${items.length} ${plur('track', items.length)}`,
@@ -120,10 +135,12 @@ export function isTrackPlayableInScope(
   return includeTrackForScope(scope, offlineMode, track) && !!track.streamingUrl();
 }
 
-function sortedTracksForSet(set: SourceSet) {
-  return Array.from<SourceTrack>(set.sourceTracks || []).sort(
-    (a, b) => a.trackPosition - b.trackPosition
-  );
+function sortedTracksForSet(set: SourceSet, catalogAccess: CarPlayCatalogAccess) {
+  return catalogObjectsForAccess(
+    set.sourceTracks || [],
+    catalogAccess,
+    'carplay.track-sections.source-track'
+  ).sort((a, b) => a.trackPosition - b.trackPosition);
 }
 
 function formatSetHeader(set: SourceSet, index: number, totalSets: number) {

--- a/relisten/components/source/source_sets_component.tsx
+++ b/relisten/components/source/source_sets_component.tsx
@@ -1,5 +1,4 @@
 import { View } from 'react-native';
-import Realm from 'realm';
 import { ItemSeparator } from '@/relisten/components/item_separator';
 import { Source } from '@/relisten/realm/models/source';
 import {
@@ -13,27 +12,98 @@ import { SourceTrackComponent } from '@/relisten/components/source/source_track_
 import { useUserSettings } from '@/relisten/realm/models/user_settings_repo';
 import { OfflineModeSetting } from '@/relisten/realm/models/user_settings';
 import { useIsOfflineTab } from '@/relisten/util/routes';
+import {
+  ACTIVE_CATALOG_QUERY,
+  readRetainedCatalogObject,
+} from '@/relisten/realm/catalog_retirement';
 
-function sortSetsByIndex(sets: Realm.List<SourceSet> | SourceSet[]): SourceSet[] {
+export type SourceMembershipPolicy =
+  | { mode: 'active' }
+  | {
+      mode: 'retained';
+      accessSite: string;
+    };
+
+function sortSetsByIndex(sets: Iterable<SourceSet>): SourceSet[] {
   return Array.from(sets).sort((a, b) => a.index - b.index);
 }
 
-function sortTracksByPosition(tracks: Realm.List<SourceTrack> | SourceTrack[]): SourceTrack[] {
+function sortTracksByPosition(tracks: Iterable<SourceTrack>): SourceTrack[] {
   return Array.from(tracks).sort((a, b) => a.trackPosition - b.trackPosition);
+}
+
+export function sourceSetsForSource(
+  source: Source,
+  membershipPolicy: SourceMembershipPolicy
+): SourceSet[] {
+  const sourceSets =
+    membershipPolicy.mode === 'active'
+      ? source.sourceSets.filtered(ACTIVE_CATALOG_QUERY)
+      : source.sourceSets;
+
+  return sortSetsByIndex(sourceSets).flatMap((sourceSet) => {
+    if (membershipPolicy.mode === 'active') {
+      return [sourceSet];
+    }
+
+    const retainedSourceSet = readRetainedCatalogObject(
+      sourceSet,
+      `${membershipPolicy.accessSite}.source-set`
+    );
+    return retainedSourceSet ? [retainedSourceSet] : [];
+  });
+}
+
+function sourceTracksForSet(
+  sourceSet: SourceSet,
+  membershipPolicy: SourceMembershipPolicy
+): SourceTrack[] {
+  const sourceTracks =
+    membershipPolicy.mode === 'active'
+      ? sourceSet.sourceTracks.filtered(ACTIVE_CATALOG_QUERY)
+      : sourceSet.sourceTracks;
+
+  return sortTracksByPosition(sourceTracks).flatMap((sourceTrack) => {
+    if (membershipPolicy.mode === 'active') {
+      return [sourceTrack];
+    }
+
+    const retainedSourceTrack = readRetainedCatalogObject(
+      sourceTrack,
+      `${membershipPolicy.accessSite}.source-track`
+    );
+    return retainedSourceTrack ? [retainedSourceTrack] : [];
+  });
+}
+
+export function sourceTracksForSource(
+  source: Source,
+  membershipPolicy: SourceMembershipPolicy
+): SourceTrack[] {
+  return sourceSetsForSource(source, membershipPolicy).flatMap((sourceSet) =>
+    sourceTracksForSet(sourceSet, membershipPolicy)
+  );
 }
 
 interface SourceSetsProps {
   source: Source;
   playShow: PlayShow;
+  membershipPolicy: SourceMembershipPolicy;
 }
 
-export const SourceSets = ({ source, playShow }: SourceSetsProps) => {
-  const sortedSets = sortSetsByIndex(source.sourceSets);
+export const SourceSets = ({ source, playShow, membershipPolicy }: SourceSetsProps) => {
+  const sourceSets = sourceSetsForSource(source, membershipPolicy);
 
   return (
     <View>
-      {sortedSets.map((s) => (
-        <SourceSetComponent key={s.uuid} sourceSet={s} source={source} playShow={playShow} />
+      {sourceSets.map((sourceSet) => (
+        <SourceSetComponent
+          key={sourceSet.uuid}
+          sourceSet={sourceSet}
+          playShow={playShow}
+          showHeader={sourceSets.length > 1}
+          membershipPolicy={membershipPolicy}
+        />
       ))}
       <View className="px-4">
         <ItemSeparator />
@@ -43,28 +113,35 @@ export const SourceSets = ({ source, playShow }: SourceSetsProps) => {
 };
 
 interface SourceSetProps {
-  source: Source;
   sourceSet: SourceSet;
   playShow: PlayShow;
+  showHeader: boolean;
+  membershipPolicy: SourceMembershipPolicy;
 }
 
-export const SourceSetComponent = ({ source, sourceSet, playShow }: SourceSetProps) => {
+export const SourceSetComponent = ({
+  sourceSet,
+  playShow,
+  showHeader,
+  membershipPolicy,
+}: SourceSetProps) => {
   const userSettings = useUserSettings();
   const isOfflineTab = useIsOfflineTab();
   const queueOfflineOnly =
     isOfflineTab || userSettings.offlineModeWithDefault() === OfflineModeSetting.AlwaysOffline;
+  const sourceTracks = sourceTracksForSet(sourceSet, membershipPolicy);
 
   return (
     <View>
-      {source.sourceSets.length > 1 && <SectionHeader title={sourceSet.name} />}
-      {sortTracksByPosition(sourceSet.sourceTracks).map((t, idx) => {
+      {showHeader && <SectionHeader title={sourceSet.name} />}
+      {sourceTracks.map((t, idx) => {
         const playable = queueOfflineOnly ? t.playable(false) : true;
 
         return (
           <SourceTrackComponent
             key={t.uuid}
             sourceTrack={t}
-            isLastTrackInSet={idx == sourceSet.sourceTracks.length - 1}
+            isLastTrackInSet={idx == sourceTracks.length - 1}
             onPress={playable ? playShow : undefined}
             actions={
               playable ? <SourceTrackActionsMenu sourceTrack={t} playShow={playShow} /> : null

--- a/relisten/components/source/source_track_with_artist.tsx
+++ b/relisten/components/source/source_track_with_artist.tsx
@@ -5,6 +5,7 @@ import RowTitle from '@/relisten/components/row_title';
 import { SectionedListItem } from '@/relisten/components/sectioned_list_item';
 import { SourceTrackSucceededIndicator } from '@/relisten/components/source/source_track_offline_indicator';
 import { SourceTrack } from '@/relisten/realm/models/source_track';
+import { readRetainedCatalogObject } from '@/relisten/realm/catalog_retirement';
 import { ShowLink } from '@/relisten/util/push_show';
 import React, { PropsWithChildren } from 'react';
 import { View } from 'react-native';
@@ -15,22 +16,42 @@ export function TrackWithArtist({
   offlineIndicator,
   indicatorComponent,
   subtitleColumn,
+  retainedAccessSite = 'history.track-row',
 }: PropsWithChildren<{
   offlineIndicator?: boolean;
   sourceTrack: SourceTrack;
   indicatorComponent?: React.ReactNode;
   subtitleColumn?: boolean;
+  retainedAccessSite?: string;
 }>) {
   if (offlineIndicator === undefined) {
     offlineIndicator = true;
   }
 
+  const retainedSourceTrack = readRetainedCatalogObject(
+    sourceTrack,
+    `${retainedAccessSite}.source-track`
+  );
+  const artist = readRetainedCatalogObject(
+    retainedSourceTrack?.artist,
+    `${retainedAccessSite}.artist`
+  );
+  const show = readRetainedCatalogObject(retainedSourceTrack?.show, `${retainedAccessSite}.show`);
+  const source = readRetainedCatalogObject(
+    retainedSourceTrack?.source,
+    `${retainedAccessSite}.source`
+  );
+
+  if (!retainedSourceTrack || !artist || !show || !source) {
+    return null;
+  }
+
   return (
     <ShowLink
       show={{
-        artist: sourceTrack.artist,
-        showUuid: sourceTrack.show.uuid,
-        sourceUuid: sourceTrack.source.uuid,
+        artist,
+        showUuid: show.uuid,
+        sourceUuid: source.uuid,
       }}
       asChild
     >
@@ -38,27 +59,27 @@ export function TrackWithArtist({
         <Flex className="flex items-center justify-between" full>
           <Flex className="flex-1 pr-2" column>
             <Flex className="items-center" style={{ gap: 8 }}>
-              <RowTitle>{sourceTrack.title}</RowTitle>
-              {sourceTrack.source.isSoundboard && (
+              <RowTitle>{retainedSourceTrack.title}</RowTitle>
+              {source.isSoundboard && (
                 <RelistenText className="text-xs font-bold text-relisten-blue-600">
                   SBD
                 </RelistenText>
               )}
-              {offlineIndicator && sourceTrack.offlineInfo?.isPlayableOffline() && (
+              {offlineIndicator && retainedSourceTrack.offlineInfo?.isPlayableOffline() && (
                 <SourceTrackSucceededIndicator />
               )}
               <View className="grow" />
             </Flex>
             <SubtitleRow {...{ column: !!subtitleColumn }}>
               <SubtitleText>
-                {sourceTrack.artist.name}
+                {artist.name}
                 &nbsp;&middot;&nbsp;
-                {sourceTrack.show.displayDate}
+                {show.displayDate}
               </SubtitleText>
               {children}
             </SubtitleRow>
           </Flex>
-          <SubtitleText>{sourceTrack.humanizedDuration}</SubtitleText>
+          <SubtitleText>{retainedSourceTrack.humanizedDuration}</SubtitleText>
 
           {indicatorComponent}
         </Flex>

--- a/relisten/lastfm/lastfm_scrobble_queue.ts
+++ b/relisten/lastfm/lastfm_scrobble_queue.ts
@@ -1,5 +1,8 @@
 import Realm from 'realm';
-import { LastFmScrobbleEntry } from '@/relisten/realm/models/lastfm_scrobble_entry';
+import {
+  ACTIVE_LASTFM_SCROBBLE_ENTRY_QUERY,
+  LastFmScrobbleEntry,
+} from '@/relisten/realm/models/lastfm_scrobble_entry';
 import { log } from '@/relisten/util/logging';
 
 const logger = log.extend('lastfm-queue');
@@ -30,10 +33,13 @@ export class LastFmScrobbleQueue {
 
   loadPersisted() {
     if (this.loaded) {
+      this.reconcileEntriesWithRealm();
       return;
     }
 
-    const persisted = this.realm.objects(LastFmScrobbleEntry);
+    const persisted = this.realm
+      .objects(LastFmScrobbleEntry)
+      .filtered(ACTIVE_LASTFM_SCROBBLE_ENTRY_QUERY);
     const now = Date.now();
     const staleEntries: LastFmScrobbleEntry[] = [];
 
@@ -58,7 +64,10 @@ export class LastFmScrobbleQueue {
 
     if (staleEntries.length > 0) {
       this.realm.write(() => {
-        this.realm.delete(staleEntries);
+        const deletedAt = new Date();
+        for (const entry of staleEntries) {
+          entry.deletedAt = deletedAt;
+        }
       });
     }
 
@@ -83,13 +92,15 @@ export class LastFmScrobbleQueue {
     };
 
     this.entries.set(id, entry);
-    this.persist(entry);
+    this.persist(entry, true);
     this.prune();
 
     return entry;
   }
 
   markAttempt(id: string, success: boolean) {
+    this.loadPersisted();
+
     const entry = this.entries.get(id);
 
     if (!entry) {
@@ -104,7 +115,7 @@ export class LastFmScrobbleQueue {
 
     entry.failureCount += 1;
     entry.lastAttemptAt = new Date();
-    this.persist(entry);
+    this.persist(entry, false);
   }
 
   list(): LastFmScrobbleQueueEntry[] {
@@ -116,14 +127,27 @@ export class LastFmScrobbleQueue {
   clearAll() {
     this.entries.clear();
     this.realm.write(() => {
-      const allEntries = this.realm.objects(LastFmScrobbleEntry);
-      this.realm.delete(allEntries);
+      const allEntries = this.realm
+        .objects(LastFmScrobbleEntry)
+        .filtered(ACTIVE_LASTFM_SCROBBLE_ENTRY_QUERY)
+        .snapshot();
+      const deletedAt = new Date();
+
+      for (const entry of allEntries) {
+        entry.deletedAt = deletedAt;
+      }
     });
   }
 
-  private persist(entry: LastFmScrobbleQueueEntry) {
+  private persist(entry: LastFmScrobbleQueueEntry, allowResurrection: boolean) {
     this.realm.write(() => {
-      this.realm.create(
+      const existing = this.realm.objectForPrimaryKey(LastFmScrobbleEntry, entry.id);
+      if (!allowResurrection && (!existing || existing.deletedAt)) {
+        this.entries.delete(entry.id);
+        return;
+      }
+
+      const persisted = this.realm.create(
         LastFmScrobbleEntry,
         {
           id: entry.id,
@@ -135,17 +159,37 @@ export class LastFmScrobbleQueue {
           timestamp: entry.timestamp,
           failureCount: entry.failureCount,
           lastAttemptAt: entry.lastAttemptAt,
+          deletedAt: undefined,
         },
         Realm.UpdateMode.Modified
       );
+
+      // A scrobble can be re-enqueued with the same deterministic id before
+      // cold-start cleanup has physically collected its tombstone.
+      persisted.deletedAt = undefined;
     });
+  }
+
+  private reconcileEntriesWithRealm() {
+    const activeIds = new Set(
+      this.realm
+        .objects(LastFmScrobbleEntry)
+        .filtered(ACTIVE_LASTFM_SCROBBLE_ENTRY_QUERY)
+        .map((entry) => entry.id)
+    );
+
+    for (const id of this.entries.keys()) {
+      if (!activeIds.has(id)) {
+        this.entries.delete(id);
+      }
+    }
   }
 
   private deletePersisted(id: string) {
     this.realm.write(() => {
       const existing = this.realm.objectForPrimaryKey(LastFmScrobbleEntry, id);
-      if (existing) {
-        this.realm.delete(existing);
+      if (existing && !existing.deletedAt) {
+        existing.deletedAt = new Date();
       }
     });
   }

--- a/relisten/offline/download_manager.ts
+++ b/relisten/offline/download_manager.ts
@@ -4,6 +4,7 @@ import {
   SourceTrack,
 } from '@/relisten/realm/models/source_track';
 import {
+  ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY,
   SourceTrackOfflineInfo,
   SourceTrackOfflineInfoStatus,
   SourceTrackOfflineInfoType,
@@ -33,6 +34,7 @@ const logger = log.extend('offline');
 
 interface DownloadTask {
   id: string;
+  generation: number;
   promise: StatefulPromise<FetchBlobResponse>;
 }
 
@@ -60,31 +62,52 @@ export class DownloadManager {
       return;
     }
 
-    if (sourceTrack.offlineInfo) {
-      if (sourceTrack.offlineInfo.type === SourceTrackOfflineInfoType.StreamingCache) {
+    if (!sourceTrack.isValid()) {
+      logger.warn('downloadTrack: Ignoring an invalid source track.');
+      return;
+    }
+
+    let offlineInfo = this.activeOfflineInfo(sourceTrack);
+
+    if (offlineInfo) {
+      if (offlineInfo.type === SourceTrackOfflineInfoType.StreamingCache) {
         // Upgrade streaming cache to user download
         realm.write(() => {
-          sourceTrack.offlineInfo!.type = SourceTrackOfflineInfoType.UserInitiated;
+          offlineInfo!.type = SourceTrackOfflineInfoType.UserInitiated;
         });
 
         return;
-      } else if (sourceTrack.offlineInfo.status !== SourceTrackOfflineInfoStatus.Failed) {
-        logger.warn(
-          `Source track already has offline info; skipping... ${sourceTrack.offlineInfo.status}`
-        );
+      } else if (offlineInfo.status !== SourceTrackOfflineInfoStatus.Failed) {
+        logger.warn(`Source track already has offline info; skipping... ${offlineInfo.status}`);
       }
     }
 
-    let offlineInfo: SourceTrackOfflineInfo | undefined = sourceTrack.offlineInfo;
-
     if (!offlineInfo) {
       realm.write(() => {
-        offlineInfo = new SourceTrackOfflineInfo(realm!, {
-          sourceTrackUuid: sourceTrack.uuid,
-          queuedAt: new Date(),
-          status: SourceTrackOfflineInfoStatus.Queued,
-          type: SourceTrackOfflineInfoType.UserInitiated,
-        });
+        const existing = realm!.objectForPrimaryKey(SourceTrackOfflineInfo, sourceTrack.uuid);
+        const queuedAt = new Date();
+
+        if (existing) {
+          existing.deletedAt = undefined;
+          existing.queuedAt = queuedAt;
+          existing.status = SourceTrackOfflineInfoStatus.Queued;
+          existing.type = SourceTrackOfflineInfoType.UserInitiated;
+          existing.startedAt = undefined;
+          existing.completedAt = undefined;
+          existing.downloadedBytes = 0;
+          existing.totalBytes = 0;
+          existing.percent = 0;
+          existing.errorInfo = undefined;
+          offlineInfo = existing;
+        } else {
+          offlineInfo = new SourceTrackOfflineInfo(realm!, {
+            sourceTrackUuid: sourceTrack.uuid,
+            queuedAt,
+            status: SourceTrackOfflineInfoStatus.Queued,
+            type: SourceTrackOfflineInfoType.UserInitiated,
+            deletedAt: undefined,
+          });
+        }
 
         sourceTrack.offlineInfo = offlineInfo;
       });
@@ -105,27 +128,54 @@ export class DownloadManager {
       return;
     }
 
-    let offlineInfo: SourceTrackOfflineInfo | undefined = sourceTrack.offlineInfo;
+    if (!sourceTrack.isValid()) {
+      logger.warn('markCachedFileAsAvailableOffline: Ignoring an invalid source track.');
+      return;
+    }
+
+    let offlineInfo = this.activeOfflineInfo(sourceTrack);
+    const activeDownloadTask = this.downloadTaskById(sourceTrack.uuid);
+    if (activeDownloadTask) {
+      activeDownloadTask.promise.cancel();
+    }
 
     realm.write(() => {
       const d = new Date();
 
       if (!offlineInfo) {
-        offlineInfo = new SourceTrackOfflineInfo(realm!, {
-          sourceTrackUuid: sourceTrack.uuid,
-          type: SourceTrackOfflineInfoType.StreamingCache,
-          queuedAt: d,
-          status: SourceTrackOfflineInfoStatus.Succeeded,
-          totalBytes,
-          downloadedBytes: totalBytes,
-          percent: 1,
-          completedAt: d,
-        });
+        const existing = realm!.objectForPrimaryKey(SourceTrackOfflineInfo, sourceTrack.uuid);
+
+        if (existing) {
+          existing.deletedAt = undefined;
+          existing.type = SourceTrackOfflineInfoType.StreamingCache;
+          existing.queuedAt = d;
+          existing.status = SourceTrackOfflineInfoStatus.Succeeded;
+          existing.totalBytes = totalBytes;
+          existing.downloadedBytes = totalBytes;
+          existing.percent = 1;
+          existing.startedAt = undefined;
+          existing.completedAt = d;
+          existing.errorInfo = undefined;
+          offlineInfo = existing;
+        } else {
+          offlineInfo = new SourceTrackOfflineInfo(realm!, {
+            sourceTrackUuid: sourceTrack.uuid,
+            type: SourceTrackOfflineInfoType.StreamingCache,
+            queuedAt: d,
+            status: SourceTrackOfflineInfoStatus.Succeeded,
+            totalBytes,
+            downloadedBytes: totalBytes,
+            percent: 1,
+            completedAt: d,
+            deletedAt: undefined,
+          });
+        }
 
         sourceTrack.offlineInfo = offlineInfo;
       } else if (offlineInfo.status !== SourceTrackOfflineInfoStatus.Succeeded) {
         // if it had been previously queued but streaming cache completed it mark it as completed
         offlineInfo.status = SourceTrackOfflineInfoStatus.Succeeded;
+        offlineInfo.startedAt = undefined;
         offlineInfo.totalBytes = totalBytes;
         offlineInfo.downloadedBytes = totalBytes;
         offlineInfo.percent = 1;
@@ -166,6 +216,16 @@ export class DownloadManager {
     return false;
   }
 
+  private activeOfflineInfo(sourceTrack: SourceTrack) {
+    const offlineInfo = sourceTrack.offlineInfo;
+
+    if (!offlineInfo?.isValid() || offlineInfo.deletedAt) {
+      return undefined;
+    }
+
+    return offlineInfo;
+  }
+
   private availableDownloadSlots() {
     return (
       DownloadManager.MAX_CONCURRENT_DOWNLOADS -
@@ -188,17 +248,29 @@ export class DownloadManager {
 
     const queuedDownloads = realm
       .objects(SourceTrackOfflineInfo)
-      .filtered('status == $0', SourceTrackOfflineInfoStatus.Queued)
+      .filtered(
+        `${ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY} AND status == $0`,
+        SourceTrackOfflineInfoStatus.Queued
+      )
       .sorted('queuedAt')
       .slice(0, this.availableDownloadSlots());
 
     for (const queuedDownload of queuedDownloads) {
-      if (this.isPendingOrDownloading(queuedDownload.sourceTrack)) {
-        logger.debug(`${queuedDownload.sourceTrack.uuid} is already pending or downloading`);
+      const sourceTrack = queuedDownload.sourceTrack;
+
+      if (!sourceTrack) {
+        realm.write(() => {
+          queuedDownload.deletedAt = new Date();
+        });
         continue;
       }
 
-      const task = await this.createDownloadTask(queuedDownload.sourceTrack, queuedDownload);
+      if (this.isPendingOrDownloading(sourceTrack)) {
+        logger.debug(`${sourceTrack.uuid} is already pending or downloading`);
+        continue;
+      }
+
+      const task = await this.createDownloadTask(sourceTrack, queuedDownload);
 
       createdTasks.add(task.id);
     }
@@ -233,6 +305,7 @@ export class DownloadManager {
 
     const task = {
       id: sourceTrack.uuid,
+      generation: Math.max(Date.now(), (offlineInfo.startedAt?.getTime() ?? 0) + 1),
       promise: ReactNativeBlobUtil.config({
         fileCache: true,
         Progress: { interval: 500, count: 10 },
@@ -254,7 +327,7 @@ export class DownloadManager {
       );
 
       offlineInfo.status = SourceTrackOfflineInfoStatus.Downloading;
-      offlineInfo.startedAt = new Date();
+      offlineInfo.startedAt = new Date(task.generation);
     });
 
     this.attachDownloadHandlers(realm!, sourceTrack, offlineInfo!, task);
@@ -273,11 +346,30 @@ export class DownloadManager {
     if (realm) {
       const offlineInfos = realm
         .objects(SourceTrackOfflineInfo)
-        .filtered('status != $0', SourceTrackOfflineInfoStatus.Succeeded);
+        .filtered(
+          `${ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY} AND status != $0`,
+          SourceTrackOfflineInfoStatus.Succeeded
+        )
+        .snapshot();
+      const removals: Promise<void>[] = [];
 
       for (const offlineInfo of offlineInfos) {
-        await this.removeDownload(offlineInfo.sourceTrack);
+        const sourceTrack = offlineInfo.sourceTrack;
+
+        if (sourceTrack) {
+          // Calling the async method starts its synchronous cancellation and
+          // tombstoning work immediately. Await the group only after every
+          // active row has been retired so cancellation callbacks cannot race
+          // ahead and rewrite a still-active row.
+          removals.push(this.removeDownload(sourceTrack));
+        } else {
+          realm.write(() => {
+            offlineInfo.deletedAt = new Date();
+          });
+        }
       }
+
+      await Promise.all(removals);
     }
   }
 
@@ -285,11 +377,25 @@ export class DownloadManager {
     await this.removeAllPendingDownloads();
 
     if (realm) {
-      const offlineInfos = realm.objects(SourceTrackOfflineInfo);
+      const offlineInfos = realm
+        .objects(SourceTrackOfflineInfo)
+        .filtered(ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY)
+        .snapshot();
+      const removals: Promise<void>[] = [];
 
       for (const offlineInfo of offlineInfos) {
-        await this.removeDownload(offlineInfo.sourceTrack);
+        const sourceTrack = offlineInfo.sourceTrack;
+
+        if (sourceTrack) {
+          removals.push(this.removeDownload(sourceTrack));
+        } else {
+          realm.write(() => {
+            offlineInfo.deletedAt = new Date();
+          });
+        }
       }
+
+      await Promise.all(removals);
     }
   }
 
@@ -317,7 +423,11 @@ export class DownloadManager {
     if (realm) {
       const offlineInfos = realm
         .objects(SourceTrackOfflineInfo)
-        .filtered('status == $0', SourceTrackOfflineInfoStatus.Failed);
+        .filtered(
+          `${ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY} AND status == $0`,
+          SourceTrackOfflineInfoStatus.Failed
+        )
+        .snapshot();
 
       realm.write(() => {
         for (const offlineInfo of offlineInfos) {
@@ -331,50 +441,71 @@ export class DownloadManager {
   }
 
   async removeDownload(sourceTrack: SourceTrack) {
-    if (this.removingDownloadTasks.has(sourceTrack.uuid)) {
-      logger.debug(`${sourceTrack.uuid} is already being removed`);
+    if (!sourceTrack.isValid()) {
+      logger.warn('removeDownload: Ignoring an invalid source track.');
       return;
     }
 
-    this.removingDownloadTasks.add(sourceTrack.uuid);
+    const sourceTrackUuid = sourceTrack.uuid;
+    const activeRealm = realm;
+
+    if (!activeRealm) {
+      logger.warn(`${sourceTrackUuid}: cannot remove download without an active Realm`);
+      return;
+    }
+
+    if (this.removingDownloadTasks.has(sourceTrackUuid)) {
+      logger.debug(`${sourceTrackUuid} is already being removed`);
+      return;
+    }
+
+    this.removingDownloadTasks.add(sourceTrackUuid);
 
     try {
       // remove task, if it exists
-      const task = this.downloadTaskById(sourceTrack.uuid);
+      const task = this.downloadTaskById(sourceTrackUuid);
 
       if (task) {
         task.promise.cancel();
       }
 
       // delete file, if it exists
+      const downloadedFileLocation = sourceTrack.downloadedFileLocation();
+      let fileCleanupSucceeded = false;
       try {
-        const downloadedFile = new File(sourceTrack.downloadedFileLocation());
+        const downloadedFile = new File(downloadedFileLocation);
         if (downloadedFile.exists) {
           downloadedFile.delete();
         }
-      } catch {
-        /* empty */
+
+        fileCleanupSucceeded = !new File(downloadedFileLocation).exists;
+      } catch (error) {
+        logger.warn(
+          `${sourceTrackUuid}: retaining offline info because its downloaded file could not be removed`,
+          error
+        );
+      }
+
+      if (!fileCleanupSucceeded) {
+        return;
       }
 
       // remove SourceTrackOfflineInfo
-      const activeRealm = realm;
-      if (activeRealm) {
-        activeRealm.write(() => {
-          if (!sourceTrack.isValid()) {
-            return;
-          }
+      activeRealm.write(() => {
+        if (!sourceTrack.isValid()) {
+          return;
+        }
 
-          const offlineInfo = sourceTrack.offlineInfo;
+        const offlineInfo = this.activeOfflineInfo(sourceTrack);
 
-          sourceTrack.offlineInfo = undefined;
-          if (offlineInfo?.isValid()) {
-            activeRealm.delete(offlineInfo);
-          }
-        });
-      }
+        sourceTrack.offlineInfo = undefined;
+        if (offlineInfo) {
+          offlineInfo.deletedAt = new Date();
+        }
+      });
     } finally {
       this.emitRemainingDownloadsChanged();
-      this.removingDownloadTasks.delete(sourceTrack.uuid);
+      this.removingDownloadTasks.delete(sourceTrackUuid);
     }
   }
 
@@ -387,7 +518,11 @@ export class DownloadManager {
     // these are downloads that were in progress when the app was killed
     const stuckDownloads = realm
       .objects(SourceTrackOfflineInfo)
-      .filtered('status == $0', SourceTrackOfflineInfoStatus.Downloading);
+      .filtered(
+        `${ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY} AND status == $0`,
+        SourceTrackOfflineInfoStatus.Downloading
+      )
+      .snapshot();
 
     if (stuckDownloads.length > 0) {
       this.statsig.logEvent(downloadsResumedEvent(stuckDownloads.length));
@@ -429,6 +564,10 @@ export class DownloadManager {
     downloadTask: DownloadTask,
     { bytesDownloaded, bytesTotal }: { bytesDownloaded: number; bytesTotal: number }
   ) {
+    if (!offlineInfo.isValid() || offlineInfo.deletedAt) {
+      return;
+    }
+
     const percent = bytesDownloaded / bytesTotal;
 
     if (percent - offlineInfo.percent >= 0.1) {
@@ -476,22 +615,28 @@ export class DownloadManager {
     downloadTask: DownloadTask
   ) {
     let offlineInfoRef = offlineInfo;
+    const sourceTrackUuid = sourceTrack.uuid;
+    const destinationPath = sourceTrack.downloadedFileLocation().replace('file://', '');
 
     const refreshOfflineInfo = () => {
       if (!offlineInfoRef.isValid()) {
         const newOfflineInfo = realm.objectForPrimaryKey<SourceTrackOfflineInfo>(
           SourceTrackOfflineInfo,
-          sourceTrack.uuid
+          sourceTrackUuid
         );
 
-        if (newOfflineInfo) {
+        if (newOfflineInfo && !newOfflineInfo.deletedAt) {
           offlineInfoRef = newOfflineInfo;
         } else {
           return;
         }
       }
 
-      if (offlineInfoRef.status !== SourceTrackOfflineInfoStatus.Downloading) {
+      if (
+        offlineInfoRef.deletedAt ||
+        offlineInfoRef.status !== SourceTrackOfflineInfoStatus.Downloading ||
+        offlineInfoRef.startedAt?.getTime() !== downloadTask.generation
+      ) {
         return;
       }
 
@@ -512,19 +657,38 @@ export class DownloadManager {
         });
       })
       .then(async (res) => {
-        const dest = sourceTrack.downloadedFileLocation().replace('file://', '');
+        const dest = destinationPath;
         const path = res.path().replace('file://', '');
         let validationResult: DownloadValidationResult;
 
         try {
+          if (!refreshOfflineInfo()) {
+            return;
+          }
+
           validationResult = await validateCompletedDownloadResponse(res, path);
+
+          if (!refreshOfflineInfo()) {
+            return;
+          }
 
           log.info(`${downloadTask.id}: copying ${path} to ${dest}`);
 
-          if (await ReactNativeBlobUtil.fs.exists(dest)) {
-            await ReactNativeBlobUtil.fs.unlink(dest);
+          if (!refreshOfflineInfo()) {
+            return;
           }
-          await ReactNativeBlobUtil.fs.mv(path, dest);
+
+          // The destination is cleared before this attempt starts. If another
+          // writer recreated it while this request was in flight (notably the
+          // native streaming cache), preserve that newer file instead of
+          // unlinking it from an older completion callback.
+          if (!(await ReactNativeBlobUtil.fs.exists(dest))) {
+            if (!refreshOfflineInfo()) {
+              return;
+            }
+
+            await ReactNativeBlobUtil.fs.mv(path, dest);
+          }
         } finally {
           // if we encounter an error, clean up the temporary file
           try {
@@ -554,18 +718,16 @@ export class DownloadManager {
 
         this.statsig.logEvent(trackDownloadCompletedEvent(sourceTrack));
         this.logTrackDownloadIntegrityAsync(sourceTrack, dest, validationResult);
-
-        this.runningDownloadTasks.splice(this.runningDownloadTasks.indexOf(downloadTask), 1);
-        this.maybeStartQueuedDownloads().then(() => {});
       })
       .catch((error) => {
-        log.warn(`error downloading ${downloadTask.id}`, error);
-
         const oi = refreshOfflineInfo();
 
         if (!oi) {
+          logger.debug(`${downloadTask.id}: stopped after its offline info was deleted`);
           return;
         }
+
+        log.warn(`error downloading ${downloadTask.id}`, error);
 
         realm.write(() => {
           const errorInfo = stringifyDownloadError(error);
@@ -585,8 +747,14 @@ export class DownloadManager {
         });
 
         this.statsig.logEvent(trackDownloadFailureEvent(sourceTrack, oi));
+      })
+      .finally(() => {
+        const taskIndex = this.runningDownloadTasks.indexOf(downloadTask);
+        if (taskIndex >= 0) {
+          this.runningDownloadTasks.splice(taskIndex, 1);
+        }
 
-        this.runningDownloadTasks.splice(this.runningDownloadTasks.indexOf(downloadTask), 1);
+        this.emitRemainingDownloadsChanged();
         this.maybeStartQueuedDownloads().then(() => {});
       });
   }

--- a/relisten/pages/tab_roots/MyLibraryTabRootPage.tsx
+++ b/relisten/pages/tab_roots/MyLibraryTabRootPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/relisten/realm/models/source_track_offline_info';
 import { useRemainingDownloadsCount } from '@/relisten/realm/root_services';
 import { logTabRootDebug } from '@/relisten/util/profile_logging';
+import { readRetainedCatalogObject } from '@/relisten/realm/catalog_retirement';
 
 function MyLibrarySectionHeader({ children, className, ...props }: PropsWithChildren<ViewProps>) {
   return (
@@ -58,14 +59,26 @@ function RecentlyPlayedShows() {
       </Link>
 
       <View className="w-full flex-row flex-wrap px-2">
-        {recentlyPlayedShows.map((show) => (
-          <ShowCard
-            show={show.show}
-            key={show.show.uuid}
-            sourceUuid={show.source.uuid}
-            className="my-1 shrink basis-1/2"
-          />
-        ))}
+        {recentlyPlayedShows.map((entry) => {
+          const show = readRetainedCatalogObject(entry.show, 'history.recent-show-card.show');
+          const source = readRetainedCatalogObject(entry.source, 'history.recent-show-card.source');
+          const artist = readRetainedCatalogObject(show?.artist, 'history.recent-show-card.artist');
+
+          if (!show || !source || !artist) {
+            return null;
+          }
+
+          readRetainedCatalogObject(show.venue, 'history.recent-show-card.venue');
+
+          return (
+            <ShowCard
+              show={show}
+              key={show.uuid}
+              sourceUuid={source.uuid}
+              className="my-1 shrink basis-1/2"
+            />
+          );
+        })}
       </View>
     </View>
   );
@@ -78,7 +91,7 @@ function FavoriteShows({ topContent }: { topContent?: ReactNode }) {
       type: Show,
       query: (query) =>
         query.filtered(
-          'isFavorite == true OR SUBQUERY(sourceTracks, $item, $item.offlineInfo.status == $0 AND $item.offlineInfo.type == $1).@count > 0',
+          'isFavorite == true OR SUBQUERY(sourceTracks, $item, $item.offlineInfo.deletedAt == nil AND $item.offlineInfo.status == $0 AND $item.offlineInfo.type == $1).@count > 0',
           SourceTrackOfflineInfoStatus.Succeeded,
           SourceTrackOfflineInfoType.UserInitiated
         ),
@@ -86,8 +99,22 @@ function FavoriteShows({ topContent }: { topContent?: ReactNode }) {
     []
   );
 
+  const retainedFavoriteShows = useMemo(() => {
+    return [...favoriteShowsQuery].flatMap((candidate) => {
+      const show = readRetainedCatalogObject(candidate, 'library.favorite-show');
+      const artist = readRetainedCatalogObject(show?.artist, 'library.favorite-show.artist');
+
+      if (!show || !artist) {
+        return [];
+      }
+
+      readRetainedCatalogObject(show.venue, 'library.favorite-show.venue');
+      return [{ artist, show }];
+    });
+  }, [favoriteShowsQuery]);
+
   const favoriteShowsByArtist: RelistenSectionData<Show> = useMemo(() => {
-    const showsByArtistUuid = aggregateBy([...favoriteShowsQuery], (s) => s.artistUuid);
+    const showsByArtistUuid = aggregateBy(retainedFavoriteShows, ({ show }) => show.artistUuid);
 
     return Object.keys(showsByArtistUuid)
       .sort((a, b) => {
@@ -100,10 +127,10 @@ function FavoriteShows({ topContent }: { topContent?: ReactNode }) {
         const shows = showsByArtistUuid[artistUuid];
         return {
           sectionTitle: shows[0].artist.name,
-          data: shows,
+          data: shows.map(({ show }) => show),
         };
       });
-  }, [favoriteShowsQuery]);
+  }, [retainedFavoriteShows]);
 
   const nonIdealState = {
     noData: {
@@ -130,7 +157,7 @@ function FavoriteShows({ topContent }: { topContent?: ReactNode }) {
           <View className="pt-4">
             {topContent}
             <MyLibrarySectionHeader>
-              <Plur word="Show" count={favoriteShowsQuery.length} /> in My Library
+              <Plur word="Show" count={retainedFavoriteShows.length} /> in My Library
             </MyLibrarySectionHeader>
           </View>
         }

--- a/relisten/playback_history_reporter.ts
+++ b/relisten/playback_history_reporter.ts
@@ -10,6 +10,11 @@ import { SourceTrack } from '@/relisten/realm/models/source_track';
 import { Artist } from '@/relisten/realm/models/artist';
 import { Show } from '@/relisten/realm/models/show';
 import { Source } from '@/relisten/realm/models/source';
+import {
+  activePlaybackHistoryEntries,
+  activePlaybackHistoryEntryForPrimaryKey,
+  readRetainedPlaybackHistoryCatalogLinks,
+} from '@/relisten/realm/models/history/playback_history_lifecycle';
 
 const logger = log.extend('playback-history-reporter');
 
@@ -58,18 +63,24 @@ export class PlaybackHistoryReporter {
   }
 
   recordPlayback(playback: PlaybackHistoryReportable): PlaybackHistoryEntry | undefined {
-    const artist = this.realm.objectForPrimaryKey(Artist, playback.sourceTrack.artistUuid);
-    const show = this.realm.objectForPrimaryKey(Show, playback.sourceTrack.showUuid);
-    const source = this.realm.objectForPrimaryKey(Source, playback.sourceTrack.sourceUuid);
+    const sourceTrack = playback.sourceTrack;
+    const artist = this.realm.objectForPrimaryKey(Artist, sourceTrack.artistUuid);
+    const show = this.realm.objectForPrimaryKey(Show, sourceTrack.showUuid);
+    const source = this.realm.objectForPrimaryKey(Source, sourceTrack.sourceUuid);
 
     if (!artist || !show || !source) {
       logger.warn(
-        `Unable to record playback for sourceTrack=${playback.sourceTrack.sourceUuid}. ` +
-          `artist=${playback.sourceTrack.artistUuid}, show=${playback.sourceTrack.showUuid}, ` +
-          `source=${playback.sourceTrack.sourceUuid}`
+        `Unable to record playback for sourceTrack=${sourceTrack.sourceUuid}. ` +
+          `artist=${sourceTrack.artistUuid}, show=${sourceTrack.showUuid}, ` +
+          `source=${sourceTrack.sourceUuid}`
       );
       return;
     }
+
+    const catalogLinks = readRetainedPlaybackHistoryCatalogLinks(
+      { sourceTrack, artist, show, source },
+      'history.recordPlayback'
+    );
 
     const entry = this.realm.write(() => {
       return new PlaybackHistoryEntry(this.realm, {
@@ -82,29 +93,36 @@ export class PlaybackHistoryReporter {
             ? PlaybackFlags.NetworkAvailable
             : PlaybackFlags.NetworkUnavailable),
         playbackStartedAt: playback.playbackStartedAt,
-        sourceTrack: playback.sourceTrack,
-        artist: artist,
-        show: show,
-        source: source,
+        sourceTrack: catalogLinks.sourceTrack,
+        artist: catalogLinks.artist,
+        show: catalogLinks.show,
+        source: catalogLinks.source,
       });
     });
 
     // fire and forget report -- async job will pick it up if it doesn't succeed
     if (this.networkAvailable) {
-      this.attemptReport(entry).then(() => {});
+      this.attemptReport(entry.uuid, catalogLinks.sourceTrack.uuid).then(() => {});
     }
 
     return entry;
   }
 
-  private async attemptReport(entry: PlaybackHistoryEntry): Promise<RelistenApiResponse<unknown>> {
-    const res = await this.apiClient.recordPlayback(entry.sourceTrack.uuid);
+  private async attemptReport(
+    entryUuid: string,
+    sourceTrackUuid: string
+  ): Promise<RelistenApiResponse<unknown>> {
+    const res = await this.apiClient.recordPlayback(sourceTrackUuid);
 
     if (!res.error) {
-      logger.info(`Reported playback ${entry.uuid} for sourceTrack=${entry.sourceTrack.uuid}`);
-      this.realm.write(() => {
-        entry.publishedAt = new Date();
-      });
+      logger.info(`Reported playback ${entryUuid} for sourceTrack=${sourceTrackUuid}`);
+      const entry = activePlaybackHistoryEntryForPrimaryKey(this.realm, entryUuid);
+
+      if (entry) {
+        this.realm.write(() => {
+          entry.publishedAt = new Date();
+        });
+      }
     }
 
     return res;
@@ -116,9 +134,19 @@ export class PlaybackHistoryReporter {
       this.retryTimer = undefined;
     }
 
-    const entriesToPublish = this.realm
-      .objects(PlaybackHistoryEntry)
-      .filtered('publishedAt == null');
+    const entriesToPublish = Array.from(
+      activePlaybackHistoryEntries(this.realm).filtered('publishedAt == nil'),
+      (entry) => {
+        const { sourceTrack } = readRetainedPlaybackHistoryCatalogLinks(
+          entry,
+          'history.reporting.pending'
+        );
+        return {
+          entryUuid: entry.uuid,
+          sourceTrackUuid: sourceTrack.uuid,
+        };
+      }
+    );
 
     if (entriesToPublish.length === 0) {
       logger.info('No playback history entries to publish');
@@ -128,11 +156,11 @@ export class PlaybackHistoryReporter {
     logger.info(`Reporting ${entriesToPublish.length} playback history entries`);
 
     for (const entry of entriesToPublish) {
-      const res = await this.attemptReport(entry);
+      const res = await this.attemptReport(entry.entryUuid, entry.sourceTrackUuid);
 
       if (res.error) {
         logger.warn(
-          `Error reporting ${entry.uuid}. Will try again in 30s; ${JSON.stringify(res.error)}`
+          `Error reporting ${entry.entryUuid}. Will try again in 30s; ${JSON.stringify(res.error)}`
         );
 
         this.retryTimer = setTimeout(() => {

--- a/relisten/player/relisten_player_queue.tsx
+++ b/relisten/player/relisten_player_queue.tsx
@@ -11,11 +11,16 @@ import { EventSource } from '@/relisten/util/event_source';
 import { realm } from '@/relisten/realm/schema';
 import { PlayerState } from '@/relisten/realm/models/player_state';
 import { log } from '@/relisten/util/logging';
-import { groupByUuid } from '@/relisten/util/group_by';
 import { Realm } from '@realm/react';
 import { indentString } from '@/relisten/util/string_indent';
+import {
+  readRetainedCatalogObject,
+  retainedCatalogObjectForPrimaryKey,
+} from '@/relisten/realm/catalog_retirement';
 
 const logger = log.extend('player-queue');
+const QUEUE_TRACK_ACCESS_SITE = 'player.queue.track';
+const QUEUE_RESTORE_ACCESS_SITE = 'player.queue.restore.source-track';
 
 export enum PlayerShuffleState {
   SHUFFLE_OFF = 1,
@@ -69,17 +74,36 @@ export class PlayerQueueTrack {
   }
 
   static fromSourceTrack(sourceTrack: SourceTrack) {
-    const artist = sourceTrack.artist;
-    const source = sourceTrack.source;
-    const venue = sourceTrack.show.venue;
+    const retainedSourceTrack = readRetainedCatalogObject(
+      sourceTrack,
+      `${QUEUE_TRACK_ACCESS_SITE}.source-track`
+    );
+    const artist = readRetainedCatalogObject(
+      retainedSourceTrack?.artist,
+      `${QUEUE_TRACK_ACCESS_SITE}.artist`
+    );
+    const source = readRetainedCatalogObject(
+      retainedSourceTrack?.source,
+      `${QUEUE_TRACK_ACCESS_SITE}.source`
+    );
+    const show = readRetainedCatalogObject(
+      retainedSourceTrack?.show,
+      `${QUEUE_TRACK_ACCESS_SITE}.show`
+    );
+
+    if (!retainedSourceTrack || !artist || !source || !show) {
+      throw new Error(`Cannot create queue track for incomplete SourceTrack ${sourceTrack.uuid}`);
+    }
+
+    const venue = readRetainedCatalogObject(show.venue, `${QUEUE_TRACK_ACCESS_SITE}.venue`);
 
     const [year, month, day] = source.displayDate.split('-');
 
-    const albumArtUrl = `https://sonos.relisten.net/album-art/${artist?.slug}/years/${year}/${year}-${month}-${day}/${source.uuid}/550.png`;
+    const albumArtUrl = `https://sonos.relisten.net/album-art/${artist.slug}/years/${year}/${year}-${month}-${day}/${source.uuid}/550.png`;
 
     return new PlayerQueueTrack(
-      sourceTrack,
-      sourceTrack.title,
+      retainedSourceTrack,
+      retainedSourceTrack.title,
       [artist.name, source.displayDate, venue?.name].filter((part) => !!part).join(' • ') || '',
       [artist.name, source.displayDate, venue?.name, venue?.location]
         .filter((part) => !!part)
@@ -622,11 +646,18 @@ ${indentString(tracks)}
         queueShuffleState: playerState.queueShuffleState,
       });
 
-      const sourceTracksByUuid = groupByUuid([
-        ...realm
-          .objects(SourceTrack)
-          .filtered('uuid in $0', [...playerState.queueSourceTrackUuids]),
-      ]);
+      const sourceTracksByUuid: Record<string, SourceTrack> = {};
+      for (const sourceTrackUuid of new Set(playerState.queueSourceTrackUuids)) {
+        const sourceTrack = retainedCatalogObjectForPrimaryKey(
+          realm,
+          SourceTrack,
+          sourceTrackUuid,
+          QUEUE_RESTORE_ACCESS_SITE
+        );
+        if (sourceTrack) {
+          sourceTracksByUuid[sourceTrackUuid] = sourceTrack;
+        }
+      }
       let droppedInvalidTrack = false;
 
       const makeQueue = (uuids: string[]) => {

--- a/relisten/realm/catalog_access_monitor.ts
+++ b/relisten/realm/catalog_access_monitor.ts
@@ -1,0 +1,167 @@
+import * as Sentry from '@sentry/react-native';
+import { AnyRealmObject } from 'realm';
+
+import { CatalogRetirementState } from '@/relisten/realm/catalog_retirement_schema';
+import { log } from '@/relisten/util/logging';
+
+const logger = log.extend('catalog-access');
+const accessCounts = new Map<string, number>();
+const retainedAccessCounts = new Map<string, number>();
+const incompleteAccessCounts = new Map<string, number>();
+
+export type RetireableCatalogObject = AnyRealmObject &
+  CatalogRetirementState & {
+    uuid: string;
+  };
+
+function safeObjectIdentity(object: RetireableCatalogObject) {
+  let modelName = 'UnknownCatalogObject';
+  let uuid = 'unknown';
+
+  try {
+    modelName = object.objectSchema().name;
+  } catch {
+    // A deleted managed object may no longer expose schema metadata.
+  }
+  try {
+    if (object.isValid()) uuid = object.uuid;
+  } catch {
+    // Identity is diagnostic-only; never let it recreate the invalid access.
+  }
+
+  return { modelName, uuid };
+}
+
+function isPowerOfTwo(value: number) {
+  return value > 0 && (value & (value - 1)) === 0;
+}
+
+export function reportUnexpectedRetiredCatalogAccess(
+  object: RetireableCatalogObject,
+  accessSite: string
+) {
+  const modelName = object.objectSchema().name;
+  const key = `${modelName}:${accessSite}`;
+  const count = (accessCounts.get(key) ?? 0) + 1;
+  accessCounts.set(key, count);
+
+  if (isPowerOfTwo(count)) {
+    Sentry.addBreadcrumb({
+      category: 'realm.catalog-retirement',
+      level: 'warning',
+      message: `Retired ${modelName} reached an active-only boundary`,
+      data: {
+        accessSite,
+        count,
+        retiredAt: object.retiredAt?.toISOString(),
+        retirementReason: object.retirementReason,
+        uuid: object.uuid,
+      },
+    });
+  }
+
+  if (count === 1) {
+    logger.warn(
+      `Retired ${modelName} reached active-only boundary ${accessSite}; uuid=${object.uuid}`
+    );
+    Sentry.captureMessage('Retired Realm catalog object reached an active-only boundary', {
+      level: 'warning',
+      fingerprint: ['realm-retired-catalog-access', modelName, accessSite],
+      tags: {
+        access_site: accessSite,
+        realm_model: modelName,
+      },
+      extra: {
+        retiredAt: object.retiredAt?.toISOString(),
+        retirementReason: object.retirementReason,
+        uuid: object.uuid,
+      },
+    });
+  }
+}
+
+export function reportUnexpectedIncompleteCatalogAccess(
+  object: RetireableCatalogObject,
+  accessSite: string,
+  issues: ReadonlyArray<string>
+) {
+  const { modelName, uuid } = safeObjectIdentity(object);
+  const issueKey = issues.join(',');
+  const key = `${modelName}:${accessSite}:${issueKey}`;
+  const count = (incompleteAccessCounts.get(key) ?? 0) + 1;
+  incompleteAccessCounts.set(key, count);
+
+  if (isPowerOfTwo(count)) {
+    Sentry.addBreadcrumb({
+      category: 'realm.catalog-integrity.access',
+      level: 'warning',
+      message: `Structurally incomplete ${modelName} reached a catalog boundary`,
+      data: { accessSite, count, issues, uuid },
+    });
+  }
+
+  if (count === 1) {
+    logger.warn(
+      `Structurally incomplete ${modelName} reached ${accessSite}; uuid=${uuid}; issues=${issueKey}`
+    );
+    Sentry.captureMessage('Structurally incomplete Realm catalog object was accessed', {
+      level: 'warning',
+      fingerprint: ['realm-incomplete-catalog-access', modelName, accessSite],
+      tags: {
+        access_site: accessSite,
+        realm_model: modelName,
+      },
+      extra: { issues, uuid },
+    });
+  }
+}
+
+export function reportCatalogMaintenance(
+  operation: 'retired' | 'restored' | 'collected' | 'collection-skipped',
+  modelName: string,
+  count: number,
+  data: Record<string, unknown> = {}
+) {
+  if (count === 0) return;
+
+  Sentry.addBreadcrumb({
+    category: 'realm.catalog-retirement',
+    level: operation === 'collection-skipped' ? 'warning' : 'info',
+    message: `Catalog objects ${operation}`,
+    data: { count, modelName, ...data },
+  });
+}
+
+export function reportRetainedCatalogAccess(object: RetireableCatalogObject, accessSite: string) {
+  if (!object.retiredAt) return;
+
+  const modelName = object.objectSchema().name;
+  const key = `${modelName}:${accessSite}`;
+  const count = (retainedAccessCounts.get(key) ?? 0) + 1;
+  retainedAccessCounts.set(key, count);
+
+  if (isPowerOfTwo(count)) {
+    Sentry.addBreadcrumb({
+      category: 'realm.catalog-retirement.retained-access',
+      level: 'info',
+      message: `Retired ${modelName} used by a retained-data path`,
+      data: {
+        accessSite,
+        count,
+        retiredAt: object.retiredAt.toISOString(),
+        retirementReason: object.retirementReason,
+        uuid: object.uuid,
+      },
+    });
+  }
+
+  if (count === 1) {
+    logger.info(`Retired ${modelName} retained at ${accessSite}; uuid=${object.uuid}`);
+  }
+}
+
+export function resetCatalogAccessMonitorForTests() {
+  accessCounts.clear();
+  retainedAccessCounts.clear();
+  incompleteAccessCounts.clear();
+}

--- a/relisten/realm/catalog_gc.test.ts
+++ b/relisten/realm/catalog_gc.test.ts
@@ -1,0 +1,338 @@
+/// <reference types="node" />
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import Realm from 'realm';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FlacType } from '@/relisten/api/models/source';
+import { runColdStartCatalogGarbageCollection } from '@/relisten/realm/catalog_gc';
+import { Artist } from '@/relisten/realm/models/artist';
+import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
+import { PlayerState } from '@/relisten/realm/models/player_state';
+import {
+  Popularity,
+  PopularityWindow,
+  PopularityWindows,
+} from '@/relisten/realm/models/popularity';
+import { Show } from '@/relisten/realm/models/show';
+import { Song } from '@/relisten/realm/models/song';
+import { Source } from '@/relisten/realm/models/source';
+import { SourceSet } from '@/relisten/realm/models/source_set';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
+import {
+  SourceTrackOfflineInfo,
+  SourceTrackOfflineInfoStatus,
+  SourceTrackOfflineInfoType,
+} from '@/relisten/realm/models/source_track_offline_info';
+import { Tour } from '@/relisten/realm/models/tour';
+import { Venue } from '@/relisten/realm/models/venue';
+import { Year } from '@/relisten/realm/models/year';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-04-01T00:00:00.000Z');
+const MATURE_RETIREMENT = new Date('2026-01-01T00:00:00.000Z');
+
+const catalogTestSchema = [
+  Artist,
+  Year,
+  Show,
+  Venue,
+  Tour,
+  Song,
+  Source,
+  SourceSet,
+  SourceTrack,
+  SourceTrackOfflineInfo,
+  PlaybackHistoryEntry,
+  PlayerState,
+  Popularity,
+  PopularityWindow,
+  PopularityWindows,
+];
+
+const openRealms: Realm[] = [];
+const tempDirectories: string[] = [];
+
+function temporaryRealm() {
+  const directory = mkdtempSync(join(tmpdir(), 'relisten-catalog-gc-'));
+  tempDirectories.push(directory);
+  const realm = new Realm({
+    path: join(directory, 'test.realm'),
+    schema: catalogTestSchema,
+    schemaVersion: 1,
+  });
+  openRealms.push(realm);
+  return realm;
+}
+
+function runGc(realm: Realm, batchLimit = 250) {
+  return runColdStartCatalogGarbageCollection(realm, {
+    now: NOW,
+    gracePeriodMs: 30 * DAY_MS,
+    batchLimit,
+    scanLimitPerModel: 100,
+    auditGraph: false,
+  });
+}
+
+function createRetiredVenue(realm: Realm, uuid: string, artistUuid = 'missing-artist') {
+  realm.create(Venue, {
+    uuid,
+    createdAt: MATURE_RETIREMENT,
+    updatedAt: MATURE_RETIREMENT,
+    artistUuid,
+    name: uuid,
+    location: 'Test Location',
+    upstreamIdentifier: uuid,
+    slug: uuid,
+    sortName: uuid,
+    showsAtVenue: 0,
+    retiredAt: MATURE_RETIREMENT,
+    isFavorite: false,
+  });
+}
+
+function createOfflineInfo(realm: Realm, sourceTrackUuid: string, deletedAt?: Date) {
+  return realm.create(SourceTrackOfflineInfo, {
+    sourceTrackUuid,
+    status: SourceTrackOfflineInfoStatus.Succeeded,
+    type: SourceTrackOfflineInfoType.UserInitiated,
+    queuedAt: MATURE_RETIREMENT,
+    downloadedBytes: 1,
+    totalBytes: 1,
+    percent: 1,
+    deletedAt,
+  });
+}
+
+function createRetiredTrack(realm: Realm, uuid: string, offlineInfo?: SourceTrackOfflineInfo) {
+  const linkedOfflineInfo = offlineInfo ?? createOfflineInfo(realm, uuid, MATURE_RETIREMENT);
+  return realm.create(SourceTrack, {
+    uuid,
+    createdAt: MATURE_RETIREMENT,
+    updatedAt: MATURE_RETIREMENT,
+    retiredAt: MATURE_RETIREMENT,
+    artistUuid: 'missing-artist',
+    sourceUuid: 'missing-source',
+    sourceSetUuid: 'missing-source-set',
+    showUuid: 'missing-show',
+    trackPosition: 1,
+    title: uuid,
+    slug: uuid,
+    mp3Url: `https://example.test/${uuid}.mp3`,
+    isFavorite: false,
+    offlineInfo: linkedOfflineInfo,
+  });
+}
+
+function createHistoryGraph(realm: Realm) {
+  const artist = realm.create(Artist, {
+    uuid: 'history-artist',
+    createdAt: MATURE_RETIREMENT,
+    updatedAt: MATURE_RETIREMENT,
+    musicbrainzId: '',
+    name: 'History Artist',
+    featured: 0,
+    slug: 'history-artist',
+    sortName: 'History Artist',
+    featuresRaw: '{}',
+    upstreamSourcesRaw: '[]',
+    showCount: 1,
+    sourceCount: 1,
+    isFavorite: false,
+  });
+  const show = realm.create(Show, {
+    uuid: 'history-show',
+    artistUuid: artist.uuid,
+    yearUuid: 'history-year',
+    createdAt: MATURE_RETIREMENT,
+    updatedAt: MATURE_RETIREMENT,
+    date: MATURE_RETIREMENT,
+    avgRating: 0,
+    displayDate: '2026-01-01',
+    mostRecentSourceUpdatedAt: MATURE_RETIREMENT,
+    hasSoundboardSource: false,
+    hasStreamableFlacSource: false,
+    sourceCount: 1,
+    artist,
+    isFavorite: false,
+  });
+  const source = realm.create(Source, {
+    uuid: 'history-source',
+    createdAt: MATURE_RETIREMENT,
+    updatedAt: MATURE_RETIREMENT,
+    artistUuid: artist.uuid,
+    showUuid: show.uuid,
+    displayDate: '2026-01-01',
+    isSoundboard: false,
+    isRemaster: false,
+    hasJamcharts: false,
+    avgRating: 0,
+    numReviews: 0,
+    avgRatingWeighted: 0,
+    upstreamIdentifier: 'history-source',
+    flacType: FlacType.NoFlac,
+    reviewCount: 0,
+    linksRaw: '[]',
+    artist,
+    sourceSets: [],
+    isFavorite: false,
+  });
+  return { artist, show, source };
+}
+
+afterEach(() => {
+  for (const realm of openRealms.splice(0)) {
+    if (!realm.isClosed) realm.close();
+  }
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('cold-start catalog garbage collection', () => {
+  it('physically collects a mature unreferenced tombstone', () => {
+    const realm = temporaryRealm();
+    realm.write(() => createRetiredVenue(realm, 'unreferenced'));
+
+    const result = runGc(realm);
+
+    expect(result.collected.Venue).toBe(1);
+    expect(result.totalCollected).toBe(1);
+    expect(realm.objectForPrimaryKey('Venue', 'unreferenced')).toBeNull();
+  });
+
+  it('keeps a retired descendant of an active favorite', () => {
+    const realm = temporaryRealm();
+    realm.write(() => {
+      realm.create(Artist, {
+        uuid: 'favorite-artist',
+        createdAt: MATURE_RETIREMENT,
+        updatedAt: MATURE_RETIREMENT,
+        musicbrainzId: '',
+        name: 'Favorite Artist',
+        featured: 0,
+        slug: 'favorite-artist',
+        sortName: 'Favorite Artist',
+        featuresRaw: '{}',
+        upstreamSourcesRaw: '[]',
+        showCount: 0,
+        sourceCount: 0,
+        isFavorite: true,
+      });
+      createRetiredVenue(realm, 'favorite-venue', 'favorite-artist');
+    });
+
+    const result = runGc(realm);
+
+    expect(result.totalCollected).toBe(0);
+    expect(result.models.Venue.blockers['favorite-root-closure']).toBe(1);
+    expect(realm.objectForPrimaryKey('Venue', 'favorite-venue')).not.toBeNull();
+  });
+
+  it('keeps a track referenced by active durable queue state', () => {
+    const realm = temporaryRealm();
+    realm.write(() => {
+      createRetiredTrack(realm, 'queued-track');
+      realm.create(PlayerState, {
+        id: 'player_state',
+        queueShuffleState: 0,
+        queueRepeatState: 0,
+        queueSourceTrackUuids: ['queued-track'],
+        queueSourceTrackShuffledUuids: [],
+        lastUpdatedAt: NOW,
+      });
+    });
+
+    const result = runGc(realm);
+
+    expect(result.totalCollected).toBe(0);
+    expect(result.models.SourceTrack.blockers['player-state-queue']).toBe(1);
+    expect(realm.objectForPrimaryKey('SourceTrack', 'queued-track')).not.toBeNull();
+  });
+
+  it('keeps a track referenced by active playback history', () => {
+    const realm = temporaryRealm();
+    realm.write(() => {
+      const { artist, show, source } = createHistoryGraph(realm);
+      const sourceTrack = createRetiredTrack(realm, 'history-track');
+      sourceTrack.artist = artist;
+      sourceTrack.show = show;
+      sourceTrack.source = source;
+      realm.create(PlaybackHistoryEntry, {
+        uuid: 'history-entry',
+        playbackFlags: 0,
+        createdAt: MATURE_RETIREMENT,
+        playbackStartedAt: MATURE_RETIREMENT,
+        sourceTrack,
+        artist,
+        show,
+        source,
+      });
+    });
+
+    const result = runGc(realm);
+
+    expect(result.totalCollected).toBe(0);
+    expect(result.models.SourceTrack.blockers['playback-history']).toBe(1);
+    expect(realm.objectForPrimaryKey('SourceTrack', 'history-track')).not.toBeNull();
+  });
+
+  it('keeps a track with active offline state', () => {
+    const realm = temporaryRealm();
+    realm.write(() => {
+      const offlineInfo = createOfflineInfo(realm, 'offline-track');
+      createRetiredTrack(realm, 'offline-track', offlineInfo);
+    });
+
+    const result = runGc(realm);
+
+    expect(result.totalCollected).toBe(0);
+    expect(result.models.SourceTrack.blockers['offline-info-link']).toBe(1);
+    expect(realm.objectForPrimaryKey('SourceTrack', 'offline-track')).not.toBeNull();
+  });
+
+  it('never physically deletes more than the configured batch limit', () => {
+    const realm = temporaryRealm();
+    realm.write(() => {
+      for (let index = 0; index < 12; index += 1) {
+        createRetiredVenue(realm, `venue-${index}`);
+      }
+    });
+
+    const result = runGc(realm, 9);
+
+    expect(result.totalCollected).toBe(9);
+    expect(result.collected.Venue).toBe(9);
+    expect(realm.objects('Venue')).toHaveLength(3);
+  });
+
+  it('rejects a nonzero batch too small to reserve every model class', () => {
+    const realm = temporaryRealm();
+
+    expect(() => runGc(realm, 8)).toThrow(
+      'batchLimit must be 0 or at least 9 so every catalog model has a reserved GC slot'
+    );
+  });
+
+  it('makes progress on later model classes under a SourceTrack backlog', () => {
+    const realm = temporaryRealm();
+    realm.write(() => {
+      for (let index = 0; index < 20; index += 1) {
+        createRetiredTrack(realm, `backlog-track-${index}`);
+      }
+      createRetiredVenue(realm, 'later-venue');
+    });
+
+    const result = runGc(realm, 9);
+
+    expect(result.totalCollected).toBe(9);
+    expect(result.collected.SourceTrack).toBe(8);
+    expect(result.collected.Venue).toBe(1);
+    expect(realm.objects(SourceTrack)).toHaveLength(12);
+    expect(realm.objectForPrimaryKey(Venue, 'later-venue')).toBeNull();
+  });
+});

--- a/relisten/realm/catalog_gc.ts
+++ b/relisten/realm/catalog_gc.ts
@@ -1,0 +1,603 @@
+import Realm, { AnyRealmObject } from 'realm';
+
+import { reportCatalogMaintenance } from '@/relisten/realm/catalog_access_monitor';
+import {
+  auditCatalogRetirementGraph,
+  CatalogGraphAuditResult,
+  CatalogModelCounts,
+  CatalogModelName,
+  CatalogObject,
+  CATALOG_MODEL_NAMES,
+  emptyCatalogModelCounts,
+} from '@/relisten/realm/catalog_retirement_graph';
+import { Artist } from '@/relisten/realm/models/artist';
+import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
+import { PlayerState } from '@/relisten/realm/models/player_state';
+import { Show } from '@/relisten/realm/models/show';
+import { Song } from '@/relisten/realm/models/song';
+import { Source } from '@/relisten/realm/models/source';
+import { SourceSet } from '@/relisten/realm/models/source_set';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
+import { SourceTrackOfflineInfo } from '@/relisten/realm/models/source_track_offline_info';
+import { Tour } from '@/relisten/realm/models/tour';
+import { Venue } from '@/relisten/realm/models/venue';
+import { Year } from '@/relisten/realm/models/year';
+
+export { auditCatalogRetirementGraph } from '@/relisten/realm/catalog_retirement_graph';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const DEFAULT_CATALOG_GC_GRACE_PERIOD_MS = 30 * DAY_MS;
+export const DEFAULT_CATALOG_GC_BATCH_LIMIT = 250;
+export const DEFAULT_CATALOG_GC_SCAN_MULTIPLIER = 4;
+
+export interface CatalogGarbageCollectionOptions {
+  now?: Date;
+  gracePeriodMs?: number;
+  batchLimit?: number;
+  scanLimitPerModel?: number;
+  auditGraph?: boolean;
+}
+
+export interface CatalogGcModelResult {
+  mature: number;
+  scanOffset: number;
+  scanned: number;
+  collected: number;
+  skipped: number;
+  deferred: number;
+  blockers: Record<string, number>;
+}
+
+export interface CatalogGarbageCollectionResult {
+  now: Date;
+  cutoff: Date;
+  gracePeriodMs: number;
+  batchLimit: number;
+  scanLimitPerModel: number;
+  collected: CatalogModelCounts;
+  totalCollected: number;
+  totalScanned: number;
+  totalSkipped: number;
+  models: Record<CatalogModelName, CatalogGcModelResult>;
+  graphAudit?: CatalogGraphAuditResult;
+}
+
+interface GcContext {
+  realm: Realm;
+  queuedSourceTrackUuids: Set<string>;
+  favoriteClosure: Map<string, boolean>;
+}
+
+interface ModelSweepState {
+  modelName: CatalogModelName;
+  result: CatalogGcModelResult;
+  candidates: CatalogObject[];
+  nextCandidateIndex: number;
+}
+
+function emptyModelResult(): CatalogGcModelResult {
+  return {
+    mature: 0,
+    scanOffset: 0,
+    scanned: 0,
+    collected: 0,
+    skipped: 0,
+    deferred: 0,
+    blockers: {},
+  };
+}
+
+function emptyModelResults(): Record<CatalogModelName, CatalogGcModelResult> {
+  return {
+    SourceTrack: emptyModelResult(),
+    SourceSet: emptyModelResult(),
+    Source: emptyModelResult(),
+    Show: emptyModelResult(),
+    Year: emptyModelResult(),
+    Venue: emptyModelResult(),
+    Tour: emptyModelResult(),
+    Song: emptyModelResult(),
+    Artist: emptyModelResult(),
+  };
+}
+
+function requireNonNegativeNumber(value: number, name: string) {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative finite number`);
+  }
+  return value;
+}
+
+function requireNonNegativeInteger(value: number, name: string) {
+  requireNonNegativeNumber(value, name);
+  if (!Number.isInteger(value)) {
+    throw new Error(`${name} must be an integer`);
+  }
+  return value;
+}
+
+function collectQueuedSourceTrackUuids(realm: Realm) {
+  const queuedUuids = new Set<string>();
+  const playerStates = realm.objects(PlayerState).filtered('deletedAt == nil').snapshot();
+
+  for (let index = 0; index < playerStates.length; index += 1) {
+    const playerState = playerStates[index];
+    for (const uuid of playerState.queueSourceTrackUuids) queuedUuids.add(uuid);
+    for (const uuid of playerState.queueSourceTrackShuffledUuids) queuedUuids.add(uuid);
+  }
+
+  return queuedUuids;
+}
+
+function hasRows<T extends AnyRealmObject>(
+  realm: Realm,
+  type: Realm.RealmObjectConstructor<T>,
+  query: string,
+  ...args: unknown[]
+) {
+  return !realm
+    .objects(type)
+    .filtered(query, ...args)
+    .isEmpty();
+}
+
+function isDirectFavorite(object: CatalogObject) {
+  switch (object.objectSchema().name as CatalogModelName) {
+    case 'Artist':
+    case 'Show':
+    case 'Venue':
+    case 'Tour':
+    case 'Song':
+    case 'Source':
+    case 'SourceTrack':
+      return (object as Artist | Show | Venue | Tour | Song | Source | SourceTrack).isFavorite;
+    case 'Year':
+    case 'SourceSet':
+      return false;
+  }
+}
+
+function isInFavoriteClosure(context: GcContext, object: CatalogObject): boolean {
+  const modelName = object.objectSchema().name as CatalogModelName;
+  const key = `${modelName}:${object.uuid}`;
+  const cached = context.favoriteClosure.get(key);
+  if (cached !== undefined) return cached;
+
+  const { realm } = context;
+  const artistIsFavorite = (artistUuid: string) =>
+    realm.objectForPrimaryKey(Artist, artistUuid)?.isFavorite ?? false;
+  const source = (uuid: string) => realm.objectForPrimaryKey(Source, uuid);
+  const sourceSet = (uuid: string) => realm.objectForPrimaryKey(SourceSet, uuid);
+  const show = (uuid: string) => realm.objectForPrimaryKey(Show, uuid);
+
+  let protectedByFavorite = isDirectFavorite(object);
+  if (!protectedByFavorite) {
+    switch (modelName) {
+      case 'Artist':
+        break;
+      case 'Year':
+        protectedByFavorite = artistIsFavorite((object as Year).artistUuid);
+        break;
+      case 'Venue':
+        protectedByFavorite = artistIsFavorite((object as Venue).artistUuid);
+        break;
+      case 'Tour':
+        protectedByFavorite = artistIsFavorite((object as Tour).artistUuid);
+        break;
+      case 'Song':
+        protectedByFavorite = artistIsFavorite((object as Song).artistUuid);
+        break;
+      case 'Show': {
+        const candidate = object as Show;
+        protectedByFavorite =
+          artistIsFavorite(candidate.artistUuid) ||
+          (candidate.venueUuid
+            ? (realm.objectForPrimaryKey(Venue, candidate.venueUuid)?.isFavorite ?? false)
+            : false) ||
+          (candidate.tourUuid
+            ? (realm.objectForPrimaryKey(Tour, candidate.tourUuid)?.isFavorite ?? false)
+            : false) ||
+          !candidate.linkingObjects(Song, 'shows').filtered('isFavorite == true').isEmpty();
+        break;
+      }
+      case 'Source': {
+        const candidate = object as Source;
+        const parentShow = show(candidate.showUuid);
+        protectedByFavorite =
+          artistIsFavorite(candidate.artistUuid) ||
+          (parentShow ? isInFavoriteClosure(context, parentShow) : false) ||
+          (candidate.venueUuid
+            ? (realm.objectForPrimaryKey(Venue, candidate.venueUuid)?.isFavorite ?? false)
+            : false);
+        break;
+      }
+      case 'SourceSet': {
+        const candidate = object as SourceSet;
+        const parentSource = source(candidate.sourceUuid);
+        protectedByFavorite =
+          artistIsFavorite(candidate.artistUuid) ||
+          (parentSource ? isInFavoriteClosure(context, parentSource) : false) ||
+          candidate
+            .linkingObjects(Source, 'sourceSets')
+            .some((sourceWithMembership) => isInFavoriteClosure(context, sourceWithMembership));
+        break;
+      }
+      case 'SourceTrack': {
+        const candidate = object as SourceTrack;
+        const parentSource = source(candidate.sourceUuid);
+        const parentSourceSet = sourceSet(candidate.sourceSetUuid);
+        const parentShow = show(candidate.showUuid);
+        protectedByFavorite =
+          artistIsFavorite(candidate.artistUuid) ||
+          (parentShow ? isInFavoriteClosure(context, parentShow) : false) ||
+          (parentSource ? isInFavoriteClosure(context, parentSource) : false) ||
+          (parentSourceSet ? isInFavoriteClosure(context, parentSourceSet) : false) ||
+          candidate
+            .linkingObjects(SourceSet, 'sourceTracks')
+            .some((sourceSetWithMembership) =>
+              isInFavoriteClosure(context, sourceSetWithMembership)
+            );
+        break;
+      }
+    }
+  }
+
+  context.favoriteClosure.set(key, protectedByFavorite);
+  return protectedByFavorite;
+}
+
+function sourceTrackRootBlocker(context: GcContext, sourceTrack: SourceTrack) {
+  if (sourceTrack.offlineInfo && !sourceTrack.offlineInfo.deletedAt) return 'offline-info-link';
+  const offlineInfo = context.realm.objectForPrimaryKey(SourceTrackOfflineInfo, sourceTrack.uuid);
+  if (offlineInfo && !offlineInfo.deletedAt) {
+    return 'offline-info-row';
+  }
+  if (context.queuedSourceTrackUuids.has(sourceTrack.uuid)) return 'player-state-queue';
+  if (!sourceTrack.linkingObjects(PlaybackHistoryEntry, 'sourceTrack').isEmpty()) {
+    return 'playback-history';
+  }
+  return undefined;
+}
+
+function removeUuidFromList<T extends { uuid: string }>(list: Realm.List<T>, uuid: string) {
+  for (let index = list.length - 1; index >= 0; index -= 1) {
+    if (list[index].uuid === uuid) list.splice(index, 1);
+  }
+}
+
+function prepareSourceTrackForCollection(context: GcContext, sourceTrack: SourceTrack) {
+  const retainedRoot = sourceTrackRootBlocker(context, sourceTrack);
+  if (retainedRoot) return retainedRoot;
+
+  const sourceSets = sourceTrack.linkingObjects(SourceSet, 'sourceTracks').snapshot();
+  if (sourceTrack.linkingObjectsCount() !== sourceSets.length) return 'realm-backlinks';
+
+  for (const sourceSet of sourceSets) {
+    if (isInFavoriteClosure(context, sourceSet)) return 'favorite-root-closure';
+  }
+  for (const sourceSet of sourceSets) {
+    removeUuidFromList(sourceSet.sourceTracks, sourceTrack.uuid);
+  }
+
+  return sourceTrack.linkingObjectsCount() === 0 ? undefined : 'realm-backlinks';
+}
+
+function prepareSourceSetForCollection(context: GcContext, sourceSet: SourceSet) {
+  if (sourceSet.sourceTracks.length !== 0) return 'SourceSet.sourceTracks';
+
+  const sources = sourceSet.linkingObjects(Source, 'sourceSets').snapshot();
+  if (sourceSet.linkingObjectsCount() !== sources.length) return 'realm-backlinks';
+
+  for (const source of sources) {
+    if (isInFavoriteClosure(context, source)) return 'favorite-root-closure';
+  }
+  for (const source of sources) {
+    removeUuidFromList(source.sourceSets, sourceSet.uuid);
+  }
+
+  return sourceSet.linkingObjectsCount() === 0 ? undefined : 'realm-backlinks';
+}
+
+function prepareShowForCollection(context: GcContext, show: Show) {
+  const scalarBlocker = scalarReferenceBlocker(context.realm, show);
+  if (scalarBlocker) return scalarBlocker;
+
+  const historyEntries = show.linkingObjects(PlaybackHistoryEntry, 'show');
+  if (!historyEntries.isEmpty()) return 'playback-history';
+
+  const sourceTracks = show.linkingObjects(SourceTrack, 'show');
+  if (!sourceTracks.isEmpty()) return 'SourceTrack.show';
+
+  const songs = show.linkingObjects(Song, 'shows').snapshot();
+  if (show.linkingObjectsCount() !== songs.length) return 'realm-backlinks';
+
+  for (const song of songs) {
+    if (isInFavoriteClosure(context, song)) return 'favorite-root-closure';
+  }
+  for (const song of songs) song.shows.delete(show);
+
+  return show.linkingObjectsCount() === 0 ? undefined : 'realm-backlinks';
+}
+
+function scalarReferenceBlocker(realm: Realm, object: CatalogObject): string | undefined {
+  const uuid = object.uuid;
+
+  switch (object.objectSchema().name as CatalogModelName) {
+    case 'SourceTrack':
+    case 'Song':
+      return undefined;
+    case 'SourceSet':
+      return hasRows(realm, SourceTrack, 'sourceSetUuid == $0', uuid)
+        ? 'SourceTrack.sourceSetUuid'
+        : undefined;
+    case 'Source':
+      if (hasRows(realm, SourceSet, 'sourceUuid == $0', uuid)) return 'SourceSet.sourceUuid';
+      if (hasRows(realm, SourceTrack, 'sourceUuid == $0', uuid)) {
+        return 'SourceTrack.sourceUuid';
+      }
+      return undefined;
+    case 'Show':
+      if (hasRows(realm, Source, 'showUuid == $0', uuid)) return 'Source.showUuid';
+      if (hasRows(realm, SourceTrack, 'showUuid == $0', uuid)) return 'SourceTrack.showUuid';
+      return undefined;
+    case 'Year':
+      return hasRows(realm, Show, 'yearUuid == $0', uuid) ? 'Show.yearUuid' : undefined;
+    case 'Venue':
+      if (hasRows(realm, Show, 'venueUuid == $0', uuid)) return 'Show.venueUuid';
+      return hasRows(realm, Source, 'venueUuid == $0', uuid) ? 'Source.venueUuid' : undefined;
+    case 'Tour':
+      return hasRows(realm, Show, 'tourUuid == $0', uuid) ? 'Show.tourUuid' : undefined;
+    case 'Artist':
+      if (hasRows(realm, Year, 'artistUuid == $0', uuid)) return 'Year.artistUuid';
+      if (hasRows(realm, Show, 'artistUuid == $0', uuid)) return 'Show.artistUuid';
+      if (hasRows(realm, Venue, 'artistUuid == $0', uuid)) return 'Venue.artistUuid';
+      if (hasRows(realm, Tour, 'artistUuid == $0', uuid)) return 'Tour.artistUuid';
+      if (hasRows(realm, Song, 'artistUuid == $0', uuid)) return 'Song.artistUuid';
+      if (hasRows(realm, Source, 'artistUuid == $0', uuid)) return 'Source.artistUuid';
+      if (hasRows(realm, SourceSet, 'artistUuid == $0', uuid)) return 'SourceSet.artistUuid';
+      return hasRows(realm, SourceTrack, 'artistUuid == $0', uuid)
+        ? 'SourceTrack.artistUuid'
+        : undefined;
+  }
+}
+
+function collectionBlocker(context: GcContext, object: CatalogObject) {
+  if (isInFavoriteClosure(context, object)) return 'favorite-root-closure';
+
+  switch (object.objectSchema().name as CatalogModelName) {
+    case 'SourceTrack':
+      return prepareSourceTrackForCollection(context, object as SourceTrack);
+    case 'SourceSet': {
+      const scalarBlocker = scalarReferenceBlocker(context.realm, object);
+      return scalarBlocker ?? prepareSourceSetForCollection(context, object as SourceSet);
+    }
+    case 'Show':
+      return prepareShowForCollection(context, object as Show);
+    case 'Source':
+      if ((object as Source).sourceSets.length !== 0) return 'Source.sourceSets';
+      break;
+    case 'Song': {
+      const song = object as Song;
+      if (song.linkingObjectsCount() !== 0) return 'realm-backlinks';
+      song.shows.clear();
+      return undefined;
+    }
+    case 'Artist':
+    case 'Year':
+    case 'Venue':
+    case 'Tour':
+      break;
+  }
+
+  if (object.linkingObjectsCount() !== 0) return 'realm-backlinks';
+  return scalarReferenceBlocker(context.realm, object);
+}
+
+function matureCatalogObjects(
+  realm: Realm,
+  modelName: CatalogModelName,
+  cutoff: Date
+): Realm.Results<CatalogObject> {
+  return realm
+    .objects<CatalogObject>(modelName)
+    .filtered('retiredAt != nil AND retiredAt <= $0', cutoff)
+    .sorted('retiredAt') as Realm.Results<CatalogObject>;
+}
+
+function boundedCandidateWindow(
+  objects: Realm.Results<CatalogObject>,
+  scanLimit: number,
+  now: Date,
+  modelIndex: number
+) {
+  if (scanLimit === 0) return { candidates: [], offset: 0 };
+
+  if (objects.length <= scanLimit) {
+    return { candidates: objects.snapshot().slice(0, scanLimit), offset: 0 };
+  }
+
+  // A fixed "oldest N" window can be pinned forever by favorites or retained history. Rotate one
+  // bounded native window per UTC day so every mature tombstone is eventually reconsidered without
+  // materializing the table in JavaScript.
+  const windowCount = Math.ceil(objects.length / scanLimit);
+  const epochDay = Math.floor(now.getTime() / DAY_MS);
+  const windowIndex = (epochDay + modelIndex) % windowCount;
+  const start = windowIndex * scanLimit;
+  return {
+    candidates: objects.snapshot().slice(start, Math.min(start + scanLimit, objects.length)),
+    offset: start,
+  };
+}
+
+function reservedDeleteQuotas(batchLimit: number) {
+  const modelCount = CATALOG_MODEL_NAMES.length;
+  const quotaPerModel = Math.floor(batchLimit / modelCount);
+  const extraSlots = batchLimit % modelCount;
+
+  return CATALOG_MODEL_NAMES.map((_, modelIndex) =>
+    modelIndex < extraSlots ? quotaPerModel + 1 : quotaPerModel
+  );
+}
+
+function incrementBlocker(result: CatalogGcModelResult, blocker: string) {
+  result.blockers[blocker] = (result.blockers[blocker] ?? 0) + 1;
+  result.skipped += 1;
+}
+
+function reportGcResult(result: CatalogGarbageCollectionResult) {
+  for (const modelName of CATALOG_MODEL_NAMES) {
+    const modelResult = result.models[modelName];
+    reportCatalogMaintenance('collected', modelName, modelResult.collected, {
+      cutoff: result.cutoff.toISOString(),
+      scanned: modelResult.scanned,
+    });
+    reportCatalogMaintenance('collection-skipped', modelName, modelResult.skipped, {
+      blockers: modelResult.blockers,
+      cutoff: result.cutoff.toISOString(),
+      deferred: modelResult.deferred,
+      mature: modelResult.mature,
+      scanOffset: modelResult.scanOffset,
+      scanned: modelResult.scanned,
+    });
+  }
+}
+
+/**
+ * Physically deletes eligible catalog tombstones.
+ *
+ * Cold-start contract: call this exactly once after Realm.open() and before publishing that Realm
+ * to React, CarPlay, the player, LibraryIndex, or any other consumer. No physical collection should
+ * run while a session is live; PlayerState is the durable root for the queue at this boundary.
+ */
+export function runColdStartCatalogGarbageCollection(
+  realm: Realm,
+  options: CatalogGarbageCollectionOptions = {}
+): CatalogGarbageCollectionResult {
+  if (realm.isClosed) throw new Error('Cannot collect a closed Realm');
+
+  const now = options.now ?? new Date();
+  const gracePeriodMs = requireNonNegativeNumber(
+    options.gracePeriodMs ?? DEFAULT_CATALOG_GC_GRACE_PERIOD_MS,
+    'gracePeriodMs'
+  );
+  const batchLimit = requireNonNegativeInteger(
+    options.batchLimit ?? DEFAULT_CATALOG_GC_BATCH_LIMIT,
+    'batchLimit'
+  );
+  if (batchLimit > 0 && batchLimit < CATALOG_MODEL_NAMES.length) {
+    throw new Error(
+      `batchLimit must be 0 or at least ${CATALOG_MODEL_NAMES.length} so every catalog model has a reserved GC slot`
+    );
+  }
+  const scanLimitPerModel = requireNonNegativeInteger(
+    options.scanLimitPerModel ?? batchLimit * DEFAULT_CATALOG_GC_SCAN_MULTIPLIER,
+    'scanLimitPerModel'
+  );
+  const cutoff = new Date(now.getTime() - gracePeriodMs);
+  const collected = emptyCatalogModelCounts();
+  const models = emptyModelResults();
+  const context: GcContext = {
+    realm,
+    queuedSourceTrackUuids: collectQueuedSourceTrackUuids(realm),
+    favoriteClosure: new Map(),
+  };
+
+  const sweep = () => {
+    const states: ModelSweepState[] = [];
+    for (let modelIndex = 0; modelIndex < CATALOG_MODEL_NAMES.length; modelIndex += 1) {
+      const modelName = CATALOG_MODEL_NAMES[modelIndex];
+      const modelResult = models[modelName];
+      const matureObjects = matureCatalogObjects(realm, modelName, cutoff);
+      modelResult.mature = matureObjects.length;
+
+      const candidateWindow = boundedCandidateWindow(
+        matureObjects,
+        scanLimitPerModel,
+        now,
+        modelIndex
+      );
+      modelResult.scanOffset = candidateWindow.offset;
+      states.push({
+        modelName,
+        result: modelResult,
+        candidates: candidateWindow.candidates,
+        nextCandidateIndex: 0,
+      });
+    }
+
+    const collectFromState = (state: ModelSweepState, deleteLimit: number) => {
+      let deleted = 0;
+
+      while (deleted < deleteLimit && state.nextCandidateIndex < state.candidates.length) {
+        const object = state.candidates[state.nextCandidateIndex];
+        state.nextCandidateIndex += 1;
+
+        state.result.scanned += 1;
+        const blocker = collectionBlocker(context, object);
+        if (blocker) {
+          incrementBlocker(state.result, blocker);
+          continue;
+        }
+
+        realm.delete(object);
+        state.result.collected += 1;
+        collected[state.modelName] += 1;
+        deleted += 1;
+      }
+
+      return deleted;
+    };
+
+    // The first child-to-parent pass reserves a fair slice for every model. This prevents a large
+    // SourceTrack backlog from consuming the whole batch before later catalog classes are visited.
+    const reservedQuotas = reservedDeleteQuotas(batchLimit);
+    let remainingDeletes = batchLimit;
+    for (let modelIndex = 0; modelIndex < states.length; modelIndex += 1) {
+      remainingDeletes -= collectFromState(states[modelIndex], reservedQuotas[modelIndex]);
+    }
+
+    // Recycle empty or blocked reservations. Resuming each bounded snapshot avoids rescanning
+    // blockers, and a second child-to-parent pass preserves collection ordering.
+    for (const state of states) {
+      if (remainingDeletes === 0) break;
+      remainingDeletes -= collectFromState(state, remainingDeletes);
+    }
+
+    for (const state of states) {
+      state.result.deferred = Math.max(0, state.result.mature - state.result.scanned);
+    }
+  };
+
+  if (realm.isInTransaction) {
+    sweep();
+  } else {
+    realm.write(sweep);
+  }
+
+  const result: CatalogGarbageCollectionResult = {
+    now,
+    cutoff,
+    gracePeriodMs,
+    batchLimit,
+    scanLimitPerModel,
+    collected,
+    totalCollected: CATALOG_MODEL_NAMES.reduce((sum, modelName) => sum + collected[modelName], 0),
+    totalScanned: CATALOG_MODEL_NAMES.reduce(
+      (sum, modelName) => sum + models[modelName].scanned,
+      0
+    ),
+    totalSkipped: CATALOG_MODEL_NAMES.reduce(
+      (sum, modelName) => sum + models[modelName].skipped,
+      0
+    ),
+    models,
+  };
+
+  reportGcResult(result);
+  if (options.auditGraph ?? true) {
+    result.graphAudit = auditCatalogRetirementGraph(realm);
+  }
+
+  return result;
+}

--- a/relisten/realm/catalog_integrity.test.ts
+++ b/relisten/realm/catalog_integrity.test.ts
@@ -1,0 +1,350 @@
+/// <reference types="node" />
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import * as Sentry from '@sentry/react-native';
+import Realm from 'realm';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const blockedOfflineFiles = vi.hoisted(() => new Set<string>());
+
+vi.mock('expo-file-system', () => ({
+  File: class {
+    constructor(private path: string) {}
+
+    get exists() {
+      return blockedOfflineFiles.has(this.path);
+    }
+
+    delete() {
+      if (blockedOfflineFiles.has(this.path)) throw new Error('blocked test file');
+    }
+  },
+  Paths: {
+    document: '/tmp',
+    join: (...parts: string[]) => parts.join('/'),
+  },
+}));
+
+import { FlacType } from '@/relisten/api/models/source';
+import { repairCatalogIntegrityAtStartup } from '@/relisten/realm/catalog_integrity';
+import { activeCatalogObjectForPrimaryKey } from '@/relisten/realm/catalog_retirement';
+import { Artist } from '@/relisten/realm/models/artist';
+import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
+import { cleanupPlaybackHistoryAtStartup } from '@/relisten/realm/models/history/playback_history_lifecycle';
+import {
+  Popularity,
+  PopularityWindow,
+  PopularityWindows,
+} from '@/relisten/realm/models/popularity';
+import { Show } from '@/relisten/realm/models/show';
+import { Song } from '@/relisten/realm/models/song';
+import { Source } from '@/relisten/realm/models/source';
+import { SourceSet } from '@/relisten/realm/models/source_set';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
+import {
+  SourceTrackOfflineInfo,
+  SourceTrackOfflineInfoStatus,
+  SourceTrackOfflineInfoType,
+} from '@/relisten/realm/models/source_track_offline_info';
+import { PlayerState } from '@/relisten/realm/models/player_state';
+import { LastFmScrobbleEntry } from '@/relisten/realm/models/lastfm_scrobble_entry';
+import { Tour } from '@/relisten/realm/models/tour';
+import { Venue } from '@/relisten/realm/models/venue';
+import { Year } from '@/relisten/realm/models/year';
+import { collectTransientTombstonesAtStartup } from '@/relisten/realm/transient_tombstone_lifecycle';
+
+const NOW = new Date('2026-08-20T12:00:00.000Z');
+const openRealms: Realm[] = [];
+const tempDirectories: string[] = [];
+
+function temporaryRealm() {
+  const directory = mkdtempSync(join(tmpdir(), 'relisten-catalog-integrity-'));
+  tempDirectories.push(directory);
+  const realm = new Realm({
+    path: join(directory, 'test.realm'),
+    schema: [
+      Artist,
+      Year,
+      Show,
+      Venue,
+      Tour,
+      Song,
+      Source,
+      SourceSet,
+      SourceTrack,
+      SourceTrackOfflineInfo,
+      PlaybackHistoryEntry,
+      PlayerState,
+      LastFmScrobbleEntry,
+      Popularity,
+      PopularityWindow,
+      PopularityWindows,
+    ],
+  });
+  openRealms.push(realm);
+  return realm;
+}
+
+function createArtist(realm: Realm) {
+  return realm.create(Artist, {
+    uuid: 'artist',
+    createdAt: NOW,
+    updatedAt: NOW,
+    musicbrainzId: '',
+    name: 'Artist',
+    featured: 0,
+    slug: 'artist',
+    sortName: 'Artist',
+    featuresRaw: '{}',
+    upstreamSourcesRaw: '[]',
+    showCount: 1,
+    sourceCount: 1,
+    isFavorite: false,
+  });
+}
+
+function createYear(realm: Realm) {
+  return realm.create(Year, {
+    uuid: 'year',
+    createdAt: NOW,
+    updatedAt: NOW,
+    artistUuid: 'artist',
+    showCount: 1,
+    sourceCount: 1,
+    year: '2026',
+  });
+}
+
+function createShow(realm: Realm, artist?: Artist) {
+  return realm.create(Show, {
+    uuid: 'show',
+    artistUuid: 'artist',
+    yearUuid: 'year',
+    createdAt: NOW,
+    updatedAt: NOW,
+    date: NOW,
+    avgRating: 0,
+    displayDate: '2026-08-20',
+    mostRecentSourceUpdatedAt: NOW,
+    hasSoundboardSource: false,
+    hasStreamableFlacSource: false,
+    sourceCount: 1,
+    artist,
+    isFavorite: false,
+  });
+}
+
+function createSource(realm: Realm, artist?: Artist) {
+  return realm.create(Source, {
+    uuid: 'source',
+    createdAt: NOW,
+    updatedAt: NOW,
+    artistUuid: 'artist',
+    showUuid: 'show',
+    displayDate: '2026-08-20',
+    isSoundboard: false,
+    isRemaster: false,
+    hasJamcharts: false,
+    avgRating: 0,
+    numReviews: 0,
+    avgRatingWeighted: 0,
+    upstreamIdentifier: 'source',
+    flacType: FlacType.NoFlac,
+    reviewCount: 0,
+    linksRaw: '[]',
+    sourceSets: [],
+    artist,
+    isFavorite: false,
+  });
+}
+
+function createTrack(
+  realm: Realm,
+  links: { artist?: Artist; year?: Year; show?: Show; source?: Source } = {}
+) {
+  return realm.create(SourceTrack, {
+    uuid: 'track',
+    createdAt: NOW,
+    updatedAt: NOW,
+    artistUuid: 'artist',
+    sourceUuid: 'source',
+    sourceSetUuid: 'set',
+    showUuid: 'show',
+    trackPosition: 1,
+    title: 'Track',
+    slug: 'track',
+    mp3Url: 'https://example.test/track.mp3',
+    isFavorite: false,
+    ...links,
+  });
+}
+
+afterEach(() => {
+  for (const realm of openRealms.splice(0)) {
+    if (!realm.isClosed) realm.close();
+  }
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+  blockedOfflineFiles.clear();
+  vi.clearAllMocks();
+});
+
+describe('catalog integrity repair', () => {
+  it('relinks every required semantic link from surviving scalar UUIDs', () => {
+    const realm = temporaryRealm();
+    let artist!: Artist;
+    let year!: Year;
+    let show!: Show;
+    let source!: Source;
+    let track!: SourceTrack;
+    realm.write(() => {
+      artist = createArtist(realm);
+      year = createYear(realm);
+      show = createShow(realm);
+      source = createSource(realm);
+      track = createTrack(realm);
+    });
+
+    const result = repairCatalogIntegrityAtStartup(realm);
+
+    expect(result.totalRelinked).toBe(6);
+    expect(result.totalQuarantinedRoots).toBe(0);
+    expect(show.artist.uuid).toBe(artist.uuid);
+    expect(source.artist.uuid).toBe(artist.uuid);
+    expect(track.artist.uuid).toBe(artist.uuid);
+    expect(track.year.uuid).toBe(year.uuid);
+    expect(track.show.uuid).toBe(show.uuid);
+    expect(track.source.uuid).toBe(source.uuid);
+  });
+
+  it('quarantines an unrecoverable track and reports one aggregate diagnostic', () => {
+    const realm = temporaryRealm();
+    let track!: SourceTrack;
+    realm.write(() => {
+      const artist = createArtist(realm);
+      const show = createShow(realm, artist);
+      const source = createSource(realm, artist);
+      track = createTrack(realm, { artist, show, source });
+    });
+
+    const result = repairCatalogIntegrityAtStartup(realm);
+
+    expect(result.newlyQuarantinedRoots.SourceTrack).toBe(1);
+    expect(track.isValid()).toBe(true);
+    expect(track.retiredAt).toBeInstanceOf(Date);
+    expect(track.retirementReason).toBe('catalog-integrity:missing-year');
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Unrecoverable Realm catalog graphs were quarantined',
+      expect.anything()
+    );
+  });
+
+  it('rejects and reports an incomplete point read', () => {
+    const realm = temporaryRealm();
+    realm.write(() => {
+      createArtist(realm);
+      createShow(realm);
+    });
+
+    expect(
+      activeCatalogObjectForPrimaryKey(realm, Show, 'show', 'test.incomplete-show')
+    ).toBeUndefined();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Structurally incomplete Realm catalog object was accessed',
+      expect.anything()
+    );
+  });
+});
+
+describe('playback history startup quarantine', () => {
+  it('keeps a newly malformed tombstone for one reboot before bounded collection', () => {
+    const realm = temporaryRealm();
+    let entry!: PlaybackHistoryEntry;
+    let deferredEntry!: PlaybackHistoryEntry;
+    realm.write(() => {
+      const artist = createArtist(realm);
+      const show = createShow(realm, artist);
+      const source = createSource(realm, artist);
+      const track = createTrack(realm, { artist, show, source });
+      entry = realm.create(PlaybackHistoryEntry, {
+        uuid: 'history',
+        playbackFlags: 0,
+        createdAt: NOW,
+        playbackStartedAt: NOW,
+        sourceTrack: track,
+        artist,
+        show,
+        source,
+      });
+      deferredEntry = realm.create(PlaybackHistoryEntry, {
+        uuid: 'history-deferred',
+        playbackFlags: 0,
+        createdAt: NOW,
+        playbackStartedAt: NOW,
+        sourceTrack: track,
+        artist,
+        show,
+        source,
+      });
+    });
+
+    const firstBoot = cleanupPlaybackHistoryAtStartup(realm, {
+      batchLimit: 1,
+      quarantineBatchLimit: 1,
+      now: NOW,
+    });
+
+    expect(firstBoot.newlyQuarantined).toBe(1);
+    expect(firstBoot.quarantineDeferred).toBe(1);
+    expect(firstBoot.physicallyDeleted).toBe(0);
+    expect(entry.isValid()).toBe(true);
+    expect(entry.deletedAt).toEqual(NOW);
+    expect(deferredEntry.deletedAt).toBeNull();
+
+    const secondBoot = cleanupPlaybackHistoryAtStartup(realm, { batchLimit: 1 });
+    expect(secondBoot.physicallyDeleted).toBe(1);
+    expect(secondBoot.newlyQuarantined).toBe(1);
+    expect(entry.isValid()).toBe(false);
+    expect(deferredEntry.deletedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('transient tombstone startup collection', () => {
+  it('rotates failed offline-file cleanup behind later tombstones', () => {
+    const realm = temporaryRealm();
+    const deletedAt = new Date('2026-01-01T00:00:00.000Z');
+    realm.write(() => {
+      for (const sourceTrackUuid of ['blocked-a', 'blocked-b', 'collectable-c']) {
+        realm.create(SourceTrackOfflineInfo, {
+          sourceTrackUuid,
+          status: SourceTrackOfflineInfoStatus.Failed,
+          type: SourceTrackOfflineInfoType.UserInitiated,
+          queuedAt: deletedAt,
+          deletedAt,
+        });
+      }
+    });
+    blockedOfflineFiles.add('/tmp/offline/blocked-a.mp3');
+    blockedOfflineFiles.add('/tmp/offline/blocked-b.mp3');
+
+    const firstBoot = collectTransientTombstonesAtStartup(realm, {
+      batchLimitPerModel: 2,
+      now: NOW,
+    });
+    expect(firstBoot.sourceTrackOfflineInfos).toBe(0);
+    expect(firstBoot.deferred.sourceTrackOfflineInfos).toBe(3);
+
+    const secondBoot = collectTransientTombstonesAtStartup(realm, {
+      batchLimitPerModel: 2,
+      now: new Date('2026-08-21T12:00:00.000Z'),
+    });
+    expect(secondBoot.sourceTrackOfflineInfos).toBe(1);
+    expect(realm.objectForPrimaryKey(SourceTrackOfflineInfo, 'collectable-c')).toBeNull();
+    expect(realm.objectForPrimaryKey(SourceTrackOfflineInfo, 'blocked-a')).not.toBeNull();
+    expect(realm.objectForPrimaryKey(SourceTrackOfflineInfo, 'blocked-b')).not.toBeNull();
+  });
+});

--- a/relisten/realm/catalog_integrity.ts
+++ b/relisten/realm/catalog_integrity.ts
@@ -1,0 +1,327 @@
+import * as Sentry from '@sentry/react-native';
+import Realm from 'realm';
+
+import { reportCatalogMaintenance } from '@/relisten/realm/catalog_access_monitor';
+import {
+  CatalogModelCounts,
+  CATALOG_MODEL_NAMES,
+  emptyCatalogModelCounts,
+  retireCatalogGraph,
+} from '@/relisten/realm/catalog_retirement_graph';
+import {
+  catalogStructuralIssues,
+  CatalogStructuralIssue,
+} from '@/relisten/realm/catalog_integrity_validation';
+import { Artist } from '@/relisten/realm/models/artist';
+import { Show } from '@/relisten/realm/models/show';
+import { Source } from '@/relisten/realm/models/source';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
+import { Year } from '@/relisten/realm/models/year';
+import { log } from '@/relisten/util/logging';
+
+const logger = log.extend('catalog-integrity');
+
+const ARTIST_LINK_REPAIR_QUERY =
+  'artist == nil OR artist.uuid != artistUuid OR (retiredAt == nil AND artist.retiredAt != nil)';
+const SOURCE_TRACK_REPAIR_QUERY = [
+  'artist == nil',
+  'artist.uuid != artistUuid',
+  'show == nil',
+  'show.uuid != showUuid',
+  'source == nil',
+  'source.uuid != sourceUuid',
+  'year == nil',
+  'year.uuid != show.yearUuid',
+  'show.artistUuid != artistUuid',
+  'source.artistUuid != artistUuid',
+  'source.showUuid != showUuid',
+  '(retiredAt == nil AND artist.retiredAt != nil)',
+  '(retiredAt == nil AND show.retiredAt != nil)',
+  '(retiredAt == nil AND source.retiredAt != nil)',
+  '(retiredAt == nil AND year.retiredAt != nil)',
+].join(' OR ');
+
+export const CATALOG_INTEGRITY_QUARANTINE_REASON_PREFIX = 'catalog-integrity';
+
+export const CATALOG_INTEGRITY_RELINK_NAMES = [
+  'Show.artist',
+  'Source.artist',
+  'SourceTrack.artist',
+  'SourceTrack.show',
+  'SourceTrack.source',
+  'SourceTrack.year',
+] as const;
+
+type CatalogIntegrityRelinkName = (typeof CATALOG_INTEGRITY_RELINK_NAMES)[number];
+type RepairableCatalogModelName = 'Show' | 'Source' | 'SourceTrack';
+
+export interface CatalogIntegrityRepairResult {
+  context: string;
+  candidates: Record<RepairableCatalogModelName, number>;
+  relinked: Record<CatalogIntegrityRelinkName, number>;
+  quarantinedRoots: Record<RepairableCatalogModelName, number>;
+  newlyQuarantinedRoots: Record<RepairableCatalogModelName, number>;
+  retired: CatalogModelCounts;
+  issues: Partial<Record<CatalogStructuralIssue, number>>;
+  totalRelinked: number;
+  totalQuarantinedRoots: number;
+  totalNewlyQuarantinedRoots: number;
+  totalRetired: number;
+}
+
+export interface CatalogIntegrityRepairScope {
+  shows?: Iterable<Show>;
+  sources?: Iterable<Source>;
+  sourceTracks?: Iterable<SourceTrack>;
+}
+
+function emptyRepairResult(context: string): CatalogIntegrityRepairResult {
+  return {
+    context,
+    candidates: { Show: 0, Source: 0, SourceTrack: 0 },
+    relinked: {
+      'Show.artist': 0,
+      'Source.artist': 0,
+      'SourceTrack.artist': 0,
+      'SourceTrack.show': 0,
+      'SourceTrack.source': 0,
+      'SourceTrack.year': 0,
+    },
+    quarantinedRoots: { Show: 0, Source: 0, SourceTrack: 0 },
+    newlyQuarantinedRoots: { Show: 0, Source: 0, SourceTrack: 0 },
+    retired: emptyCatalogModelCounts(),
+    issues: {},
+    totalRelinked: 0,
+    totalQuarantinedRoots: 0,
+    totalNewlyQuarantinedRoots: 0,
+    totalRetired: 0,
+  };
+}
+
+function uniqueValidObjects<T extends { uuid: string; isValid(): boolean }>(objects: Iterable<T>) {
+  const byUuid = new Map<string, T>();
+  for (const object of objects) {
+    if (object.isValid()) byUuid.set(object.uuid, object);
+  }
+  return [...byUuid.values()];
+}
+
+function countIssue(result: CatalogIntegrityRepairResult, issue: CatalogStructuralIssue) {
+  result.issues[issue] = (result.issues[issue] ?? 0) + 1;
+}
+
+function addRetirementCounts(result: CatalogIntegrityRepairResult, counts: CatalogModelCounts) {
+  for (const modelName of CATALOG_MODEL_NAMES) {
+    result.retired[modelName] += counts[modelName];
+    result.totalRetired += counts[modelName];
+  }
+}
+
+function quarantine(
+  realm: Realm,
+  result: CatalogIntegrityRepairResult,
+  root: Show | Source | SourceTrack,
+  issue: CatalogStructuralIssue
+) {
+  const modelName = root.objectSchema().name as RepairableCatalogModelName;
+  const wasActive = root.retiredAt == null;
+  result.quarantinedRoots[modelName] += 1;
+  result.totalQuarantinedRoots += 1;
+  countIssue(result, issue);
+
+  const retirement = retireCatalogGraph(realm, root, {
+    reason: `${CATALOG_INTEGRITY_QUARANTINE_REASON_PREFIX}:${issue}`,
+    report: false,
+  });
+  addRetirementCounts(result, retirement.counts);
+
+  if (wasActive && root.retiredAt != null) {
+    result.newlyQuarantinedRoots[modelName] += 1;
+    result.totalNewlyQuarantinedRoots += 1;
+  }
+}
+
+function canLinkActiveOwner(owner: Show | Source | SourceTrack, target: { retiredAt?: Date }) {
+  return owner.retiredAt != null || target.retiredAt == null;
+}
+
+function relinkShow(realm: Realm, result: CatalogIntegrityRepairResult, show: Show) {
+  result.candidates.Show += 1;
+  const artist = realm.objectForPrimaryKey(Artist, show.artistUuid);
+
+  if (!artist) {
+    quarantine(realm, result, show, 'missing-artist');
+    return;
+  }
+  if (!canLinkActiveOwner(show, artist)) {
+    quarantine(realm, result, show, 'retired-artist');
+    return;
+  }
+
+  if (!show.artist || show.artist.uuid !== artist.uuid) {
+    show.artist = artist;
+    result.relinked['Show.artist'] += 1;
+    result.totalRelinked += 1;
+  }
+}
+
+function relinkSource(realm: Realm, result: CatalogIntegrityRepairResult, source: Source) {
+  result.candidates.Source += 1;
+  const artist = realm.objectForPrimaryKey(Artist, source.artistUuid);
+
+  if (!artist) {
+    quarantine(realm, result, source, 'missing-artist');
+    return;
+  }
+  if (!canLinkActiveOwner(source, artist)) {
+    quarantine(realm, result, source, 'retired-artist');
+    return;
+  }
+
+  if (!source.artist || source.artist.uuid !== artist.uuid) {
+    source.artist = artist;
+    result.relinked['Source.artist'] += 1;
+    result.totalRelinked += 1;
+  }
+}
+
+function relinkSourceTrack(realm: Realm, result: CatalogIntegrityRepairResult, track: SourceTrack) {
+  result.candidates.SourceTrack += 1;
+  const artist = realm.objectForPrimaryKey(Artist, track.artistUuid);
+  const show = realm.objectForPrimaryKey(Show, track.showUuid);
+  const source = realm.objectForPrimaryKey(Source, track.sourceUuid);
+  const year = show ? realm.objectForPrimaryKey(Year, show.yearUuid) : undefined;
+
+  let quarantineIssue: CatalogStructuralIssue | undefined;
+  if (!artist) quarantineIssue = 'missing-artist';
+  else if (!show) quarantineIssue = 'missing-show';
+  else if (!source) quarantineIssue = 'missing-source';
+  else if (!year) quarantineIssue = 'missing-year';
+  else if (show.artistUuid !== track.artistUuid) quarantineIssue = 'show-artist-mismatch';
+  else if (source.artistUuid !== track.artistUuid) quarantineIssue = 'source-artist-mismatch';
+  else if (source.showUuid !== track.showUuid) quarantineIssue = 'source-show-mismatch';
+  else if (!canLinkActiveOwner(track, artist)) quarantineIssue = 'retired-artist';
+  else if (!canLinkActiveOwner(track, show)) quarantineIssue = 'retired-show';
+  else if (!canLinkActiveOwner(track, source)) quarantineIssue = 'retired-source';
+  else if (!canLinkActiveOwner(track, year)) quarantineIssue = 'retired-year';
+
+  const links: Array<
+    [
+      CatalogIntegrityRelinkName,
+      'artist' | 'show' | 'source' | 'year',
+      Artist | Show | Source | Year | null | undefined,
+    ]
+  > = [
+    ['SourceTrack.artist', 'artist', artist],
+    ['SourceTrack.show', 'show', show],
+    ['SourceTrack.source', 'source', source],
+    ['SourceTrack.year', 'year', year],
+  ];
+
+  for (const [edge, property, target] of links) {
+    if (
+      target &&
+      canLinkActiveOwner(track, target) &&
+      (!track[property] || track[property].uuid !== target.uuid)
+    ) {
+      track[property] = target as never;
+      result.relinked[edge] += 1;
+      result.totalRelinked += 1;
+    }
+  }
+
+  if (quarantineIssue) {
+    quarantine(realm, result, track, quarantineIssue);
+    return;
+  }
+
+  const unresolvedIssue = catalogStructuralIssues(track)[0];
+  if (unresolvedIssue) quarantine(realm, result, track, unresolvedIssue);
+}
+
+export function reportCatalogIntegrityRepair(result: CatalogIntegrityRepairResult) {
+  if (result.totalRelinked === 0 && result.totalQuarantinedRoots === 0) return;
+
+  const hasNewQuarantine = result.totalNewlyQuarantinedRoots > 0;
+  Sentry.addBreadcrumb({
+    category: 'realm.catalog-integrity',
+    level: hasNewQuarantine ? 'warning' : 'info',
+    message: 'Realm catalog integrity maintenance completed',
+    data: result,
+  });
+  if (hasNewQuarantine) logger.warn('Realm catalog integrity maintenance completed', result);
+  else logger.info('Realm catalog integrity maintenance completed', result);
+
+  for (const modelName of CATALOG_MODEL_NAMES) {
+    reportCatalogMaintenance('retired', modelName, result.retired[modelName], {
+      reason: CATALOG_INTEGRITY_QUARANTINE_REASON_PREFIX,
+      context: result.context,
+    });
+  }
+
+  if (hasNewQuarantine) {
+    Sentry.captureMessage('Unrecoverable Realm catalog graphs were quarantined', {
+      level: 'warning',
+      fingerprint: ['realm-catalog-integrity-quarantine', result.context],
+      tags: { realm_catalog_integrity_context: result.context },
+      extra: { ...result },
+    });
+  }
+}
+
+export function repairCatalogIntegrity(
+  realm: Realm,
+  scope: CatalogIntegrityRepairScope,
+  { context = 'scoped-reconciliation', report = true }: { context?: string; report?: boolean } = {}
+): CatalogIntegrityRepairResult {
+  const result = emptyRepairResult(context);
+  const shows = uniqueValidObjects(scope.shows ?? []);
+  const sources = uniqueValidObjects(scope.sources ?? []);
+  const sourceTracks = uniqueValidObjects(scope.sourceTracks ?? []);
+
+  const repair = () => {
+    for (const show of shows) relinkShow(realm, result, show);
+    for (const source of sources) relinkSource(realm, result, source);
+    for (const track of sourceTracks) relinkSourceTrack(realm, result, track);
+  };
+
+  if (realm.isInTransaction) repair();
+  else realm.write(repair);
+
+  if (report) reportCatalogIntegrityRepair(result);
+  return result;
+}
+
+/**
+ * Runs before consumers acquire managed objects. Native Realm predicates keep
+ * the scan limited to rows whose required direct links are missing,
+ * mismatched, or point from an active row into a tombstone.
+ */
+export function repairCatalogIntegrityAtStartup(realm: Realm): CatalogIntegrityRepairResult {
+  return repairCatalogIntegrity(
+    realm,
+    {
+      shows: realm.objects(Show).filtered(ARTIST_LINK_REPAIR_QUERY).snapshot(),
+      sources: realm.objects(Source).filtered(ARTIST_LINK_REPAIR_QUERY).snapshot(),
+      sourceTracks: realm.objects(SourceTrack).filtered(SOURCE_TRACK_REPAIR_QUERY).snapshot(),
+    },
+    { context: 'cold-start' }
+  );
+}
+
+export function ensureShowResponseCatalogIntegrity(
+  realm: Realm,
+  show: Show | null | undefined,
+  sources: Iterable<Source>,
+  sourceTracks: Iterable<SourceTrack>
+) {
+  return repairCatalogIntegrity(
+    realm,
+    {
+      shows: show ? [show] : [],
+      sources,
+      sourceTracks,
+    },
+    { context: 'show-api-reconciliation' }
+  );
+}

--- a/relisten/realm/catalog_integrity_validation.ts
+++ b/relisten/realm/catalog_integrity_validation.ts
@@ -1,0 +1,164 @@
+import type { RetireableCatalogObject } from '@/relisten/realm/catalog_access_monitor';
+
+export const CATALOG_STRUCTURAL_ISSUES = {
+  invalidRealmObject: 'invalid-realm-object',
+  missingArtist: 'missing-artist',
+  mismatchedArtist: 'mismatched-artist',
+  retiredArtist: 'retired-artist',
+  missingShow: 'missing-show',
+  mismatchedShow: 'mismatched-show',
+  retiredShow: 'retired-show',
+  missingSource: 'missing-source',
+  mismatchedSource: 'mismatched-source',
+  retiredSource: 'retired-source',
+  missingYear: 'missing-year',
+  mismatchedYear: 'mismatched-year',
+  retiredYear: 'retired-year',
+  showArtistMismatch: 'show-artist-mismatch',
+  sourceArtistMismatch: 'source-artist-mismatch',
+  sourceShowMismatch: 'source-show-mismatch',
+} as const;
+
+export type CatalogStructuralIssue =
+  (typeof CATALOG_STRUCTURAL_ISSUES)[keyof typeof CATALOG_STRUCTURAL_ISSUES];
+
+interface CatalogLink {
+  uuid: string;
+  retiredAt?: Date;
+}
+
+interface ShowShape extends RetireableCatalogObject {
+  artistUuid: string;
+  artist?: CatalogLink;
+}
+
+interface SourceShape extends RetireableCatalogObject {
+  artistUuid: string;
+  artist?: CatalogLink;
+}
+
+interface SourceTrackShape extends RetireableCatalogObject {
+  artistUuid: string;
+  showUuid: string;
+  sourceUuid: string;
+  artist?: CatalogLink;
+  show?: CatalogLink & { artistUuid: string; yearUuid: string };
+  source?: CatalogLink & { artistUuid: string; showUuid: string };
+  year?: CatalogLink;
+}
+
+function validateLink(
+  issues: CatalogStructuralIssue[],
+  link: CatalogLink | null | undefined,
+  expectedUuid: string,
+  missing: CatalogStructuralIssue,
+  mismatched: CatalogStructuralIssue,
+  retired: CatalogStructuralIssue,
+  ownerIsRetired: boolean
+) {
+  if (!link) {
+    issues.push(missing);
+    return;
+  }
+
+  if (link.uuid !== expectedUuid) {
+    issues.push(mismatched);
+  }
+  if (!ownerIsRetired && link.retiredAt) {
+    issues.push(retired);
+  }
+}
+
+/**
+ * Validates the direct links that consumers dereference without a nullable
+ * check. Scalar UUIDs are the repair authority because they survive a Realm
+ * target being physically removed by an older build.
+ */
+export function catalogStructuralIssues(object: RetireableCatalogObject): CatalogStructuralIssue[] {
+  if (!object.isValid()) {
+    return [CATALOG_STRUCTURAL_ISSUES.invalidRealmObject];
+  }
+
+  const issues: CatalogStructuralIssue[] = [];
+  const ownerIsRetired = object.retiredAt != null;
+
+  switch (object.objectSchema().name) {
+    case 'Show': {
+      const show = object as ShowShape;
+      validateLink(
+        issues,
+        show.artist,
+        show.artistUuid,
+        CATALOG_STRUCTURAL_ISSUES.missingArtist,
+        CATALOG_STRUCTURAL_ISSUES.mismatchedArtist,
+        CATALOG_STRUCTURAL_ISSUES.retiredArtist,
+        ownerIsRetired
+      );
+      break;
+    }
+    case 'Source': {
+      const source = object as SourceShape;
+      validateLink(
+        issues,
+        source.artist,
+        source.artistUuid,
+        CATALOG_STRUCTURAL_ISSUES.missingArtist,
+        CATALOG_STRUCTURAL_ISSUES.mismatchedArtist,
+        CATALOG_STRUCTURAL_ISSUES.retiredArtist,
+        ownerIsRetired
+      );
+      break;
+    }
+    case 'SourceTrack': {
+      const track = object as SourceTrackShape;
+      validateLink(
+        issues,
+        track.artist,
+        track.artistUuid,
+        CATALOG_STRUCTURAL_ISSUES.missingArtist,
+        CATALOG_STRUCTURAL_ISSUES.mismatchedArtist,
+        CATALOG_STRUCTURAL_ISSUES.retiredArtist,
+        ownerIsRetired
+      );
+      validateLink(
+        issues,
+        track.show,
+        track.showUuid,
+        CATALOG_STRUCTURAL_ISSUES.missingShow,
+        CATALOG_STRUCTURAL_ISSUES.mismatchedShow,
+        CATALOG_STRUCTURAL_ISSUES.retiredShow,
+        ownerIsRetired
+      );
+      validateLink(
+        issues,
+        track.source,
+        track.sourceUuid,
+        CATALOG_STRUCTURAL_ISSUES.missingSource,
+        CATALOG_STRUCTURAL_ISSUES.mismatchedSource,
+        CATALOG_STRUCTURAL_ISSUES.retiredSource,
+        ownerIsRetired
+      );
+
+      if (!track.year) {
+        issues.push(CATALOG_STRUCTURAL_ISSUES.missingYear);
+      } else if (track.show && track.year.uuid !== track.show.yearUuid) {
+        issues.push(CATALOG_STRUCTURAL_ISSUES.mismatchedYear);
+      } else if (!ownerIsRetired && track.year.retiredAt) {
+        issues.push(CATALOG_STRUCTURAL_ISSUES.retiredYear);
+      }
+
+      if (track.show && track.show.artistUuid !== track.artistUuid) {
+        issues.push(CATALOG_STRUCTURAL_ISSUES.showArtistMismatch);
+      }
+      if (track.source && track.source.artistUuid !== track.artistUuid) {
+        issues.push(CATALOG_STRUCTURAL_ISSUES.sourceArtistMismatch);
+      }
+      if (track.source && track.source.showUuid !== track.showUuid) {
+        issues.push(CATALOG_STRUCTURAL_ISSUES.sourceShowMismatch);
+      }
+      break;
+    }
+  }
+
+  return issues;
+}

--- a/relisten/realm/catalog_retirement.test.ts
+++ b/relisten/realm/catalog_retirement.test.ts
@@ -1,0 +1,487 @@
+/// <reference types="node" />
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import * as Sentry from '@sentry/react-native';
+import Realm from 'realm';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  activeCatalogObjectForPrimaryKey,
+  activeCatalogObjects,
+} from '@/relisten/realm/catalog_retirement';
+import { resetCatalogAccessMonitorForTests } from '@/relisten/realm/catalog_access_monitor';
+import {
+  auditCatalogRetirementGraph,
+  retireCatalogGraph,
+} from '@/relisten/realm/catalog_retirement_graph';
+import { Artist } from '@/relisten/realm/models/artist';
+import {
+  Popularity,
+  PopularityWindow,
+  PopularityWindows,
+} from '@/relisten/realm/models/popularity';
+import { Show } from '@/relisten/realm/models/show';
+import { Song } from '@/relisten/realm/models/song';
+import { Source } from '@/relisten/realm/models/source';
+import { SourceSet } from '@/relisten/realm/models/source_set';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
+import { SourceTrackOfflineInfo } from '@/relisten/realm/models/source_track_offline_info';
+import { Tour } from '@/relisten/realm/models/tour';
+import { Venue } from '@/relisten/realm/models/venue';
+import { Year } from '@/relisten/realm/models/year';
+import { Repository } from '@/relisten/realm/repository';
+import { ActiveCatalogObjectValueStream } from '@/relisten/realm/value_streams';
+
+interface VenueProperties {
+  uuid: string;
+  createdAt: Date;
+  updatedAt: Date;
+  name: string;
+}
+
+interface VenueApi {
+  uuid: string;
+  created_at: string;
+  updated_at: string;
+  name: string;
+}
+
+class TestVenue extends Realm.Object<TestVenue, keyof VenueProperties> implements VenueProperties {
+  static schema: Realm.ObjectSchema = {
+    name: 'Venue',
+    primaryKey: 'uuid',
+    properties: {
+      uuid: 'string',
+      createdAt: 'date',
+      updatedAt: 'date',
+      name: 'string',
+      retiredAt: { type: 'date', optional: true, indexed: true },
+      retirementReason: 'string?',
+    },
+  };
+
+  declare uuid: string;
+  declare createdAt: Date;
+  declare updatedAt: Date;
+  declare name: string;
+  declare retiredAt?: Date;
+  declare retirementReason?: string;
+
+  static propertiesFromApi(api: VenueApi): VenueProperties {
+    return {
+      uuid: api.uuid,
+      createdAt: new Date(api.created_at),
+      updatedAt: new Date(api.updated_at),
+      name: api.name,
+    };
+  }
+}
+
+class TestTour extends Realm.Object<TestTour> {
+  static schema: Realm.ObjectSchema = {
+    name: 'Tour',
+    primaryKey: 'uuid',
+    properties: {
+      uuid: 'string',
+      retiredAt: { type: 'date', optional: true, indexed: true },
+      retirementReason: 'string?',
+    },
+  };
+
+  declare uuid: string;
+  declare retiredAt?: Date;
+  declare retirementReason?: string;
+}
+
+class TestShow extends Realm.Object<TestShow> {
+  static schema: Realm.ObjectSchema = {
+    name: 'Show',
+    primaryKey: 'uuid',
+    properties: {
+      uuid: 'string',
+      retiredAt: { type: 'date', optional: true, indexed: true },
+      retirementReason: 'string?',
+      venueUuid: 'string?',
+      tourUuid: 'string?',
+      venue: 'Venue?',
+      tour: 'Tour?',
+    },
+  };
+
+  declare uuid: string;
+  declare retiredAt?: Date;
+  declare retirementReason?: string;
+  declare venueUuid?: string;
+  declare tourUuid?: string;
+  declare venue?: TestVenue;
+  declare tour?: TestTour;
+}
+
+const openRealms: Realm[] = [];
+const tempDirectories: string[] = [];
+
+function temporaryRealm(schemaVersion = 13) {
+  const directory = mkdtempSync(join(tmpdir(), 'relisten-catalog-retirement-'));
+  tempDirectories.push(directory);
+  const realm = new Realm({
+    path: join(directory, 'test.realm'),
+    schema: [TestVenue, TestTour, TestShow],
+    schemaVersion,
+  });
+  openRealms.push(realm);
+  return realm;
+}
+
+function temporaryCatalogRealm() {
+  const directory = mkdtempSync(join(tmpdir(), 'relisten-catalog-graph-'));
+  tempDirectories.push(directory);
+  const realm = new Realm({
+    path: join(directory, 'test.realm'),
+    schema: [
+      Artist,
+      Year,
+      Show,
+      Venue,
+      Tour,
+      Song,
+      Source,
+      SourceSet,
+      SourceTrack,
+      SourceTrackOfflineInfo,
+      Popularity,
+      PopularityWindow,
+      PopularityWindows,
+    ],
+    schemaVersion: 1,
+  });
+  openRealms.push(realm);
+  return realm;
+}
+
+function createVenue(realm: Realm, uuid: string, updatedAt: Date) {
+  return realm.write(
+    () =>
+      new TestVenue(realm, {
+        uuid,
+        createdAt: updatedAt,
+        updatedAt,
+        name: uuid,
+      })
+  );
+}
+
+afterEach(() => {
+  for (const realm of openRealms.splice(0)) {
+    if (!realm.isClosed) realm.close();
+  }
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+  resetCatalogAccessMonitorForTests();
+  vi.clearAllMocks();
+});
+
+describe('catalog retirement', () => {
+  it('retires a missing authoritative row without invalidating its managed object', () => {
+    const realm = temporaryRealm();
+    const updatedAt = new Date('2026-01-01T00:00:00.000Z');
+    const retiredAt = new Date('2026-02-01T00:00:00.000Z');
+    const retained = createVenue(realm, 'retained', updatedAt);
+    const missing = createVenue(realm, 'missing', updatedAt);
+    const repository = new Repository(TestVenue);
+
+    const result = repository.upsertMultiple(
+      realm,
+      [
+        {
+          uuid: retained.uuid,
+          created_at: updatedAt.toISOString(),
+          updated_at: updatedAt.toISOString(),
+          name: retained.name,
+        },
+      ],
+      activeCatalogObjects(realm, TestVenue),
+      { retiredAt }
+    );
+
+    expect(result.retired).toBe(1);
+    expect(result.retiredModels).toEqual([missing]);
+    expect(missing.isValid()).toBe(true);
+    expect(missing.retiredAt).toEqual(retiredAt);
+    expect(missing.retirementReason).toBe('api-reconciliation');
+    expect(activeCatalogObjects(realm, TestVenue).map((venue) => venue.uuid)).toEqual(['retained']);
+  });
+
+  it('resurrects the same row even when the API timestamp has not changed', () => {
+    const realm = temporaryRealm();
+    const updatedAt = new Date('2026-01-01T00:00:00.000Z');
+    const venue = createVenue(realm, 'venue', updatedAt);
+    const repository = new Repository(TestVenue);
+
+    realm.write(() => {
+      venue.retiredAt = new Date('2026-02-01T00:00:00.000Z');
+      venue.retirementReason = 'test';
+    });
+
+    const result = repository.upsertMultiple(
+      realm,
+      [
+        {
+          uuid: venue.uuid,
+          created_at: updatedAt.toISOString(),
+          updated_at: updatedAt.toISOString(),
+          name: venue.name,
+        },
+      ],
+      activeCatalogObjects(realm, TestVenue)
+    );
+
+    expect(result.created).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.restored).toBe(1);
+    expect(result.restoredModels).toEqual([venue]);
+    expect(venue.isValid()).toBe(true);
+    expect(venue.retiredAt).toBeNull();
+    expect(venue.retirementReason).toBeNull();
+    expect(realm.objects(TestVenue).length).toBe(1);
+  });
+
+  it('preserves a Venue omitted by an authoritative response while an active Show names it', () => {
+    const realm = temporaryRealm();
+    const venue = createVenue(realm, 'venue', new Date('2026-01-01T00:00:00.000Z'));
+    const repository = new Repository(TestVenue);
+    realm.write(() => {
+      new TestShow(realm, { uuid: 'show', venueUuid: venue.uuid });
+    });
+
+    const result = repository.upsertMultiple(realm, [], [venue]);
+
+    expect(result.retired).toBe(0);
+    expect(result.retiredModels).toEqual([]);
+    expect(venue.retiredAt).toBeNull();
+  });
+
+  it('preserves a Tour reached by an active Show direct link', () => {
+    const realm = temporaryRealm();
+    let tour!: TestTour;
+    realm.write(() => {
+      tour = new TestTour(realm, { uuid: 'tour' });
+      new TestShow(realm, { uuid: 'show', tour });
+    });
+
+    const result = retireCatalogGraph(realm, tour, {
+      reason: 'test',
+      report: false,
+    });
+
+    expect(result.total).toBe(0);
+    expect(tour.retiredAt).toBeNull();
+  });
+
+  it('returns an already-retired omitted child as a tombstone for membership preservation', () => {
+    const realm = temporaryRealm();
+    const venue = createVenue(realm, 'venue', new Date('2026-01-01T00:00:00.000Z'));
+    const repository = new Repository(TestVenue);
+    realm.write(() => {
+      venue.retiredAt = new Date('2026-02-01T00:00:00.000Z');
+      venue.retirementReason = 'earlier-reconciliation';
+    });
+
+    const result = repository.upsertMultiple(realm, [], [venue]);
+
+    expect(result.retired).toBe(0);
+    expect(result.retiredModels).toEqual([venue]);
+  });
+
+  it('retires Shows before their Venue and Tour during an Artist cascade', () => {
+    const realm = temporaryCatalogRealm();
+    const timestamp = new Date('2026-01-01T00:00:00.000Z');
+    const retiredAt = new Date('2026-02-01T00:00:00.000Z');
+    let artist!: Artist;
+    let venue!: Venue;
+    let tour!: Tour;
+    let show!: Show;
+
+    realm.write(() => {
+      artist = realm.create(Artist, {
+        uuid: 'artist',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        musicbrainzId: '',
+        name: 'Artist',
+        featured: 0,
+        slug: 'artist',
+        sortName: 'Artist',
+        featuresRaw: '{}',
+        upstreamSourcesRaw: '[]',
+        showCount: 1,
+        sourceCount: 0,
+        isFavorite: false,
+      });
+      venue = realm.create(Venue, {
+        uuid: 'venue',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        artistUuid: artist.uuid,
+        name: 'Venue',
+        location: 'Somewhere',
+        upstreamIdentifier: 'venue',
+        slug: 'venue',
+        sortName: 'Venue',
+        showsAtVenue: 1,
+        isFavorite: false,
+      });
+      tour = realm.create(Tour, {
+        uuid: 'tour',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        artistUuid: artist.uuid,
+        startDate: timestamp,
+        endDate: timestamp,
+        name: 'Tour',
+        slug: 'tour',
+        upstreamIdentifier: 'tour',
+        isFavorite: false,
+      });
+      show = realm.create(Show, {
+        uuid: 'show',
+        artistUuid: artist.uuid,
+        yearUuid: 'year',
+        venueUuid: venue.uuid,
+        tourUuid: tour.uuid,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        date: timestamp,
+        avgRating: 0,
+        displayDate: '2026-01-01',
+        mostRecentSourceUpdatedAt: timestamp,
+        hasSoundboardSource: false,
+        hasStreamableFlacSource: false,
+        sourceCount: 0,
+        artist,
+        venue,
+        tour,
+        isFavorite: false,
+      });
+    });
+
+    const result = retireCatalogGraph(realm, artist, {
+      reason: 'artist-api-reconciliation',
+      retiredAt,
+      report: false,
+    });
+
+    expect(result.counts.Artist).toBe(1);
+    expect(result.counts.Show).toBe(1);
+    expect(result.counts.Venue).toBe(1);
+    expect(result.counts.Tour).toBe(1);
+    expect(show.retiredAt).toEqual(retiredAt);
+    expect(venue.retiredAt).toEqual(retiredAt);
+    expect(tour.retiredAt).toEqual(retiredAt);
+
+    realm.write(() => {
+      realm.create(Song, {
+        uuid: 'song',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        artistUuid: artist.uuid,
+        name: 'Song',
+        slug: 'song',
+        upstreamIdentifier: 'song',
+        sortName: 'Song',
+        showsPlayedAt: 1,
+        isFavorite: false,
+        shows: [show],
+      });
+    });
+
+    const audit = auditCatalogRetirementGraph(realm);
+    expect(audit.membershipLinks['Song.shows']).toBe(1);
+    expect(audit.totalRetainedMemberships).toBe(1);
+    expect(audit.totalViolations).toBe(0);
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'info',
+        message: 'Retained catalog memberships observed',
+      })
+    );
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'warning' })
+    );
+  });
+
+  it('groups unexpected active lookups once per model and access site', () => {
+    const realm = temporaryRealm();
+    const venue = createVenue(realm, 'venue', new Date('2026-01-01T00:00:00.000Z'));
+    realm.write(() => {
+      venue.retiredAt = new Date('2026-02-01T00:00:00.000Z');
+    });
+
+    expect(venue.uuid).toBe('venue');
+    expect(
+      activeCatalogObjectForPrimaryKey(realm, TestVenue, venue.uuid, 'test.active-lookup')
+    ).toBeUndefined();
+    expect(
+      activeCatalogObjectForPrimaryKey(realm, TestVenue, venue.uuid, 'test.active-lookup')
+    ).toBeUndefined();
+
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides and reports a tombstone reached through a live active stream', () => {
+    const realm = temporaryRealm();
+    const venue = createVenue(realm, 'venue', new Date('2026-01-01T00:00:00.000Z'));
+    realm.write(() => {
+      venue.retiredAt = new Date('2026-02-01T00:00:00.000Z');
+    });
+
+    const stream = new ActiveCatalogObjectValueStream(
+      realm,
+      TestVenue,
+      venue.uuid,
+      'test.active-stream'
+    );
+
+    expect(stream.currentValue).toBeNull();
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    stream.tearDown();
+  });
+
+  it('migrates an existing schema by adding nullable retirement fields', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'relisten-catalog-migration-'));
+    tempDirectories.push(directory);
+    const path = join(directory, 'migration.realm');
+    const oldSchema: Realm.ObjectSchema = {
+      name: 'Venue',
+      primaryKey: 'uuid',
+      properties: {
+        uuid: 'string',
+        createdAt: 'date',
+        updatedAt: 'date',
+        name: 'string',
+      },
+    };
+    const updatedAt = new Date('2026-01-01T00:00:00.000Z');
+    const oldRealm = new Realm({ path, schema: [oldSchema], schemaVersion: 12 });
+    oldRealm.write(() => {
+      oldRealm.create('Venue', {
+        uuid: 'existing',
+        createdAt: updatedAt,
+        updatedAt,
+        name: 'Existing Venue',
+      });
+    });
+    oldRealm.close();
+
+    const migratedRealm = new Realm({ path, schema: [TestVenue], schemaVersion: 13 });
+    openRealms.push(migratedRealm);
+    const venue = migratedRealm.objectForPrimaryKey(TestVenue, 'existing');
+
+    expect(venue?.name).toBe('Existing Venue');
+    expect(venue?.retiredAt).toBeNull();
+    expect(venue?.retirementReason).toBeNull();
+  });
+});

--- a/relisten/realm/catalog_retirement.ts
+++ b/relisten/realm/catalog_retirement.ts
@@ -1,0 +1,110 @@
+import Realm from 'realm';
+
+import {
+  reportRetainedCatalogAccess,
+  reportUnexpectedIncompleteCatalogAccess,
+  reportUnexpectedRetiredCatalogAccess,
+  RetireableCatalogObject,
+} from '@/relisten/realm/catalog_access_monitor';
+import { catalogStructuralIssues } from '@/relisten/realm/catalog_integrity_validation';
+
+export const ACTIVE_CATALOG_QUERY = 'retiredAt == nil';
+
+export enum MissingCatalogObjectBehavior {
+  Preserve = 'preserve',
+  Retire = 'retire',
+}
+
+export function isRetiredCatalogObject(object: RetireableCatalogObject) {
+  return object.retiredAt != null;
+}
+
+export function retireCatalogObject(
+  object: RetireableCatalogObject,
+  reason: string,
+  retiredAt: Date = new Date()
+) {
+  if (isRetiredCatalogObject(object)) return false;
+
+  object.retiredAt = retiredAt;
+  object.retirementReason = reason;
+  return true;
+}
+
+export function restoreCatalogObject(object: RetireableCatalogObject) {
+  if (!isRetiredCatalogObject(object)) return false;
+
+  object.retiredAt = undefined;
+  object.retirementReason = undefined;
+  return true;
+}
+
+export function activeCatalogResults<T extends RetireableCatalogObject>(
+  results: Realm.Results<T>
+): Realm.Results<T> {
+  return results.filtered(ACTIVE_CATALOG_QUERY);
+}
+
+export function activeCatalogObjects<T extends RetireableCatalogObject>(
+  realm: Realm,
+  type: Realm.RealmObjectConstructor<T>
+): Realm.Results<T> {
+  return activeCatalogResults(realm.objects(type));
+}
+
+function structurallyCompleteCatalogObject<T extends RetireableCatalogObject>(
+  object: T | null | undefined,
+  accessSite: string
+): T | undefined {
+  if (!object) return undefined;
+
+  const structuralIssues = catalogStructuralIssues(object);
+  if (structuralIssues.length === 0) return object;
+
+  reportUnexpectedIncompleteCatalogAccess(object, accessSite, structuralIssues);
+  return undefined;
+}
+
+export function activeCatalogObjectForPrimaryKey<T extends RetireableCatalogObject>(
+  realm: Realm,
+  type: Realm.RealmObjectConstructor<T>,
+  primaryKey: T[keyof T],
+  accessSite: string
+): T | undefined {
+  return readActiveCatalogObject(realm.objectForPrimaryKey(type, primaryKey), accessSite);
+}
+
+export function readActiveCatalogObject<T extends RetireableCatalogObject>(
+  object: T | null | undefined,
+  accessSite: string
+): T | undefined {
+  const completeObject = structurallyCompleteCatalogObject(object, accessSite);
+  if (!completeObject) return undefined;
+
+  if (isRetiredCatalogObject(completeObject)) {
+    reportUnexpectedRetiredCatalogAccess(completeObject, accessSite);
+    return undefined;
+  }
+
+  return completeObject;
+}
+
+export function retainedCatalogObjectForPrimaryKey<T extends RetireableCatalogObject>(
+  realm: Realm,
+  type: Realm.RealmObjectConstructor<T>,
+  primaryKey: T[keyof T],
+  accessSite: string
+): T | undefined {
+  return readRetainedCatalogObject(realm.objectForPrimaryKey(type, primaryKey), accessSite);
+}
+
+export function readRetainedCatalogObject<T extends RetireableCatalogObject>(
+  object: T | null | undefined,
+  accessSite: string
+): T | undefined {
+  const completeObject = structurallyCompleteCatalogObject(object, accessSite);
+  if (!completeObject) return undefined;
+
+  reportRetainedCatalogAccess(completeObject, accessSite);
+  return completeObject;
+}

--- a/relisten/realm/catalog_retirement_graph.ts
+++ b/relisten/realm/catalog_retirement_graph.ts
@@ -1,0 +1,374 @@
+import * as Sentry from '@sentry/react-native';
+import Realm from 'realm';
+
+import {
+  reportCatalogMaintenance,
+  RetireableCatalogObject,
+} from '@/relisten/realm/catalog_access_monitor';
+import { retireCatalogObject } from '@/relisten/realm/catalog_retirement';
+import { Artist } from '@/relisten/realm/models/artist';
+import { Show } from '@/relisten/realm/models/show';
+import { Song } from '@/relisten/realm/models/song';
+import { Source } from '@/relisten/realm/models/source';
+import { SourceSet } from '@/relisten/realm/models/source_set';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
+import { Tour } from '@/relisten/realm/models/tour';
+import { Venue } from '@/relisten/realm/models/venue';
+import { Year } from '@/relisten/realm/models/year';
+
+export const CATALOG_MODEL_NAMES = [
+  'SourceTrack',
+  'SourceSet',
+  'Source',
+  'Show',
+  'Year',
+  'Venue',
+  'Tour',
+  'Song',
+  'Artist',
+] as const;
+
+export type CatalogModelName = (typeof CATALOG_MODEL_NAMES)[number];
+
+export type CatalogObject = RetireableCatalogObject;
+
+export type CatalogModelCounts = Record<CatalogModelName, number>;
+
+export interface CatalogRetirementResult {
+  counts: CatalogModelCounts;
+  total: number;
+}
+
+export interface RetireCatalogGraphOptions {
+  reason: string;
+  retiredAt?: Date;
+  report?: boolean;
+}
+
+const DIRECT_LINK_EDGE_NAMES = [
+  'Show.artist',
+  'Show.tour',
+  'Show.venue',
+  'Source.artist',
+  'SourceTrack.artist',
+  'SourceTrack.show',
+  'SourceTrack.source',
+  'SourceTrack.year',
+] as const;
+
+const MEMBERSHIP_EDGE_NAMES = [
+  'Song.shows',
+  'Source.sourceSets',
+  'SourceSet.sourceTracks',
+] as const;
+
+type DirectLinkEdgeName = (typeof DIRECT_LINK_EDGE_NAMES)[number];
+type MembershipEdgeName = (typeof MEMBERSHIP_EDGE_NAMES)[number];
+
+export interface CatalogGraphAuditResult {
+  directLinks: Record<DirectLinkEdgeName, number>;
+  membershipLinks: Record<MembershipEdgeName, number>;
+  totalRetainedMemberships: number;
+  totalViolations: number;
+}
+
+interface RetirementContext {
+  realm: Realm;
+  reason: string;
+  retiredAt: Date;
+  counts: CatalogModelCounts;
+  visited: Set<string>;
+}
+
+export function emptyCatalogModelCounts(): CatalogModelCounts {
+  return {
+    SourceTrack: 0,
+    SourceSet: 0,
+    Source: 0,
+    Show: 0,
+    Year: 0,
+    Venue: 0,
+    Tour: 0,
+    Song: 0,
+    Artist: 0,
+  };
+}
+
+function forEachSnapshot<T>(collection: Realm.OrderedCollection<T>, visit: (object: T) => void) {
+  const snapshot = collection.snapshot();
+
+  for (let index = 0; index < snapshot.length; index += 1) {
+    visit(snapshot[index]);
+  }
+}
+
+function visitSnapshot<T extends CatalogObject>(
+  context: RetirementContext,
+  collection: Realm.OrderedCollection<T>
+) {
+  forEachSnapshot(collection, (object) => visitCatalogObject(context, object));
+}
+
+function retireArtistDescendants(context: RetirementContext, artist: Artist) {
+  const { realm } = context;
+  const artistUuid = artist.uuid;
+
+  // Shows must retire before Venue and Tour. Those parents are shared catalog records and are
+  // protected while any active Show still refers to them, including through a scalar UUID when
+  // the direct Realm link has not been attached yet.
+  visitSnapshot(context, realm.objects(Show).filtered('artistUuid == $0', artistUuid));
+  visitSnapshot(context, realm.objects(Year).filtered('artistUuid == $0', artistUuid));
+  visitSnapshot(context, realm.objects(Venue).filtered('artistUuid == $0', artistUuid));
+  visitSnapshot(context, realm.objects(Tour).filtered('artistUuid == $0', artistUuid));
+  visitSnapshot(context, realm.objects(Song).filtered('artistUuid == $0', artistUuid));
+  visitSnapshot(context, realm.objects(Source).filtered('artistUuid == $0', artistUuid));
+  visitSnapshot(context, realm.objects(SourceSet).filtered('artistUuid == $0', artistUuid));
+  visitSnapshot(context, realm.objects(SourceTrack).filtered('artistUuid == $0', artistUuid));
+}
+
+function hasActiveShowReference(context: RetirementContext, object: Venue | Tour) {
+  const shows = context.realm.objects<Show>('Show');
+
+  if (object.objectSchema().name === 'Venue') {
+    return (
+      shows.filtered('retiredAt == nil AND venueUuid == $0', object.uuid).length > 0 ||
+      shows.filtered('retiredAt == nil AND venue.uuid == $0', object.uuid).length > 0
+    );
+  }
+
+  return (
+    shows.filtered('retiredAt == nil AND tourUuid == $0', object.uuid).length > 0 ||
+    shows.filtered('retiredAt == nil AND tour.uuid == $0', object.uuid).length > 0
+  );
+}
+
+function retireYearDescendants(context: RetirementContext, year: Year) {
+  visitSnapshot(context, context.realm.objects(Show).filtered('yearUuid == $0', year.uuid));
+
+  // This catches an old or partially-reconciled track whose Show relationship is absent.
+  visitSnapshot(context, context.realm.objects(SourceTrack).filtered('year.uuid == $0', year.uuid));
+}
+
+function retireShowDescendants(context: RetirementContext, show: Show) {
+  visitSnapshot(context, context.realm.objects(Source).filtered('showUuid == $0', show.uuid));
+
+  // The scalar association is authoritative when a parent collection or direct link is damaged.
+  visitSnapshot(context, context.realm.objects(SourceTrack).filtered('showUuid == $0', show.uuid));
+}
+
+function retireSourceDescendants(context: RetirementContext, source: Source) {
+  visitSnapshot(context, source.sourceSets);
+  visitSnapshot(
+    context,
+    context.realm.objects(SourceSet).filtered('sourceUuid == $0', source.uuid)
+  );
+  visitSnapshot(
+    context,
+    context.realm.objects(SourceTrack).filtered('sourceUuid == $0', source.uuid)
+  );
+}
+
+function retireSourceSetDescendants(context: RetirementContext, sourceSet: SourceSet) {
+  visitSnapshot(context, sourceSet.sourceTracks);
+  visitSnapshot(
+    context,
+    context.realm.objects(SourceTrack).filtered('sourceSetUuid == $0', sourceSet.uuid)
+  );
+}
+
+function visitCatalogObject(context: RetirementContext, object: CatalogObject) {
+  if (!object.isValid()) return;
+
+  const modelName = object.objectSchema().name as CatalogModelName;
+  const visitKey = `${modelName}:${object.uuid}`;
+  if (context.visited.has(visitKey)) return;
+  context.visited.add(visitKey);
+
+  if (
+    (modelName === 'Venue' || modelName === 'Tour') &&
+    hasActiveShowReference(context, object as Venue | Tour)
+  ) {
+    return;
+  }
+
+  if (retireCatalogObject(object, context.reason, context.retiredAt)) {
+    context.counts[modelName] += 1;
+  }
+
+  switch (modelName) {
+    case 'Artist':
+      retireArtistDescendants(context, object as Artist);
+      break;
+    case 'Year':
+      retireYearDescendants(context, object as Year);
+      break;
+    case 'Show':
+      retireShowDescendants(context, object as Show);
+      break;
+    case 'Source':
+      retireSourceDescendants(context, object as Source);
+      break;
+    case 'SourceSet':
+      retireSourceSetDescendants(context, object as SourceSet);
+      break;
+    case 'SourceTrack':
+    case 'Song':
+    case 'Venue':
+    case 'Tour':
+      break;
+  }
+}
+
+/**
+ * Retires a catalog object and the descendants whose identity depends on it.
+ *
+ * The operation is idempotent. All Realm links and memberships are deliberately retained here so
+ * history, downloads, favorites, and player queue entries keep a complete browseable graph. The
+ * cold-start collector removes a derived membership only when its target tombstone is mature and
+ * no retained root depends on that membership.
+ */
+export function retireCatalogGraph(
+  realm: Realm,
+  root: CatalogObject,
+  { reason, retiredAt = new Date(), report = true }: RetireCatalogGraphOptions
+): CatalogRetirementResult {
+  const context: RetirementContext = {
+    realm,
+    reason,
+    retiredAt,
+    counts: emptyCatalogModelCounts(),
+    visited: new Set(),
+  };
+
+  const retire = () => visitCatalogObject(context, root);
+  if (realm.isInTransaction) {
+    retire();
+  } else {
+    realm.write(retire);
+  }
+
+  const total = CATALOG_MODEL_NAMES.reduce((sum, modelName) => sum + context.counts[modelName], 0);
+  if (report) {
+    for (const modelName of CATALOG_MODEL_NAMES) {
+      reportCatalogMaintenance('retired', modelName, context.counts[modelName], {
+        reason,
+        rootModel: root.objectSchema().name,
+      });
+    }
+  }
+
+  return { counts: context.counts, total };
+}
+
+function emptyDirectLinkCounts(): Record<DirectLinkEdgeName, number> {
+  return {
+    'Show.artist': 0,
+    'Show.tour': 0,
+    'Show.venue': 0,
+    'Source.artist': 0,
+    'SourceTrack.artist': 0,
+    'SourceTrack.show': 0,
+    'SourceTrack.source': 0,
+    'SourceTrack.year': 0,
+  };
+}
+
+function emptyMembershipLinkCounts(): Record<MembershipEdgeName, number> {
+  return {
+    'Song.shows': 0,
+    'Source.sourceSets': 0,
+    'SourceSet.sourceTracks': 0,
+  };
+}
+
+function countRetiredMembers<T extends { retiredAt?: Date }>(collection: Iterable<T>) {
+  let count = 0;
+  for (const object of collection) {
+    if (object.retiredAt) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Reports active catalog rows that still point at retired catalog rows. Direct links are integrity
+ * violations. Parent memberships retain retired children deliberately so offline, favorite, and
+ * history graphs remain browseable; those edges are counted separately at info level.
+ */
+export function auditCatalogRetirementGraph(
+  realm: Realm,
+  { report = true }: { report?: boolean } = {}
+): CatalogGraphAuditResult {
+  const directLinks = emptyDirectLinkCounts();
+  const membershipLinks = emptyMembershipLinkCounts();
+
+  directLinks['Show.artist'] = realm
+    .objects(Show)
+    .filtered('retiredAt == nil AND artist.retiredAt != nil').length;
+  directLinks['Show.tour'] = realm
+    .objects(Show)
+    .filtered('retiredAt == nil AND tour.retiredAt != nil').length;
+  directLinks['Show.venue'] = realm
+    .objects(Show)
+    .filtered('retiredAt == nil AND venue.retiredAt != nil').length;
+  directLinks['Source.artist'] = realm
+    .objects(Source)
+    .filtered('retiredAt == nil AND artist.retiredAt != nil').length;
+  directLinks['SourceTrack.artist'] = realm
+    .objects(SourceTrack)
+    .filtered('retiredAt == nil AND artist.retiredAt != nil').length;
+  directLinks['SourceTrack.show'] = realm
+    .objects(SourceTrack)
+    .filtered('retiredAt == nil AND show.retiredAt != nil').length;
+  directLinks['SourceTrack.source'] = realm
+    .objects(SourceTrack)
+    .filtered('retiredAt == nil AND source.retiredAt != nil').length;
+  directLinks['SourceTrack.year'] = realm
+    .objects(SourceTrack)
+    .filtered('retiredAt == nil AND year.retiredAt != nil').length;
+
+  forEachSnapshot(
+    realm.objects(Source).filtered('retiredAt == nil AND ANY sourceSets.retiredAt != nil'),
+    (source) => {
+      membershipLinks['Source.sourceSets'] += countRetiredMembers(source.sourceSets);
+    }
+  );
+  forEachSnapshot(
+    realm.objects(SourceSet).filtered('retiredAt == nil AND ANY sourceTracks.retiredAt != nil'),
+    (sourceSet) => {
+      membershipLinks['SourceSet.sourceTracks'] += countRetiredMembers(sourceSet.sourceTracks);
+    }
+  );
+  forEachSnapshot(
+    realm.objects(Song).filtered('retiredAt == nil AND ANY shows.retiredAt != nil'),
+    (song) => {
+      membershipLinks['Song.shows'] += countRetiredMembers(song.shows);
+    }
+  );
+
+  const totalViolations = DIRECT_LINK_EDGE_NAMES.reduce((sum, edge) => sum + directLinks[edge], 0);
+  const totalRetainedMemberships = MEMBERSHIP_EDGE_NAMES.reduce(
+    (sum, edge) => sum + membershipLinks[edge],
+    0
+  );
+
+  if (report) {
+    reportCatalogMaintenance('collection-skipped', 'CatalogGraph', totalViolations, {
+      directLinks,
+      reason: 'active-to-retired-link',
+    });
+    if (totalRetainedMemberships > 0) {
+      Sentry.addBreadcrumb({
+        category: 'realm.catalog-retirement',
+        level: 'info',
+        message: 'Retained catalog memberships observed',
+        data: {
+          count: totalRetainedMemberships,
+          membershipLinks,
+          reason: 'intentional-retained-membership',
+        },
+      });
+    }
+  }
+
+  return { directLinks, membershipLinks, totalRetainedMemberships, totalViolations };
+}

--- a/relisten/realm/catalog_retirement_schema.ts
+++ b/relisten/realm/catalog_retirement_schema.ts
@@ -1,0 +1,11 @@
+import Realm from 'realm';
+
+export interface CatalogRetirementState {
+  retiredAt?: Date;
+  retirementReason?: string;
+}
+
+export const CATALOG_RETIREMENT_SCHEMA_PROPERTIES = {
+  retiredAt: { type: 'date', optional: true, indexed: true },
+  retirementReason: 'string?',
+} satisfies Realm.PropertiesTypes;

--- a/relisten/realm/library_index.ts
+++ b/relisten/realm/library_index.ts
@@ -1,11 +1,17 @@
 import Realm from 'realm';
 import { Artist } from '@/relisten/realm/models/artist';
 import { Show } from '@/relisten/realm/models/show';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
 import {
+  ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY,
   SourceTrackOfflineInfo,
   SourceTrackOfflineInfoStatus,
 } from '@/relisten/realm/models/source_track_offline_info';
 import { logLibraryIndexDebug } from '@/relisten/util/profile_logging';
+import {
+  readRetainedCatalogObject,
+  retainedCatalogObjectForPrimaryKey,
+} from '@/relisten/realm/catalog_retirement';
 
 type Listener = () => void;
 
@@ -145,10 +151,16 @@ export class LibraryIndex {
     this.favoriteShows = this.realm.objects(Show).filtered('isFavorite == true');
     this.offlineInfos = this.realm
       .objects(SourceTrackOfflineInfo)
-      .filtered('status == $0', SourceTrackOfflineInfoStatus.Succeeded);
+      .filtered(
+        `${ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY} AND status == $0`,
+        SourceTrackOfflineInfoStatus.Succeeded
+      );
     this.remainingDownloads = this.realm
       .objects(SourceTrackOfflineInfo)
-      .filtered('status != $0', SourceTrackOfflineInfoStatus.Succeeded);
+      .filtered(
+        `${ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY} AND status != $0`,
+        SourceTrackOfflineInfoStatus.Succeeded
+      );
     this.lastNotifiedRemainingDownloadsCount = this.remainingDownloads.length;
 
     this.favoriteArtists.addListener(this.handleFavoriteArtistsChanged);
@@ -357,7 +369,10 @@ export class LibraryIndex {
 
     this.favoriteArtistUuids.clear();
 
-    for (const artist of this.favoriteArtists) {
+    for (const candidate of this.favoriteArtists) {
+      const artist = readRetainedCatalogObject(candidate, 'library-index.favorite-artist');
+      if (!artist) continue;
+
       this.favoriteArtistUuids.add(artist.uuid);
     }
 
@@ -391,7 +406,10 @@ export class LibraryIndex {
     this.favoriteShowArtistCounts.clear();
     this.favoriteShowYearCounts.clear();
 
-    for (const show of this.favoriteShows) {
+    for (const candidate of this.favoriteShows) {
+      const show = readRetainedCatalogObject(candidate, 'library-index.favorite-show');
+      if (!show) continue;
+
       this.favoriteShowUuids.add(show.uuid);
       this.incrementCount(this.favoriteShowArtistCounts, show.artistUuid);
       this.incrementCount(this.favoriteShowYearCounts, show.yearUuid);
@@ -458,7 +476,12 @@ export class LibraryIndex {
     this.sourceOfflineCounts.clear();
 
     for (const offlineInfo of this.offlineInfos) {
-      const track = offlineInfo.sourceTrack;
+      const track = retainedCatalogObjectForPrimaryKey(
+        this.realm,
+        SourceTrack,
+        offlineInfo.sourceTrackUuid,
+        'library-index.offline-track'
+      );
       if (!track) {
         continue;
       }
@@ -467,10 +490,18 @@ export class LibraryIndex {
       this.incrementCount(this.showOfflineCounts, track.showUuid);
       this.incrementCount(this.sourceOfflineCounts, track.sourceUuid);
 
-      const yearUuid =
-        track.year?.uuid ??
-        track.show?.yearUuid ??
-        this.realm.objectForPrimaryKey(Show, track.showUuid)?.yearUuid;
+      const year = readRetainedCatalogObject(track.year, 'library-index.offline-track.year');
+      const show = readRetainedCatalogObject(track.show, 'library-index.offline-track.show');
+      const fallbackShow =
+        year || show
+          ? undefined
+          : retainedCatalogObjectForPrimaryKey(
+              this.realm,
+              Show,
+              track.showUuid,
+              'library-index.offline-track.show-fallback'
+            );
+      const yearUuid = year?.uuid ?? show?.yearUuid ?? fallbackShow?.yearUuid;
       this.incrementCount(this.yearOfflineCounts, yearUuid);
     }
 

--- a/relisten/realm/models/artist.ts
+++ b/relisten/realm/models/artist.ts
@@ -7,6 +7,10 @@ import { RelistenObjectRequiredProperties } from '../relisten_object';
 import { SourceTrack } from './source_track';
 import { Popularity } from './popularity';
 import type { LibraryIndex } from '@/relisten/realm/library_index';
+import {
+  CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
+  CatalogRetirementState,
+} from '@/relisten/realm/catalog_retirement_schema';
 
 export interface ArtistRequiredProperties extends RelistenObjectRequiredProperties {
   musicbrainzId: string;
@@ -29,7 +33,7 @@ export enum ArtistFeaturedFlags {
 
 export class Artist
   extends Realm.Object<Artist, keyof ArtistRequiredProperties>
-  implements ArtistRequiredProperties, FavoritableObject
+  implements ArtistRequiredProperties, FavoritableObject, CatalogRetirementState
 {
   static schema: Realm.ObjectSchema = {
     name: 'Artist',
@@ -38,6 +42,7 @@ export class Artist
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      ...CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
       musicbrainzId: 'string',
       name: 'string',
       featured: 'int',
@@ -60,6 +65,8 @@ export class Artist
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  retiredAt?: Date;
+  retirementReason?: string;
   musicbrainzId!: string;
   name!: string;
   featured!: number;

--- a/relisten/realm/models/artist_repo.ts
+++ b/relisten/realm/models/artist_repo.ts
@@ -12,20 +12,22 @@ import { useQuery, useRealm } from '../schema';
 import { Artist, ArtistFeaturedFlags, ArtistRequiredProperties } from './artist';
 import { ArtistWithCounts } from '@/relisten/api/models/artist';
 
-import { useIsOfflineTab } from '@/relisten/util/routes';
+import { useGroupSegment, useIsOfflineTab } from '@/relisten/util/routes';
 import { filterForUser, useRealmTabsFilter } from '../realm_filters';
 import { Show } from './show';
 import { Source } from './source';
 import { NetworkBackedModelArrayBehavior } from '@/relisten/realm/network_backed_model_array_behavior';
-import { RealmQueryValueStream, ValueStream } from '@/relisten/realm/value_streams';
+import {
+  ActiveCatalogObjectValueStream,
+  RealmQueryValueStream,
+  RetainedCatalogObjectValueStream,
+  ValueStream,
+} from '@/relisten/realm/value_streams';
 import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_network_backed_behavior';
 import { attachArtistsToExistingShows } from '@/relisten/realm/models/show_artist_relationships';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 export const artistRepo = new Repository(Artist);
-
-function artistHasUserInteraction(artist: Artist): boolean {
-  return artist.isFavorite || artist.hasOfflineTracks();
-}
 
 class ArtistsNetworkBackedBehavior extends NetworkBackedModelArrayBehavior<
   Artist,
@@ -35,14 +37,7 @@ class ArtistsNetworkBackedBehavior extends NetworkBackedModelArrayBehavior<
 > {
   override upsert(localData: Realm.Results<Artist>, apiData: ArtistWithCounts[]): void {
     this.realm.write(() => {
-      const { allModels } = artistRepo.upsertMultiple(
-        this.realm,
-        apiData,
-        localData,
-        true,
-        true,
-        artistHasUserInteraction
-      );
+      const { allModels } = artistRepo.upsertMultiple(this.realm, apiData, localData);
 
       attachArtistsToExistingShows(this.realm, allModels);
     });
@@ -64,7 +59,10 @@ export function artistsNetworkBackedBehavior(
     realm,
     artistRepo,
     (realm) => {
-      let q = filterForUser(realm.objects<Artist>(Artist), {
+      const catalogArtists = availableOfflineOnly
+        ? realm.objects<Artist>(Artist)
+        : activeCatalogObjects(realm, Artist);
+      let q = filterForUser(catalogArtists, {
         isFavorite: null,
         isPlayableOffline: availableOfflineOnly ? availableOfflineOnly : null,
       });
@@ -77,7 +75,8 @@ export function artistsNetworkBackedBehavior(
     },
     (api, forcedRefresh) =>
       api.artists(includeAutomaticallyCreated, api.refreshOptions(forcedRefresh)),
-    options
+    options,
+    availableOfflineOnly ? 'offline.artist-list' : undefined
   );
 }
 
@@ -135,7 +134,7 @@ class ArtistBootstrapNetworkBackedBehavior extends ThrottledNetworkBackedBehavio
 > {
   constructor(
     realm: Realm.Realm,
-    private readonly localQueryFactory: (realm: Realm.Realm) => Realm.Results<Artist>,
+    private readonly localValueStreamFactory: (realm: Realm.Realm) => ValueStream<Artist | null>,
     options?: NetworkBackedBehaviorOptions
   ) {
     super(realm, {
@@ -149,7 +148,7 @@ class ArtistBootstrapNetworkBackedBehavior extends ThrottledNetworkBackedBehavio
   }
 
   override createLocalUpdatingResults(): ValueStream<Artist | null> {
-    return new SingleArtistValueStream(this.realm, this.localQueryFactory(this.realm));
+    return this.localValueStreamFactory(this.realm);
   }
 
   override isLocalDataShowable(localData: Artist | null): boolean {
@@ -162,7 +161,11 @@ class ArtistBootstrapNetworkBackedBehavior extends ThrottledNetworkBackedBehavio
     }
 
     this.realm.write(() => {
-      const { allModels } = artistRepo.upsertMultiple(this.realm, apiData, [], false, true);
+      const { allModels } = artistRepo.upsertMultiple(
+        this.realm,
+        apiData,
+        activeCatalogObjects(this.realm, Artist)
+      );
 
       attachArtistsToExistingShows(this.realm, allModels);
     });
@@ -170,6 +173,7 @@ class ArtistBootstrapNetworkBackedBehavior extends ThrottledNetworkBackedBehavio
 }
 
 export function useOfflineArtistMetadata(artist?: Artist | null): ArtistMetadataSummary {
+  // Offline metadata intentionally includes retired parents that still own retained downloads.
   const shows = useRealmTabsFilter(
     useQuery(Show, (query) => query.filtered('artistUuid = $0', artist?.uuid), [artist?.uuid])
   );
@@ -187,6 +191,7 @@ export function useOfflineArtistMetadata(artist?: Artist | null): ArtistMetadata
 export function useOfflineArtistMetadataMap(
   artists: ReadonlyArray<Artist>
 ): ReadonlyMap<string, ArtistMetadataSummary> {
+  // Offline metadata intentionally includes retired parents that still own retained downloads.
   const shows = useRealmTabsFilter(useQuery(Show));
   const sources = useRealmTabsFilter(useQuery(Source));
 
@@ -226,14 +231,28 @@ export function useArtist(
     };
   }, [options]);
   const realm = useRealm();
+  const groupSegment = useGroupSegment();
+  const includeRetiredCatalog = groupSegment !== '(artists)';
   const behavior = useMemo(() => {
     return new ArtistBootstrapNetworkBackedBehavior(
       realm,
       (currentRealm) =>
-        currentRealm.objects(Artist).filtered('uuid == $0', artistUuid ?? '__missing__'),
+        includeRetiredCatalog
+          ? new RetainedCatalogObjectValueStream(
+              currentRealm,
+              Artist,
+              artistUuid ?? '__missing__',
+              'artist-detail.root'
+            )
+          : new ActiveCatalogObjectValueStream(
+              currentRealm,
+              Artist,
+              artistUuid ?? '__missing__',
+              'artist-detail.root'
+            ),
       memoOptions
     );
-  }, [artistUuid, memoOptions, realm]);
+  }, [artistUuid, includeRetiredCatalog, memoOptions, realm]);
 
   return useNetworkBackedBehavior(behavior);
 }
@@ -253,7 +272,13 @@ export function useArtistBySlug(
     return new ArtistBootstrapNetworkBackedBehavior(
       realm,
       (currentRealm) =>
-        currentRealm.objects(Artist).filtered('slug == $0', artistSlug ?? '__missing__'),
+        new SingleArtistValueStream(
+          currentRealm,
+          activeCatalogObjects(currentRealm, Artist).filtered(
+            'slug == $0',
+            artistSlug ?? '__missing__'
+          )
+        ),
       memoOptions
     );
   }, [artistSlug, memoOptions, realm]);

--- a/relisten/realm/models/history/playback_history_entry.ts
+++ b/relisten/realm/models/history/playback_history_entry.ts
@@ -25,6 +25,7 @@ export class PlaybackHistoryEntry extends Realm.Object<PlaybackHistoryEntry> {
 
       createdAt: 'date',
       playbackStartedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
 
       sourceTrack: 'SourceTrack',
       artist: 'Artist',
@@ -39,6 +40,7 @@ export class PlaybackHistoryEntry extends Realm.Object<PlaybackHistoryEntry> {
 
   createdAt!: Date;
   playbackStartedAt!: Date;
+  deletedAt?: Date;
 
   private _humanizedPlaybackStartedAt?: string;
   humanizedPlaybackStartedAt() {

--- a/relisten/realm/models/history/playback_history_entry_repo.ts
+++ b/relisten/realm/models/history/playback_history_entry_repo.ts
@@ -2,11 +2,16 @@ import { useQuery, useRealm } from '@/relisten/realm/schema';
 import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { InteractionManager } from 'react-native';
+import {
+  ACTIVE_PLAYBACK_HISTORY_QUERY,
+  readRetainedPlaybackHistoryCatalogLinks,
+} from '@/relisten/realm/models/history/playback_history_lifecycle';
 
 export function useTotalListeningTime(): number {
   const allEntries = useQuery(
     {
       type: PlaybackHistoryEntry,
+      query: (query) => query.filtered(ACTIVE_PLAYBACK_HISTORY_QUERY),
     },
     []
   );
@@ -14,7 +19,11 @@ export function useTotalListeningTime(): number {
   const totalSeconds = useMemo(() => {
     let total = 0;
     for (const entry of allEntries) {
-      total += entry.sourceTrack.duration ?? 0;
+      const { sourceTrack } = readRetainedPlaybackHistoryCatalogLinks(
+        entry,
+        'history.statistics.totalTime'
+      );
+      total += sourceTrack.duration ?? 0;
     }
     return total;
   }, [allEntries]);
@@ -38,6 +47,7 @@ export function useListeningTimeByArtist(): ArtistListeningTime[] {
   const allEntries = useQuery(
     {
       type: PlaybackHistoryEntry,
+      query: (query) => query.filtered(ACTIVE_PLAYBACK_HISTORY_QUERY),
     },
     []
   );
@@ -54,16 +64,20 @@ export function useListeningTimeByArtist(): ArtistListeningTime[] {
     > = {};
 
     for (const entry of allEntries) {
-      const uuid = entry.artist.uuid;
+      const { artist: catalogArtist, sourceTrack } = readRetainedPlaybackHistoryCatalogLinks(
+        entry,
+        'history.statistics.byArtist'
+      );
+      const uuid = catalogArtist.uuid;
       if (!artist[uuid]) {
         artist[uuid] = {
           uuid: uuid,
-          artistName: entry.artist.name,
+          artistName: catalogArtist.name,
           totalSeconds: 0,
           years: {},
         };
       }
-      const duration = entry.sourceTrack.duration ?? 0;
+      const duration = sourceTrack.duration ?? 0;
       artist[uuid].totalSeconds += duration;
       const year = entry.playbackStartedAt.getFullYear();
       artist[uuid].years[year] = (artist[uuid].years[year] ?? 0) + duration;
@@ -86,7 +100,10 @@ export function useHistoryRecentlyPlayedShows(
   const recentlyPlayed = useQuery(
     {
       type: PlaybackHistoryEntry,
-      query: (query) => query.sorted('playbackStartedAt', /* reverse= */ true),
+      query: (query) =>
+        query
+          .filtered(ACTIVE_PLAYBACK_HISTORY_QUERY)
+          .sorted('playbackStartedAt', /* reverse= */ true),
     },
     []
   );
@@ -96,9 +113,10 @@ export function useHistoryRecentlyPlayedShows(
     const entryByShowUuid: { [uuid: string]: PlaybackHistoryEntry } = {};
 
     for (const entry of recentlyPlayed) {
-      if (recentlyPlayedShowUuids.indexOf(entry.show.uuid) === -1) {
-        recentlyPlayedShowUuids.push(entry.show.uuid);
-        entryByShowUuid[entry.show.uuid] = entry;
+      const { show } = readRetainedPlaybackHistoryCatalogLinks(entry, 'history.recentShows');
+      if (recentlyPlayedShowUuids.indexOf(show.uuid) === -1) {
+        recentlyPlayedShowUuids.push(show.uuid);
+        entryByShowUuid[show.uuid] = entry;
       }
 
       if (recentlyPlayedShowUuids.length >= limit) {
@@ -179,7 +197,9 @@ export function useTopPlayedArtistUuidsOnce(
 
       const entries = realm
         .objects(PlaybackHistoryEntry)
-        .sorted('playbackStartedAt', /* reverse= */ true);
+        .filtered(ACTIVE_PLAYBACK_HISTORY_QUERY)
+        .sorted('playbackStartedAt', /* reverse= */ true)
+        .snapshot();
       const cutoffTime = Date.now() - EARLY_EXIT_DAYS_MS;
       const counts = new Map<string, number>();
       const sortNames = new Map<string, string>();
@@ -205,7 +225,7 @@ export function useTopPlayedArtistUuidsOnce(
 
         while (index < end) {
           const entry = entries[index];
-          const artist = entry.artist;
+          const { artist } = readRetainedPlaybackHistoryCatalogLinks(entry, 'history.topArtists');
           const uuid = artist?.uuid;
 
           if (uuid) {

--- a/relisten/realm/models/history/playback_history_lifecycle.ts
+++ b/relisten/realm/models/history/playback_history_lifecycle.ts
@@ -1,0 +1,186 @@
+import * as Sentry from '@sentry/react-native';
+import Realm from 'realm';
+import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
+import { log } from '@/relisten/util/logging';
+import { readRetainedCatalogObject } from '@/relisten/realm/catalog_retirement';
+
+const logger = log.extend('playback-history-lifecycle');
+
+/**
+ * A history entry is visible only while it has not been cleared and all links
+ * required by history consumers still resolve. The link checks also quarantine
+ * databases written by older versions that physically deleted catalog rows.
+ */
+export const ACTIVE_PLAYBACK_HISTORY_QUERY =
+  'deletedAt == nil AND sourceTrack != nil AND artist != nil AND show != nil AND source != nil ' +
+  'AND sourceTrack.artist != nil AND sourceTrack.show != nil ' +
+  'AND sourceTrack.source != nil AND sourceTrack.year != nil';
+
+const MALFORMED_PLAYBACK_HISTORY_QUERY =
+  'deletedAt == nil AND (sourceTrack == nil OR artist == nil OR show == nil OR source == nil ' +
+  'OR sourceTrack.artist == nil OR sourceTrack.show == nil ' +
+  'OR sourceTrack.source == nil OR sourceTrack.year == nil)';
+
+export const DEFAULT_PLAYBACK_HISTORY_STARTUP_CLEANUP_BATCH_LIMIT = 250;
+
+export interface PlaybackHistoryStartupCleanupResult {
+  physicallyDeleted: number;
+  malformed: number;
+  newlyQuarantined: number;
+  collectionDeferred: number;
+  quarantineDeferred: number;
+  deferred: number;
+  previouslyCleared: number;
+}
+
+export interface PlaybackHistoryStartupCleanupOptions {
+  batchLimit?: number;
+  quarantineBatchLimit?: number;
+  now?: Date;
+}
+
+export type PlaybackHistoryCatalogLinks = Pick<
+  PlaybackHistoryEntry,
+  'sourceTrack' | 'artist' | 'show' | 'source'
+>;
+
+/**
+ * History deliberately retains its catalog links after those rows leave the
+ * current catalog. Record that expected use without treating it as an
+ * active-catalog invariant violation.
+ */
+export function readRetainedPlaybackHistoryCatalogLinks<T extends PlaybackHistoryCatalogLinks>(
+  links: T,
+  accessSite: string
+): T {
+  readRetainedCatalogObject(links.sourceTrack, `${accessSite}.sourceTrack`);
+  readRetainedCatalogObject(links.artist, `${accessSite}.artist`);
+  readRetainedCatalogObject(links.show, `${accessSite}.show`);
+  readRetainedCatalogObject(links.source, `${accessSite}.source`);
+  return links;
+}
+
+export function activePlaybackHistoryEntries(realm: Realm): Realm.Results<PlaybackHistoryEntry> {
+  return realm.objects(PlaybackHistoryEntry).filtered(ACTIVE_PLAYBACK_HISTORY_QUERY);
+}
+
+export function activePlaybackHistoryEntryForPrimaryKey(
+  realm: Realm,
+  uuid: string
+): PlaybackHistoryEntry | undefined {
+  return activePlaybackHistoryEntries(realm).filtered('uuid == $0', uuid)[0];
+}
+
+export function softDeletePlaybackHistoryEntries(
+  realm: Realm,
+  entries: Realm.Results<PlaybackHistoryEntry> = activePlaybackHistoryEntries(realm),
+  deletedAt: Date = new Date()
+): number {
+  const entriesToDelete = entries.filtered('deletedAt == nil').snapshot();
+  const count = entriesToDelete.length;
+
+  if (count === 0) {
+    return 0;
+  }
+
+  const markDeleted = () => {
+    for (const entry of entriesToDelete) {
+      if (entry && entry.deletedAt == null) {
+        entry.deletedAt = deletedAt;
+      }
+    }
+  };
+
+  if (realm.isInTransaction) {
+    markDeleted();
+  } else {
+    realm.write(markDeleted);
+  }
+
+  return count;
+}
+
+/**
+ * Physically removes history that no live consumer is allowed to observe.
+ * Call this once during Realm startup, before rendering services or opening
+ * CarPlay, so normal in-session clears never invalidate managed objects.
+ */
+export function cleanupPlaybackHistoryAtStartup(
+  realm: Realm,
+  {
+    batchLimit = DEFAULT_PLAYBACK_HISTORY_STARTUP_CLEANUP_BATCH_LIMIT,
+    quarantineBatchLimit = batchLimit,
+    now = new Date(),
+  }: PlaybackHistoryStartupCleanupOptions = {}
+): PlaybackHistoryStartupCleanupResult {
+  if (!Number.isInteger(batchLimit) || batchLimit < 0) {
+    throw new Error('Playback history cleanup batchLimit must be a non-negative integer');
+  }
+  if (!Number.isInteger(quarantineBatchLimit) || quarantineBatchLimit < 0) {
+    throw new Error('Playback history quarantineBatchLimit must be a non-negative integer');
+  }
+
+  const allEntries = realm.objects(PlaybackHistoryEntry);
+  const previouslyClearedEntries = allEntries.filtered('deletedAt != nil').sorted('deletedAt');
+  const previouslyCleared = previouslyClearedEntries.length;
+  const entriesToDelete = previouslyClearedEntries.snapshot().slice(0, batchLimit);
+  const malformedResults = allEntries.filtered(MALFORMED_PLAYBACK_HISTORY_QUERY);
+  const malformed = malformedResults.length;
+  const malformedEntries = malformedResults.snapshot().slice(0, quarantineBatchLimit);
+  const newlyQuarantined = malformedEntries.length;
+  const physicallyDeleted = entriesToDelete.length;
+  const collectionDeferred = previouslyCleared - physicallyDeleted;
+  const quarantineDeferred = malformed - newlyQuarantined;
+  const deferred = collectionDeferred + quarantineDeferred;
+
+  if (physicallyDeleted > 0 || newlyQuarantined > 0) {
+    const maintainEntries = () => {
+      for (const entry of malformedEntries) {
+        if (entry?.isValid() && entry.deletedAt == null) entry.deletedAt = now;
+      }
+      if (entriesToDelete.length > 0) realm.delete(entriesToDelete);
+    };
+
+    if (realm.isInTransaction) {
+      maintainEntries();
+    } else {
+      realm.write(maintainEntries);
+    }
+
+    logger.info('Quarantined or collected unusable playback history during startup', {
+      deferred,
+      collectionDeferred,
+      malformed,
+      newlyQuarantined,
+      physicallyDeleted,
+      previouslyCleared,
+      quarantineDeferred,
+    });
+  }
+
+  if (deferred > 0) {
+    Sentry.addBreadcrumb({
+      category: 'realm.playback-history.cleanup',
+      level: 'info',
+      message: 'Playback history maintenance deferred to a later reboot',
+      data: {
+        batchLimit,
+        collectionDeferred,
+        deferred,
+        previouslyCleared,
+        quarantineBatchLimit,
+        quarantineDeferred,
+      },
+    });
+  }
+
+  return {
+    physicallyDeleted,
+    malformed,
+    newlyQuarantined,
+    collectionDeferred,
+    quarantineDeferred,
+    deferred,
+    previouslyCleared,
+  };
+}

--- a/relisten/realm/models/lastfm_scrobble_entry.ts
+++ b/relisten/realm/models/lastfm_scrobble_entry.ts
@@ -1,5 +1,7 @@
 import Realm from 'realm';
 
+export const ACTIVE_LASTFM_SCROBBLE_ENTRY_QUERY = 'deletedAt == nil';
+
 export interface LastFmScrobbleEntryProps {
   id: string;
   createdAt: Date;
@@ -29,6 +31,7 @@ export class LastFmScrobbleEntry
       timestamp: 'date',
       failureCount: { type: 'int', default: 0 },
       lastAttemptAt: 'date?',
+      deletedAt: { type: 'date', optional: true, indexed: true },
     },
   };
 
@@ -41,4 +44,5 @@ export class LastFmScrobbleEntry
   timestamp!: Date;
   failureCount!: number;
   lastAttemptAt?: Date;
+  deletedAt?: Date;
 }

--- a/relisten/realm/models/offline_repo.ts
+++ b/relisten/realm/models/offline_repo.ts
@@ -1,11 +1,15 @@
 import { useQuery } from '@/relisten/realm/schema';
 import {
+  ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY,
   SourceTrackOfflineInfo,
   SourceTrackOfflineInfoStatus,
 } from '@/relisten/realm/models/source_track_offline_info';
 
 export function useRemainingDownloads() {
   return useQuery(SourceTrackOfflineInfo, (query) =>
-    query.filtered('status != $0', SourceTrackOfflineInfoStatus.Succeeded)
+    query.filtered(
+      `${ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY} AND status != $0`,
+      SourceTrackOfflineInfoStatus.Succeeded
+    )
   );
 }

--- a/relisten/realm/models/player_state.ts
+++ b/relisten/realm/models/player_state.ts
@@ -31,6 +31,7 @@ export class PlayerState extends Realm.Object<PlayerState> implements PlayerStat
       progress: 'float?',
       duration: 'float?',
       elapsed: 'float?',
+      deletedAt: { type: 'date', optional: true, indexed: true },
     },
   };
 
@@ -45,16 +46,20 @@ export class PlayerState extends Realm.Object<PlayerState> implements PlayerStat
   progress?: number;
   duration?: number;
   elapsed?: number;
+  deletedAt?: Date;
 
   static defaultObject(realm: Realm) {
-    return realm.objectForPrimaryKey(PlayerState, PLAYER_STATE_SENTINEL);
+    const obj = realm.objectForPrimaryKey(PlayerState, PLAYER_STATE_SENTINEL);
+
+    return obj?.deletedAt ? undefined : obj;
   }
 
   static upsert(realm: Realm, props: PlayerStateProps): PlayerState {
-    const obj = this.defaultObject(realm);
+    const obj = realm.objectForPrimaryKey(PlayerState, PLAYER_STATE_SENTINEL);
 
     return realm.write(() => {
       if (obj) {
+        obj.deletedAt = undefined;
         obj.queueShuffleState = props.queueShuffleState;
         obj.queueRepeatState = props.queueRepeatState;
         obj.queueSourceTrackUuids = props.queueSourceTrackUuids;
@@ -69,6 +74,7 @@ export class PlayerState extends Realm.Object<PlayerState> implements PlayerStat
       } else {
         return realm.create(PlayerState, {
           id: PLAYER_STATE_SENTINEL,
+          deletedAt: undefined,
           ...props,
           duration: Number.isFinite(props.duration) ? props.duration : undefined,
           progress: Number.isFinite(props.progress) ? props.progress : undefined,
@@ -86,7 +92,7 @@ export class PlayerState extends Realm.Object<PlayerState> implements PlayerStat
     }
 
     realm.write(() => {
-      realm.delete(obj);
+      obj.deletedAt = new Date();
     });
   }
 

--- a/relisten/realm/models/repo_utils.ts
+++ b/relisten/realm/models/repo_utils.ts
@@ -1,4 +1,4 @@
-import Realm from 'realm';
+import Realm, { AnyRealmObject } from 'realm';
 import { Show } from '@/relisten/realm/models/show';
 import { Show as ApiShow } from '@/relisten/api/models/show';
 import { showRepo } from '@/relisten/realm/models/show_repo';
@@ -10,11 +10,17 @@ import { RelistenObjectRequiredProperties } from '@/relisten/realm/relisten_obje
 import { log } from '@/relisten/util/logging';
 import { Song } from '@/relisten/realm/models/song';
 import { attachShowArtists } from '@/relisten/realm/models/show_artist_relationships';
+import { MissingCatalogObjectBehavior } from '@/relisten/realm/catalog_retirement';
+import { CatalogRetirementState } from '@/relisten/realm/catalog_retirement_schema';
+import { repairCatalogIntegrity } from '@/relisten/realm/catalog_integrity';
 
 const logger = log.extend('repo-utils');
 
 function upsertShowRelationship<
-  TModel extends RequiredProperties & RequiredRelationships,
+  TModel extends AnyRealmObject &
+    RequiredProperties &
+    RequiredRelationships &
+    CatalogRetirementState,
   TApi extends RelistenApiUpdatableObject,
   RequiredProperties extends RelistenObjectRequiredProperties,
   RequiredRelationships extends object,
@@ -29,18 +35,21 @@ function upsertShowRelationship<
   const uniqueApiUuids = [...new Set(apiUuids)];
   const localValues = [...repo.forUuids(realm, uniqueApiUuids)];
 
-  const { createdModels: createdValues } = repo.upsertMultiple(
+  const { allModels } = repo.upsertMultiple(
     realm,
     api.filter((v) => v !== null && v !== undefined) as TApi[],
     localValues,
-    /* performDeletes= */ false
+    { missingObjectBehavior: MissingCatalogObjectBehavior.Preserve }
   );
 
-  const valuesByUuid = { ...groupByUuid(localValues), ...groupByUuid(createdValues) };
+  const valuesByUuid = groupByUuid([...localValues, ...allModels]);
 
-  for (const show of shows) {
-    applyToShow(show, valuesByUuid);
-  }
+  const applyRelationships = () => {
+    for (const show of shows) applyToShow(show, valuesByUuid);
+  };
+
+  if (realm.isInTransaction) applyRelationships();
+  else realm.write(applyRelationships);
 }
 
 export function upsertShowList(
@@ -49,11 +58,9 @@ export function upsertShowList(
   localShows: Realm.Results<Show>,
   {
     performDeletes,
-    queryForModel,
     upsertModels,
   }: {
     performDeletes: boolean;
-    queryForModel: boolean;
     upsertModels?: {
       tours?: boolean;
       venues?: boolean;
@@ -68,8 +75,11 @@ export function upsertShowList(
     realm,
     apiShows,
     localShows,
-    performDeletes,
-    queryForModel
+    {
+      missingObjectBehavior: performDeletes
+        ? MissingCatalogObjectBehavior.Retire
+        : MissingCatalogObjectBehavior.Preserve,
+    }
   );
 
   attachShowArtists(realm, allShows);
@@ -82,9 +92,7 @@ export function upsertShowList(
       tourRepo,
       allShows,
       (show, toursByUuid) => {
-        if (show.tourUuid && !show.tour) {
-          show.tour = toursByUuid[show.tourUuid];
-        }
+        show.tour = show.tourUuid ? toursByUuid[show.tourUuid] : undefined;
       }
     );
   }
@@ -97,9 +105,7 @@ export function upsertShowList(
       venueRepo,
       allShows,
       (show, venuesByUuid) => {
-        if (show.venueUuid && (!show.venue || show.venue.uuid !== show.venueUuid)) {
-          show.venue = venuesByUuid[show.venueUuid];
-        }
+        show.venue = show.venueUuid ? venuesByUuid[show.venueUuid] : undefined;
       }
     );
   }
@@ -121,4 +127,6 @@ export function upsertShowList(
       realm.write(writeHandler);
     }
   }
+
+  repairCatalogIntegrity(realm, { shows: allShows }, { context: 'show-list-api-reconciliation' });
 }

--- a/relisten/realm/models/show.ts
+++ b/relisten/realm/models/show.ts
@@ -12,6 +12,10 @@ import { duration } from '@/relisten/util/duration';
 import type { Song } from '@/relisten/realm/models/song';
 import { Popularity } from './popularity';
 import type { LibraryIndex } from '@/relisten/realm/library_index';
+import {
+  CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
+  CatalogRetirementState,
+} from '@/relisten/realm/catalog_retirement_schema';
 
 export interface ShowRequiredProperties extends RelistenObjectRequiredProperties {
   artistUuid: string;
@@ -32,7 +36,7 @@ export interface ShowRequiredProperties extends RelistenObjectRequiredProperties
 
 export class Show
   extends Realm.Object<Show, keyof ShowRequiredProperties>
-  implements ShowRequiredProperties, FavoritableObject
+  implements ShowRequiredProperties, FavoritableObject, CatalogRetirementState
 {
   static schema: Realm.ObjectSchema = {
     name: 'Show',
@@ -45,6 +49,7 @@ export class Show
       tourUuid: { type: 'string', optional: true, indexed: true },
       createdAt: 'date',
       updatedAt: 'date',
+      ...CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
       date: { type: 'date', indexed: true },
       avgRating: 'float',
       avgDuration: 'float?',
@@ -74,6 +79,8 @@ export class Show
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  retiredAt?: Date;
+  retirementReason?: string;
   artistUuid!: string;
   yearUuid!: string;
   venueUuid?: string;

--- a/relisten/realm/models/show_artist_relationships.ts
+++ b/relisten/realm/models/show_artist_relationships.ts
@@ -2,6 +2,7 @@ import Realm from 'realm';
 import { groupByUuid } from '@/relisten/util/group_by';
 import { Artist } from '@/relisten/realm/models/artist';
 import { Show } from '@/relisten/realm/models/show';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 function attachShowsToArtists(
   realm: Realm,
@@ -42,7 +43,7 @@ export function attachShowArtists(realm: Realm, shows: Iterable<Show>): number {
 
   const artistUuids = [...new Set(showsNeedingArtists.map((show) => show.artistUuid))];
   const artistsByUuid = groupByUuid(
-    Array.from(realm.objects(Artist).filtered('uuid in $0', artistUuids))
+    Array.from(activeCatalogObjects(realm, Artist).filtered('uuid in $0', artistUuids))
   );
 
   return attachShowsToArtists(realm, showsNeedingArtists, artistsByUuid);
@@ -55,5 +56,9 @@ export function attachArtistsToExistingShows(realm: Realm, artists: Iterable<Art
     return 0;
   }
 
-  return attachShowsToArtists(realm, realm.objects(Show).filtered('artist == nil'), artistsByUuid);
+  return attachShowsToArtists(
+    realm,
+    realm.objects<Show>(Show).filtered('artist == nil'),
+    artistsByUuid
+  );
 }

--- a/relisten/realm/models/show_repo.ts
+++ b/relisten/realm/models/show_repo.ts
@@ -13,13 +13,17 @@ import { NetworkBackedBehaviorOptions } from '../network_backed_behavior';
 import { useNetworkBackedBehavior } from '../network_backed_behavior_hooks';
 import { Show } from './show';
 import { Source } from './source';
+import { SourceTrack } from './source_track';
 import { venueRepo } from './venue_repo';
+import { tourRepo } from './tour_repo';
+import { Venue } from './venue';
+import { Tour } from './tour';
 import { Artist } from './artist';
 import { Year } from './year';
-import { useObject, useRealm } from '@/relisten/realm/schema';
+import { useQuery, useRealm } from '@/relisten/realm/schema';
 import {
+  ActiveCatalogObjectValueStream,
   CombinedValueStream,
-  RealmObjectValueStream,
   RealmQueryValueStream,
   ValueStream,
 } from '@/relisten/realm/value_streams';
@@ -27,6 +31,13 @@ import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_netwo
 import { LibraryIndex } from '@/relisten/realm/library_index';
 import { useOfflineAvailabilityIndex } from '@/relisten/realm/root_services';
 import { attachShowArtists } from '@/relisten/realm/models/show_artist_relationships';
+import {
+  activeCatalogObjectForPrimaryKey,
+  activeCatalogResults,
+  restoreCatalogObject,
+} from '@/relisten/realm/catalog_retirement';
+import { reportCatalogMaintenance } from '@/relisten/realm/catalog_access_monitor';
+import { ensureShowResponseCatalogIntegrity } from '@/relisten/realm/catalog_integrity';
 
 export const showRepo = new Repository(Show);
 
@@ -104,7 +115,12 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
 
   override createLocalUpdatingResults(): ValueStream<ShowWithSources> {
     if (this.sourceUuid !== undefined && this.showUuid === undefined) {
-      const source = this.realm.objectForPrimaryKey(Source, this.sourceUuid);
+      const source = activeCatalogObjectForPrimaryKey(
+        this.realm,
+        Source,
+        this.sourceUuid,
+        'show-detail.source-route-resolution'
+      );
 
       if (source) {
         this.showUuid = source.showUuid;
@@ -113,10 +129,15 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
 
     const showUuid = this.showUuid || '__no_show_sentinel__';
 
-    const showResults = new RealmObjectValueStream(this.realm, Show, showUuid);
+    const showResults = new ActiveCatalogObjectValueStream(
+      this.realm,
+      Show,
+      showUuid,
+      'show-detail.root'
+    );
     const sourcesResults = new RealmQueryValueStream<Source>(
       this.realm,
-      this.realm.objects(Source).filtered('showUuid == $0', showUuid)
+      activeCatalogResults(this.realm.objects(Source)).filtered('showUuid == $0', showUuid)
     );
 
     return new CombinedValueStream(showResults, sourcesResults, (show, sources) => {
@@ -125,7 +146,7 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
   }
 
   isLocalDataShowable(localData: ShowWithSources): boolean {
-    return localData.show !== null && localData.sources.length > 0;
+    return localData.show != null && localData.sources.length > 0;
   }
 
   override upsert(localData: ShowWithSources, apiData: ApiShowWithSources): void {
@@ -135,48 +156,61 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
     const apiSourceTracks = R.flatMap(apiSourceSets, (s) => s.tracks);
     const apiSourceSetsBySource = R.groupBy(apiSourceSets, (s) => s.source_uuid);
     const apiSourceTracksBySet = R.groupBy(apiSourceTracks, (s) => s.source_set_uuid);
+    let restoredArtists = 0;
+    let restoredYears = 0;
+    const reconciledSources: Source[] = [];
+    const reconciledSourceTracks: SourceTrack[] = [];
 
     this.realm.write(() => {
+      if (artist && restoreCatalogObject(artist)) restoredArtists += 1;
+      if (year && restoreCatalogObject(year)) restoredYears += 1;
+
       // TODO: maybe should be inside if statement?
       // it broke doing that, but worth reivisiting
-      const {
-        createdModels: [createdShow],
-        updatedModels: [updatedShow],
-      } = showRepo.upsert(this.realm, apiData, localData.show);
-
-      if (createdShow) {
-        createdShow.artist = artist!;
-      }
-
-      if (!localData.show) {
-        localData.show = updatedShow || createdShow;
-      }
+      const { allModels: showModels } = showRepo.upsert(this.realm, apiData, localData.show);
+      localData.show = showModels[0];
 
       if (localData.show) {
+        if (artist) localData.show.artist = artist;
         attachShowArtists(this.realm, [localData.show]);
       }
 
-      if (localData.show && apiData.venue) {
+      if (localData.show && localData.show.venueUuid && apiData.venue) {
         let venueToUpdate = localData.show.venue;
 
-        if (venueToUpdate && venueToUpdate.uuid !== apiData.venue.uuid) {
+        if (venueToUpdate && venueToUpdate.uuid !== localData.show.venueUuid) {
           venueToUpdate = undefined;
         }
 
-        const { createdModels: createdVenues, updatedModels: updatedVenues } = venueRepo.upsert(
+        const { allModels: venueModels } = venueRepo.upsert(
           this.realm,
           apiData.venue,
-          venueToUpdate,
-          true
+          venueToUpdate
         );
+        localData.show.venue =
+          venueModels[0]?.uuid === localData.show.venueUuid ? venueModels[0] : undefined;
+      } else if (localData.show) {
+        const venue = localData.show.venueUuid
+          ? this.realm.objectForPrimaryKey(Venue, localData.show.venueUuid)
+          : undefined;
+        localData.show.venue = venue && venue.retiredAt == null ? venue : undefined;
+      }
 
-        if (createdVenues.length > 0) {
-          localData.show.venue = createdVenues[0];
+      if (localData.show && localData.show.tourUuid && apiData.tour) {
+        let tourToUpdate = localData.show.tour;
+
+        if (tourToUpdate && tourToUpdate.uuid !== localData.show.tourUuid) {
+          tourToUpdate = undefined;
         }
 
-        if (updatedVenues.length > 0) {
-          localData.show.venue = updatedVenues[0];
-        }
+        const { allModels: tourModels } = tourRepo.upsert(this.realm, apiData.tour, tourToUpdate);
+        localData.show.tour =
+          tourModels[0]?.uuid === localData.show.tourUuid ? tourModels[0] : undefined;
+      } else if (localData.show) {
+        const tour = localData.show.tourUuid
+          ? this.realm.objectForPrimaryKey(Tour, localData.show.tourUuid)
+          : undefined;
+        localData.show.tour = tour && tour.retiredAt == null ? tour : undefined;
       }
 
       // These child objects have global primary keys, but the local lists here are only scoped to
@@ -185,48 +219,70 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
       const { allModels: sourceModels } = sourceRepo.upsertMultiple(
         this.realm,
         apiData.sources,
-        localData.sources,
-        true,
-        true
+        localData.sources
       );
+      reconciledSources.push(...sourceModels);
 
       for (const source of sourceModels) {
-        source.artist = artist!;
+        if (artist) source.artist = artist;
 
-        const { allModels: sourceSets } = sourceSetRepo.upsertMultiple(
-          this.realm,
-          apiSourceSetsBySource[source.uuid] || [],
-          source.sourceSets,
-          true,
-          true
-        );
+        const { allModels: sourceSets, retiredModels: retiredSourceSets } =
+          sourceSetRepo.upsertMultiple(
+            this.realm,
+            apiSourceSetsBySource[source.uuid] || [],
+            source.sourceSets
+          );
 
         // Rebuild the parent list from allModels rather than only appending createdModels. When
         // queryForModel finds an existing row elsewhere in Realm, it must still be reattached to
         // this parent list and stale children must be removed.
-        source.sourceSets.splice(0, source.sourceSets.length, ...sourceSets);
+        source.sourceSets.splice(
+          0,
+          source.sourceSets.length,
+          ...sourceSets,
+          ...retiredSourceSets.sort((a, b) => a.index - b.index)
+        );
 
         for (const sourceSet of sourceSets) {
-          const { allModels: sourceTracks } = sourceTrackRepo.upsertMultiple(
-            this.realm,
-            apiSourceTracksBySet[sourceSet.uuid] || [],
-            sourceSet.sourceTracks,
-            true,
-            true
-          );
+          const { allModels: sourceTracks, retiredModels: retiredSourceTracks } =
+            sourceTrackRepo.upsertMultiple(
+              this.realm,
+              apiSourceTracksBySet[sourceSet.uuid] || [],
+              sourceSet.sourceTracks
+            );
 
           // Same reconciliation rule for tracks: the payload is authoritative for membership and
           // order, even when some rows were found by global lookup instead of being newly created.
-          sourceSet.sourceTracks.splice(0, sourceSet.sourceTracks.length, ...sourceTracks);
+          sourceSet.sourceTracks.splice(
+            0,
+            sourceSet.sourceTracks.length,
+            ...sourceTracks,
+            ...retiredSourceTracks.sort((a, b) => a.trackPosition - b.trackPosition)
+          );
 
           sourceTracks.forEach((st) => {
-            st.artist = artist!;
-            st.year = year!;
-            st.show = localData.show!;
+            if (artist) st.artist = artist;
+            if (year) st.year = year;
+            if (localData.show) st.show = localData.show;
             st.source = source;
           });
+          reconciledSourceTracks.push(...sourceTracks);
         }
       }
+
+      ensureShowResponseCatalogIntegrity(
+        this.realm,
+        localData.show,
+        reconciledSources,
+        reconciledSourceTracks
+      );
+    });
+
+    reportCatalogMaintenance('restored', 'Artist', restoredArtists, {
+      reason: 'referenced-by-show-response',
+    });
+    reportCatalogMaintenance('restored', 'Year', restoredYears, {
+      reason: 'referenced-by-show-response',
     });
   }
 }
@@ -246,10 +302,13 @@ export function useFullShowWithSelectedSource(showUuid: string, selectedSourceUu
   const results = useFullShow(String(showUuid));
   const show = results.data?.show;
   const sources = results.data?.sources;
-  const fallbackArtist = useObject(
+  const fallbackArtistUuid = show?.artistUuid ?? sources?.[0]?.artistUuid ?? '__missing__';
+  const fallbackArtists = useQuery(
     Artist,
-    show?.artistUuid ?? sources?.[0]?.artistUuid ?? '__missing__'
+    (query) => query.filtered('uuid == $0 AND retiredAt == nil', fallbackArtistUuid),
+    [fallbackArtistUuid]
   );
+  const fallbackArtist = fallbackArtists[0];
   const libraryIndex = useOfflineAvailabilityIndex();
 
   const sortedSources = useMemo(() => {
@@ -258,14 +317,10 @@ export function useFullShowWithSelectedSource(showUuid: string, selectedSourceUu
     return sortSources(sources, libraryIndex);
   }, [libraryIndex, sources]);
 
-  // default sourceUuid is initial which will just fall back to sortedSources[0]
   const selectedSource =
-    sortedSources.find(
-      (source) =>
-        source.uuid === selectedSourceUuid ||
-        // Prioritize favorited sources by default
-        (selectedSourceUuid === 'initial' && source.isFavorite)
-    ) ?? sortedSources[0];
+    selectedSourceUuid === 'initial'
+      ? (sortedSources.find((source) => source.isFavorite) ?? sortedSources[0])
+      : sortedSources.find((source) => source.uuid === selectedSourceUuid);
 
   return {
     results,
@@ -281,10 +336,18 @@ export function upsertShowWithSources(
   apiData: ApiShowWithSources
 ): Show | undefined {
   const existingShow = realm.objectForPrimaryKey(Show, apiData.uuid) || undefined;
-  const existingSources = realm.objects(Source).filtered('showUuid == $0', apiData.uuid);
+  const existingSources = activeCatalogResults(realm.objects(Source)).filtered(
+    'showUuid == $0',
+    apiData.uuid
+  );
   const behavior = new ShowWithFullSourcesNetworkBackedBehavior(realm, apiData.uuid);
 
   behavior.upsert({ show: existingShow, sources: existingSources }, apiData);
 
-  return realm.objectForPrimaryKey(Show, apiData.uuid) || existingShow;
+  return activeCatalogObjectForPrimaryKey(
+    realm,
+    Show,
+    apiData.uuid,
+    'show-repository.imperative-upsert'
+  );
 }

--- a/relisten/realm/models/shows/recent_shows_repo.ts
+++ b/relisten/realm/models/shows/recent_shows_repo.ts
@@ -17,6 +17,7 @@ import {
 } from '@/relisten/realm/network_backed_behavior';
 import { useRealm } from '../../schema';
 import { RealmQueryValueStream } from '@/relisten/realm/value_streams';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 export enum RecentShowTabs {
   Performed = 'performed',
@@ -63,7 +64,9 @@ class RecentShowsNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBehavi
 
     return new RealmQueryValueStream<Show>(
       this.realm,
-      this.realm.objects(Show).filtered('artistUuid == $0', this.artistUuid).sorted(sortKey, true)
+      activeCatalogObjects(this.realm, Show)
+        .filtered('artistUuid == $0', this.artistUuid)
+        .sorted(sortKey, true)
     );
   }
 }

--- a/relisten/realm/models/shows/show_with_venues_behavior.ts
+++ b/relisten/realm/models/shows/show_with_venues_behavior.ts
@@ -27,7 +27,6 @@ export abstract class ShowsWithVenueNetworkBackedBehavior extends ThrottledNetwo
     this.realm.write(() => {
       upsertShowList(this.realm, apiData, localData, {
         performDeletes: false,
-        queryForModel: true,
       });
     });
   }

--- a/relisten/realm/models/shows/shows_by_momentum_repo.ts
+++ b/relisten/realm/models/shows/shows_by_momentum_repo.ts
@@ -15,6 +15,7 @@ import {
   NetworkBackedBehaviorOptions,
 } from '@/relisten/realm/network_backed_behavior';
 import { RealmQueryValueStream } from '@/relisten/realm/value_streams';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 class ShowsByMomentumNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBehavior {
   constructor(
@@ -37,7 +38,7 @@ class ShowsByMomentumNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBe
   }
 
   override createLocalUpdatingResults(): RealmQueryValueStream<Show> {
-    let query = this.realm.objects(Show).filtered('popularity != nil');
+    let query = activeCatalogObjects(this.realm, Show).filtered('popularity != nil');
 
     if (this.artistUuids.length > 0) {
       query = query.filtered('artistUuid in $0', this.artistUuids);

--- a/relisten/realm/models/shows/song_shows_repo.ts
+++ b/relisten/realm/models/shows/song_shows_repo.ts
@@ -12,12 +12,16 @@ import { Song } from '../song';
 import { songRepo } from '../song_repo';
 import { useRealm } from '@/relisten/realm/schema';
 import {
+  ActiveCatalogObjectValueStream,
   CombinedValueStream,
-  RealmObjectValueStream,
   RealmQueryValueStream,
+  RetainedCatalogObjectValueStream,
+  RetainedCatalogResultsValueStream,
   ValueStream,
 } from '@/relisten/realm/value_streams';
 import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_network_backed_behavior';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
+import { useGroupSegment } from '@/relisten/util/routes';
 
 export interface SongShows {
   song: Song | null;
@@ -32,6 +36,7 @@ class SongShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
     realm: Realm.Realm,
     public artistUuid: string,
     public songUuid: string,
+    private includeRetiredCatalog: boolean,
     options?: NetworkBackedBehaviorOptions
   ) {
     super(realm, options);
@@ -45,11 +50,16 @@ class SongShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
   }
 
   override createLocalUpdatingResults(): ValueStream<SongShows> {
-    const songResults = new RealmObjectValueStream(this.realm, Song, this.songUuid);
-    const showsResults = new RealmQueryValueStream<Show>(
-      this.realm,
-      this.realm.objects(Show).filtered('ANY songs.uuid == $0', this.songUuid)
-    );
+    const songResults = this.includeRetiredCatalog
+      ? new RetainedCatalogObjectValueStream(this.realm, Song, this.songUuid, 'song-detail.root')
+      : new ActiveCatalogObjectValueStream(this.realm, Song, this.songUuid, 'song-detail.root');
+    const catalogShows = this.includeRetiredCatalog
+      ? this.realm.objects(Show)
+      : activeCatalogObjects(this.realm, Show);
+    const showsQuery = catalogShows.filtered('ANY songs.uuid == $0', this.songUuid);
+    const showsResults = this.includeRetiredCatalog
+      ? new RetainedCatalogResultsValueStream(this.realm, showsQuery, 'song-detail.shows')
+      : new RealmQueryValueStream(this.realm, showsQuery);
 
     return new CombinedValueStream(songResults, showsResults, (song, shows) => {
       return { song, shows };
@@ -61,23 +71,20 @@ class SongShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
   }
 
   override upsert(localData: SongShows, apiData: SongWithShows): void {
-    if (!localData.shows.isValid() || !localData.song?.isValid()) {
+    if (!localData.shows.isValid()) {
       return;
     }
 
     this.realm.write(() => {
-      const { createdModels, updatedModels } = songRepo.upsert(
+      const { allModels } = songRepo.upsert(
         this.realm,
         { ...apiData, shows_played_at: apiData.shows.length },
         localData.song || undefined
       );
 
-      const allModels = [localData.song, ...createdModels, ...updatedModels].filter((s) => !!s);
-
       upsertShowList(this.realm, apiData.shows, localData.shows, {
         // we may not have all the shows here on initial load
         performDeletes: false,
-        queryForModel: true,
         upsertModels: {
           song: allModels.length > 0 ? allModels[0] : undefined,
         },
@@ -91,9 +98,11 @@ export function useSongShows(
   songUuid: string
 ): NetworkBackedResults<SongShows> {
   const realm = useRealm();
+  const groupSegment = useGroupSegment();
+  const includeRetiredCatalog = groupSegment !== '(artists)';
   const behavior = useMemo(() => {
-    return new SongShowsNetworkBackedBehavior(realm, artistUuid, songUuid);
-  }, [realm, artistUuid, songUuid]);
+    return new SongShowsNetworkBackedBehavior(realm, artistUuid, songUuid, includeRetiredCatalog);
+  }, [realm, artistUuid, songUuid, includeRetiredCatalog]);
 
   return useNetworkBackedBehavior(behavior);
 }

--- a/relisten/realm/models/shows/today_shows_repo.ts
+++ b/relisten/realm/models/shows/today_shows_repo.ts
@@ -12,6 +12,7 @@ import { useRealm } from '@/relisten/realm/schema';
 import { useMemo } from 'react';
 import Realm from 'realm';
 import { RealmQueryValueStream } from '@/relisten/realm/value_streams';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 export class TodayShowsNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBehavior {
   private asOf = new Date();
@@ -36,9 +37,10 @@ export class TodayShowsNetworkBackedBehavior extends ShowsWithVenueNetworkBacked
     const formattedMonth = (now.getMonth() + 1).toFixed(0).padStart(2, '0');
     const formattedDay = now.getDate().toFixed(0).padStart(2, '0');
 
-    let query = this.realm
-      .objects(Show)
-      .filtered('displayDate ENDSWITH $0', `-${formattedMonth}-${formattedDay}`);
+    let query = activeCatalogObjects(this.realm, Show).filtered(
+      'displayDate ENDSWITH $0',
+      `-${formattedMonth}-${formattedDay}`
+    );
 
     if (this.artistUuids) {
       query = query.filtered('artistUuid in $0', this.artistUuids);

--- a/relisten/realm/models/shows/top_shows_repo.ts
+++ b/relisten/realm/models/shows/top_shows_repo.ts
@@ -17,6 +17,7 @@ import {
   NetworkBackedBehaviorOptions,
 } from '@/relisten/realm/network_backed_behavior';
 import { RealmQueryValueStream } from '@/relisten/realm/value_streams';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 class TopShowsNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBehavior {
   constructor(
@@ -47,8 +48,7 @@ class TopShowsNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBehavior 
   override createLocalUpdatingResults(): RealmQueryValueStream<Show> {
     return new RealmQueryValueStream<Show>(
       this.realm,
-      this.realm
-        .objects(Show)
+      activeCatalogObjects(this.realm, Show)
         .filtered('artistUuid == $0', this.artistUuid)
         .sorted('avgRating', true)
     );

--- a/relisten/realm/models/shows/tour_shows_repo.ts
+++ b/relisten/realm/models/shows/tour_shows_repo.ts
@@ -12,12 +12,16 @@ import Realm from 'realm';
 import { upsertShowList } from '@/relisten/realm/models/repo_utils';
 import { useRealm } from '@/relisten/realm/schema';
 import {
+  ActiveCatalogObjectValueStream,
   CombinedValueStream,
-  RealmObjectValueStream,
   RealmQueryValueStream,
+  RetainedCatalogObjectValueStream,
+  RetainedCatalogResultsValueStream,
   ValueStream,
 } from '@/relisten/realm/value_streams';
 import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_network_backed_behavior';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
+import { useGroupSegment } from '@/relisten/util/routes';
 
 export interface TourShows {
   tour: Tour | null;
@@ -32,6 +36,7 @@ class TourShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
     realm: Realm.Realm,
     public artistUuid: string,
     public tourUuid: string,
+    private includeRetiredCatalog: boolean,
     options?: NetworkBackedBehaviorOptions
   ) {
     super(realm, options);
@@ -45,11 +50,16 @@ class TourShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
   }
 
   override createLocalUpdatingResults(): ValueStream<TourShows> {
-    const tourResults = new RealmObjectValueStream(this.realm, Tour, this.tourUuid);
-    const showsResults = new RealmQueryValueStream<Show>(
-      this.realm,
-      this.realm.objects(Show).filtered('tourUuid == $0', this.tourUuid)
-    );
+    const tourResults = this.includeRetiredCatalog
+      ? new RetainedCatalogObjectValueStream(this.realm, Tour, this.tourUuid, 'tour-detail.root')
+      : new ActiveCatalogObjectValueStream(this.realm, Tour, this.tourUuid, 'tour-detail.root');
+    const catalogShows = this.includeRetiredCatalog
+      ? this.realm.objects(Show)
+      : activeCatalogObjects(this.realm, Show);
+    const showsQuery = catalogShows.filtered('tourUuid == $0', this.tourUuid);
+    const showsResults = this.includeRetiredCatalog
+      ? new RetainedCatalogResultsValueStream(this.realm, showsQuery, 'tour-detail.shows')
+      : new RealmQueryValueStream(this.realm, showsQuery);
 
     return new CombinedValueStream(tourResults, showsResults, (tour, shows) => {
       return { tour, shows };
@@ -69,7 +79,6 @@ class TourShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
       upsertShowList(this.realm, apiData.shows, localData.shows, {
         // we may not have all the shows here on initial load
         performDeletes: false,
-        queryForModel: true,
         upsertModels: {
           // every tour is the same, so just do it once here
           tours: false,
@@ -86,9 +95,11 @@ export function useTourShows(
   tourUuid: string
 ): NetworkBackedResults<TourShows> {
   const realm = useRealm();
+  const groupSegment = useGroupSegment();
+  const includeRetiredCatalog = groupSegment !== '(artists)';
   const behavior = useMemo(() => {
-    return new TourShowsNetworkBackedBehavior(realm, artistUuid, tourUuid);
-  }, [realm, artistUuid, tourUuid]);
+    return new TourShowsNetworkBackedBehavior(realm, artistUuid, tourUuid, includeRetiredCatalog);
+  }, [realm, artistUuid, tourUuid, includeRetiredCatalog]);
 
   return useNetworkBackedBehavior(behavior);
 }

--- a/relisten/realm/models/shows/venue_shows_repo.ts
+++ b/relisten/realm/models/shows/venue_shows_repo.ts
@@ -12,12 +12,16 @@ import Realm from 'realm';
 import { upsertShowList } from '@/relisten/realm/models/repo_utils';
 import { useRealm } from '@/relisten/realm/schema';
 import {
+  ActiveCatalogObjectValueStream,
   CombinedValueStream,
-  RealmObjectValueStream,
   RealmQueryValueStream,
+  RetainedCatalogObjectValueStream,
+  RetainedCatalogResultsValueStream,
   ValueStream,
 } from '@/relisten/realm/value_streams';
 import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_network_backed_behavior';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
+import { useGroupSegment } from '@/relisten/util/routes';
 
 export interface VenueShows {
   venue: Venue | null;
@@ -32,6 +36,7 @@ class VenueShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
     realm: Realm.Realm,
     public artistUuid: string,
     public venueUuid: string,
+    private includeRetiredCatalog: boolean,
     options?: NetworkBackedBehaviorOptions
   ) {
     super(realm, options);
@@ -45,11 +50,16 @@ class VenueShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
   }
 
   override createLocalUpdatingResults(): ValueStream<VenueShows> {
-    const venueResults = new RealmObjectValueStream(this.realm, Venue, this.venueUuid);
-    const showsResults = new RealmQueryValueStream<Show>(
-      this.realm,
-      this.realm.objects(Show).filtered('venueUuid == $0', this.venueUuid)
-    );
+    const venueResults = this.includeRetiredCatalog
+      ? new RetainedCatalogObjectValueStream(this.realm, Venue, this.venueUuid, 'venue-detail.root')
+      : new ActiveCatalogObjectValueStream(this.realm, Venue, this.venueUuid, 'venue-detail.root');
+    const catalogShows = this.includeRetiredCatalog
+      ? this.realm.objects(Show)
+      : activeCatalogObjects(this.realm, Show);
+    const showsQuery = catalogShows.filtered('venueUuid == $0', this.venueUuid);
+    const showsResults = this.includeRetiredCatalog
+      ? new RetainedCatalogResultsValueStream(this.realm, showsQuery, 'venue-detail.shows')
+      : new RealmQueryValueStream(this.realm, showsQuery);
 
     return new CombinedValueStream(venueResults, showsResults, (venue, shows) => {
       return { venue, shows };
@@ -69,7 +79,6 @@ class VenueShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
       upsertShowList(this.realm, apiData.shows, localData.shows, {
         // we may not have all the shows here on initial load
         performDeletes: false,
-        queryForModel: true,
         upsertModels: {
           // every venue is the same here, so just do it once here
           venues: true,
@@ -86,9 +95,11 @@ export function useVenueShows(
   venueUuid: string
 ): NetworkBackedResults<VenueShows> {
   const realm = useRealm();
+  const groupSegment = useGroupSegment();
+  const includeRetiredCatalog = groupSegment !== '(artists)';
   const behavior = useMemo(() => {
-    return new VenueShowsNetworkBackedBehavior(realm, artistUuid, venueUuid);
-  }, [realm, artistUuid, venueUuid]);
+    return new VenueShowsNetworkBackedBehavior(realm, artistUuid, venueUuid, includeRetiredCatalog);
+  }, [realm, artistUuid, venueUuid, includeRetiredCatalog]);
 
   return useNetworkBackedBehavior(behavior);
 }

--- a/relisten/realm/models/song.ts
+++ b/relisten/realm/models/song.ts
@@ -4,6 +4,10 @@ import { RelistenObjectRequiredProperties } from '../relisten_object';
 import dayjs from 'dayjs';
 import { FavoritableObject } from '../favoritable_object';
 import type { Show } from '@/relisten/realm/models/show';
+import {
+  CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
+  CatalogRetirementState,
+} from '@/relisten/realm/catalog_retirement_schema';
 
 export interface SongRequiredProperties extends RelistenObjectRequiredProperties {
   uuid: string;
@@ -19,7 +23,7 @@ export interface SongRequiredProperties extends RelistenObjectRequiredProperties
 
 export class Song
   extends Realm.Object<Song, keyof SongRequiredProperties>
-  implements SongRequiredProperties, FavoritableObject
+  implements SongRequiredProperties, FavoritableObject, CatalogRetirementState
 {
   static schema: Realm.ObjectSchema = {
     name: 'Song',
@@ -27,6 +31,7 @@ export class Song
     properties: {
       createdAt: 'date',
       updatedAt: 'date',
+      ...CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
       artistUuid: 'string',
       name: 'string',
       slug: 'string',
@@ -45,6 +50,8 @@ export class Song
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  retiredAt?: Date;
+  retirementReason?: string;
   artistUuid!: string;
   name!: string;
   slug!: string;

--- a/relisten/realm/models/song_repo.ts
+++ b/relisten/realm/models/song_repo.ts
@@ -7,6 +7,7 @@ import { useArtist } from './artist_repo';
 import { Song } from './song';
 import { NetworkBackedBehaviorOptions } from '@/relisten/realm/network_backed_behavior';
 import { NetworkBackedModelArrayBehavior } from '@/relisten/realm/network_backed_model_array_behavior';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 export const songRepo = new Repository(Song);
 
@@ -17,7 +18,7 @@ export function useSongs(artistUuid: string, options?: NetworkBackedBehaviorOpti
     return new NetworkBackedModelArrayBehavior(
       realm,
       songRepo,
-      (realm) => realm.objects(Song).filtered('artistUuid == $0', artistUuid),
+      (realm) => activeCatalogObjects(realm, Song).filtered('artistUuid == $0', artistUuid),
       (api) => api.songs(artistUuid),
       options
     );

--- a/relisten/realm/models/source.ts
+++ b/relisten/realm/models/source.ts
@@ -9,6 +9,10 @@ import { Artist } from '@/relisten/realm/models/artist';
 import { duration } from '@/relisten/util/duration';
 import { checkIfOfflineSourceTrackExists } from '@/relisten/realm/realm_filters';
 import type { LibraryIndex } from '@/relisten/realm/library_index';
+import {
+  CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
+  CatalogRetirementState,
+} from '@/relisten/realm/catalog_retirement_schema';
 
 export interface SourceRequiredProperties extends RelistenObjectRequiredProperties {
   artistUuid: string;
@@ -37,7 +41,7 @@ export interface SourceRequiredProperties extends RelistenObjectRequiredProperti
 
 export class Source
   extends Realm.Object<Source, keyof SourceRequiredProperties>
-  implements SourceRequiredProperties, FavoritableObject
+  implements SourceRequiredProperties, FavoritableObject, CatalogRetirementState
 {
   static schema: Realm.ObjectSchema = {
     name: 'Source',
@@ -46,6 +50,7 @@ export class Source
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      ...CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
       artistUuid: { type: 'string', indexed: true },
       showUuid: { type: 'string', indexed: true },
       venueUuid: { type: 'string', optional: true, indexed: true },
@@ -85,6 +90,8 @@ export class Source
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  retiredAt?: Date;
+  retirementReason?: string;
   artistUuid!: string;
   venueUuid?: string;
   displayDate!: string;

--- a/relisten/realm/models/source_set.ts
+++ b/relisten/realm/models/source_set.ts
@@ -4,6 +4,10 @@ import { SourceSet as ApiSourceSet } from '../../api/models/source_set';
 import { RelistenObjectRequiredProperties } from '../relisten_object';
 import dayjs from 'dayjs';
 import type { SourceTrack } from './source_track';
+import {
+  CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
+  CatalogRetirementState,
+} from '@/relisten/realm/catalog_retirement_schema';
 
 export interface SourceSetRequiredProperties extends RelistenObjectRequiredProperties {
   uuid: string;
@@ -20,7 +24,7 @@ export interface SourceSetRequiredProperties extends RelistenObjectRequiredPrope
 
 export class SourceSet
   extends Realm.Object<SourceSet, keyof SourceSetRequiredProperties>
-  implements SourceSetRequiredProperties
+  implements SourceSetRequiredProperties, CatalogRetirementState
 {
   static schema: Realm.ObjectSchema = {
     name: 'SourceSet',
@@ -29,6 +33,7 @@ export class SourceSet
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      ...CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
       artistUuid: { type: 'string', indexed: true },
       sourceUuid: { type: 'string', indexed: true },
 
@@ -43,6 +48,8 @@ export class SourceSet
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  retiredAt?: Date;
+  retirementReason?: string;
 
   artistUuid!: string;
   sourceUuid!: string;

--- a/relisten/realm/models/source_track.ts
+++ b/relisten/realm/models/source_track.ts
@@ -11,6 +11,10 @@ import { Year } from './year';
 import { trackDuration } from '@/relisten/util/duration';
 import { Paths } from 'expo-file-system';
 import { sharedStatsigClient } from '@/relisten/events';
+import {
+  CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
+  CatalogRetirementState,
+} from '@/relisten/realm/catalog_retirement_schema';
 
 export const OFFLINE_DIRECTORY = Paths.join(Paths.document, 'offline');
 
@@ -48,7 +52,7 @@ export interface SourceTrackRequiredProperties extends RelistenObjectRequiredPro
 
 export class SourceTrack
   extends Realm.Object<SourceTrack, keyof SourceTrackRequiredProperties>
-  implements SourceTrackRequiredProperties
+  implements SourceTrackRequiredProperties, CatalogRetirementState
 {
   static schema: Realm.ObjectSchema = {
     name: 'SourceTrack',
@@ -57,6 +61,7 @@ export class SourceTrack
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      ...CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
       artistUuid: { type: 'string', indexed: true },
       sourceUuid: { type: 'string', indexed: true },
       sourceSetUuid: { type: 'string', indexed: true },
@@ -85,6 +90,8 @@ export class SourceTrack
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  retiredAt?: Date;
+  retirementReason?: string;
 
   sourceUuid!: string;
   sourceSetUuid!: string;

--- a/relisten/realm/models/source_track_offline_info.ts
+++ b/relisten/realm/models/source_track_offline_info.ts
@@ -1,6 +1,8 @@
 import Realm from 'realm';
 import type { SourceTrack } from '@/relisten/realm/models/source_track';
 
+export const ACTIVE_SOURCE_TRACK_OFFLINE_INFO_QUERY = 'deletedAt == nil';
+
 export enum SourceTrackOfflineInfoStatus {
   UNKNOWN,
   Queued,
@@ -34,6 +36,7 @@ export class SourceTrackOfflineInfo extends Realm.Object<SourceTrackOfflineInfo>
       percent: { type: 'double', default: 0 },
 
       errorInfo: 'string?',
+      deletedAt: { type: 'date', optional: true, indexed: true },
 
       sourceTracks: {
         type: 'linkingObjects',
@@ -60,6 +63,7 @@ export class SourceTrackOfflineInfo extends Realm.Object<SourceTrackOfflineInfo>
   percent!: number;
 
   errorInfo?: string;
+  deletedAt?: Date;
 
   sourceTracks!: Realm.List<SourceTrack>;
 
@@ -68,6 +72,6 @@ export class SourceTrackOfflineInfo extends Realm.Object<SourceTrackOfflineInfo>
   }
 
   isPlayableOffline() {
-    return this.status == SourceTrackOfflineInfoStatus.Succeeded;
+    return !this.deletedAt && this.status == SourceTrackOfflineInfoStatus.Succeeded;
   }
 }

--- a/relisten/realm/models/tour.ts
+++ b/relisten/realm/models/tour.ts
@@ -3,6 +3,10 @@ import { TourWithShowCount } from '../../api/models/tour';
 import { RelistenObjectRequiredProperties } from '../relisten_object';
 import dayjs from 'dayjs';
 import { FavoritableObject } from '../favoritable_object';
+import {
+  CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
+  CatalogRetirementState,
+} from '@/relisten/realm/catalog_retirement_schema';
 
 export interface TourRequiredProperties extends RelistenObjectRequiredProperties {
   uuid: string;
@@ -19,7 +23,7 @@ export interface TourRequiredProperties extends RelistenObjectRequiredProperties
 
 export class Tour
   extends Realm.Object<Tour, keyof TourRequiredProperties>
-  implements TourRequiredProperties, FavoritableObject
+  implements TourRequiredProperties, FavoritableObject, CatalogRetirementState
 {
   static schema: Realm.ObjectSchema = {
     name: 'Tour',
@@ -27,6 +31,7 @@ export class Tour
     properties: {
       createdAt: 'date',
       updatedAt: 'date',
+      ...CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
       artistUuid: 'string',
       startDate: 'date',
       endDate: 'date',
@@ -41,6 +46,8 @@ export class Tour
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  retiredAt?: Date;
+  retirementReason?: string;
   artistUuid!: string;
   startDate!: Date;
   endDate!: Date;

--- a/relisten/realm/models/tour_repo.ts
+++ b/relisten/realm/models/tour_repo.ts
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 import { Tour } from './tour';
 import { NetworkBackedBehaviorOptions } from '@/relisten/realm/network_backed_behavior';
 import { NetworkBackedModelArrayBehavior } from '@/relisten/realm/network_backed_model_array_behavior';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 export const tourRepo = new Repository(Tour);
 
@@ -17,7 +18,7 @@ export function useTours(artistUuid: string, options?: NetworkBackedBehaviorOpti
     return new NetworkBackedModelArrayBehavior(
       realm,
       tourRepo,
-      (realm) => realm.objects(Tour).filtered('artistUuid == $0', artistUuid),
+      (realm) => activeCatalogObjects(realm, Tour).filtered('artistUuid == $0', artistUuid),
       (api) => api.tours(artistUuid),
       options
     );

--- a/relisten/realm/models/venue.ts
+++ b/relisten/realm/models/venue.ts
@@ -4,6 +4,10 @@ import { FavoritableObject } from '../favoritable_object';
 
 import { RelistenObjectRequiredProperties } from '../relisten_object';
 import dayjs from 'dayjs';
+import {
+  CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
+  CatalogRetirementState,
+} from '@/relisten/realm/catalog_retirement_schema';
 
 export interface VenueRequiredProperties extends RelistenObjectRequiredProperties {
   createdAt: Date;
@@ -21,7 +25,7 @@ export interface VenueRequiredProperties extends RelistenObjectRequiredPropertie
 
 export class Venue
   extends Realm.Object<Venue, keyof VenueRequiredProperties>
-  implements VenueRequiredProperties, FavoritableObject
+  implements VenueRequiredProperties, FavoritableObject, CatalogRetirementState
 {
   static schema: Realm.ObjectSchema = {
     name: 'Venue',
@@ -30,6 +34,7 @@ export class Venue
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      ...CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
       artistUuid: 'string',
       latitude: 'double?',
       longitude: 'double?',
@@ -47,6 +52,8 @@ export class Venue
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  retiredAt?: Date;
+  retirementReason?: string;
   artistUuid!: string;
   latitude?: number;
   longitude?: number;

--- a/relisten/realm/models/venue_repo.ts
+++ b/relisten/realm/models/venue_repo.ts
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 import { Venue } from './venue';
 import { NetworkBackedBehaviorOptions } from '@/relisten/realm/network_backed_behavior';
 import { NetworkBackedModelArrayBehavior } from '@/relisten/realm/network_backed_model_array_behavior';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 export const venueRepo = new Repository(Venue);
 
@@ -17,7 +18,11 @@ export function useVenues(artistUuid: string, options?: NetworkBackedBehaviorOpt
     return new NetworkBackedModelArrayBehavior(
       realm,
       venueRepo,
-      (realm) => realm.objects(Venue).filtered('artistUuid == $0 && showsAtVenue > 0', artistUuid),
+      (realm) =>
+        activeCatalogObjects(realm, Venue).filtered(
+          'artistUuid == $0 && showsAtVenue > 0',
+          artistUuid
+        ),
       (api) => api.venues(artistUuid),
       options
     );

--- a/relisten/realm/models/year.ts
+++ b/relisten/realm/models/year.ts
@@ -6,6 +6,10 @@ import { checkIfOfflineSourceTrackExists } from '../realm_filters';
 import { SourceTrack } from './source_track';
 import { Popularity } from './popularity';
 import type { LibraryIndex } from '@/relisten/realm/library_index';
+import {
+  CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
+  CatalogRetirementState,
+} from '@/relisten/realm/catalog_retirement_schema';
 
 export interface YearRequiredProperties extends RelistenObjectRequiredProperties {
   artistUuid: string;
@@ -20,7 +24,7 @@ export interface YearRequiredProperties extends RelistenObjectRequiredProperties
 
 export class Year
   extends Realm.Object<Year, keyof YearRequiredProperties>
-  implements YearRequiredProperties
+  implements YearRequiredProperties, CatalogRetirementState
 {
   static schema: Realm.ObjectSchema = {
     name: 'Year',
@@ -29,6 +33,7 @@ export class Year
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      ...CATALOG_RETIREMENT_SCHEMA_PROPERTIES,
       artistUuid: { type: 'string', indexed: true },
       showCount: 'int',
       sourceCount: 'int',
@@ -49,6 +54,8 @@ export class Year
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  retiredAt?: Date;
+  retirementReason?: string;
   artistUuid!: string;
   showCount!: Realm.Types.Int;
   sourceCount!: Realm.Types.Int;

--- a/relisten/realm/models/year_repo.ts
+++ b/relisten/realm/models/year_repo.ts
@@ -2,7 +2,7 @@ import { Repository } from '../repository';
 import { useQuery, useRealm } from '../schema';
 import { Year } from './year';
 
-import { useIsOfflineTab } from '@/relisten/util/routes';
+import { useGroupSegment } from '@/relisten/util/routes';
 import { useMemo } from 'react';
 import Realm from 'realm';
 import { RelistenApiClient, RelistenApiResponse } from '../../api/client';
@@ -15,13 +15,16 @@ import { useArtist } from './artist_repo';
 import { Show } from './show';
 import { upsertShowList } from '@/relisten/realm/models/repo_utils';
 import {
+  ActiveCatalogObjectValueStream,
   CombinedValueStream,
-  RealmObjectValueStream,
   RealmQueryValueStream,
+  RetainedCatalogObjectValueStream,
+  RetainedCatalogResultsValueStream,
   ValueStream,
 } from '@/relisten/realm/value_streams';
 import { NetworkBackedModelArrayBehavior } from '@/relisten/realm/network_backed_model_array_behavior';
 import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_network_backed_behavior';
+import { activeCatalogObjects } from '@/relisten/realm/catalog_retirement';
 
 export const yearRepo = new Repository(Year);
 
@@ -29,28 +32,42 @@ export function yearsNetworkBackedModelArrayBehavior(
   realm: Realm.Realm,
   isOfflineTab: boolean,
   artistUuid: string,
-  options?: NetworkBackedBehaviorOptions
+  options?: NetworkBackedBehaviorOptions,
+  includeRetiredCatalog: boolean = isOfflineTab
 ) {
   return new NetworkBackedModelArrayBehavior(
     realm,
     yearRepo,
-    (realm) =>
-      filterForUser<Year>(realm.objects(Year).filtered('artistUuid == $0', artistUuid), {
+    (realm) => {
+      const catalogYears = includeRetiredCatalog
+        ? realm.objects(Year)
+        : activeCatalogObjects(realm, Year);
+      return filterForUser<Year>(catalogYears.filtered('artistUuid == $0', artistUuid), {
         isFavorite: null,
         isPlayableOffline: isOfflineTab ? true : null,
-      }),
+      });
+    },
     (api) => api.years(artistUuid),
-    options
+    options,
+    includeRetiredCatalog ? 'year-list.retained' : undefined
   );
 }
 
 export function useYears(artistUuid: string, options?: NetworkBackedBehaviorOptions) {
   const realm = useRealm();
-  const isOfflineTab = useIsOfflineTab();
+  const groupSegment = useGroupSegment();
+  const isOfflineTab = groupSegment === '(offline)';
+  const includeRetiredCatalog = groupSegment !== '(artists)';
 
   const behavior = useMemo(() => {
-    return yearsNetworkBackedModelArrayBehavior(realm, isOfflineTab, artistUuid, options);
-  }, [realm, isOfflineTab, artistUuid, options]);
+    return yearsNetworkBackedModelArrayBehavior(
+      realm,
+      isOfflineTab,
+      artistUuid,
+      options,
+      includeRetiredCatalog
+    );
+  }, [realm, isOfflineTab, artistUuid, options, includeRetiredCatalog]);
 
   return useNetworkBackedBehavior(behavior);
 }
@@ -83,6 +100,7 @@ export class YearShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavi
     public artistUuid: string,
     public yearUuid: string,
     private userFilters: UserFilters,
+    private includeRetiredCatalog: boolean,
     options?: NetworkBackedBehaviorOptions
   ) {
     super(realm, options);
@@ -96,14 +114,19 @@ export class YearShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavi
   }
 
   override createLocalUpdatingResults(): ValueStream<YearShows> {
-    const yearResults = new RealmObjectValueStream(this.realm, Year, this.yearUuid);
-    const showsResults = new RealmQueryValueStream<Show>(
-      this.realm,
-      filterForUser(
-        this.realm.objects(Show).filtered('yearUuid == $0', this.yearUuid),
-        this.userFilters
-      )
+    const yearResults = this.includeRetiredCatalog
+      ? new RetainedCatalogObjectValueStream(this.realm, Year, this.yearUuid, 'year-detail.root')
+      : new ActiveCatalogObjectValueStream(this.realm, Year, this.yearUuid, 'year-detail.root');
+    const catalogShows = this.includeRetiredCatalog
+      ? this.realm.objects(Show)
+      : activeCatalogObjects(this.realm, Show);
+    const showsQuery = filterForUser(
+      catalogShows.filtered('yearUuid == $0', this.yearUuid),
+      this.userFilters
     );
+    const showsResults = this.includeRetiredCatalog
+      ? new RetainedCatalogResultsValueStream(this.realm, showsQuery, 'year-detail.shows')
+      : new RealmQueryValueStream(this.realm, showsQuery);
 
     return new CombinedValueStream(yearResults, showsResults, (year, shows) => {
       return { year, shows };
@@ -123,8 +146,8 @@ export class YearShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavi
       upsertShowList(this.realm, apiData.shows, localData.shows, {
         // we may not have all the shows here on initial load
         performDeletes: false,
-        queryForModel: true, // we know this list of shows is authoritative
       });
+      yearRepo.upsert(this.realm, apiData, localData.year ?? undefined);
     });
   }
 }
@@ -136,7 +159,16 @@ export function createYearShowsNetworkBackedBehavior(
   userFilters: UserFilters,
   options?: NetworkBackedBehaviorOptions
 ) {
-  return new YearShowsNetworkBackedBehavior(realm, artistUuid, yearUuid, userFilters, options);
+  const includeRetiredCatalog =
+    userFilters.isPlayableOffline === true || userFilters.isFavorite === true;
+  return new YearShowsNetworkBackedBehavior(
+    realm,
+    artistUuid,
+    yearUuid,
+    userFilters,
+    includeRetiredCatalog,
+    options
+  );
 }
 
 export function useYearShows(
@@ -144,14 +176,22 @@ export function useYearShows(
   yearUuid: string
 ): NetworkBackedResults<YearShows> {
   const realm = useRealm();
-  const isOfflineTab = useIsOfflineTab();
+  const groupSegment = useGroupSegment();
+  const isOfflineTab = groupSegment === '(offline)';
+  const includeRetiredCatalog = groupSegment !== '(artists)';
 
   const behavior = useMemo(() => {
-    return new YearShowsNetworkBackedBehavior(realm, artistUuid, yearUuid, {
-      isPlayableOffline: isOfflineTab ? true : null,
-      isFavorite: null,
-    });
-  }, [realm, artistUuid, yearUuid, isOfflineTab]);
+    return new YearShowsNetworkBackedBehavior(
+      realm,
+      artistUuid,
+      yearUuid,
+      {
+        isPlayableOffline: isOfflineTab ? true : null,
+        isFavorite: null,
+      },
+      includeRetiredCatalog
+    );
+  }, [realm, artistUuid, yearUuid, isOfflineTab, includeRetiredCatalog]);
 
   return useNetworkBackedBehavior(behavior);
 }
@@ -171,6 +211,7 @@ export const useArtistYearShows = (artistUuid: string, yearUuid: string) => {
 };
 
 export const useOfflineYearMetadata = (year?: Year | null) => {
+  // Offline metadata intentionally includes retired parents that still own retained downloads.
   const shows = useRealmTabsFilter(
     useQuery(Show, (query) => query.filtered('yearUuid = $0', year?.uuid), [year?.uuid])
   );

--- a/relisten/realm/network_backed_model_array_behavior.ts
+++ b/relisten/realm/network_backed_model_array_behavior.ts
@@ -2,12 +2,20 @@ import Realm, { AnyRealmObject } from 'realm';
 import { RelistenApiUpdatableObject, Repository } from '@/relisten/realm/repository';
 import { RelistenObjectRequiredProperties } from '@/relisten/realm/relisten_object';
 import { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
-import { RealmQueryValueStream, ValueStream } from '@/relisten/realm/value_streams';
+import {
+  RealmQueryValueStream,
+  RetainedCatalogResultsValueStream,
+  ValueStream,
+} from '@/relisten/realm/value_streams';
 import { NetworkBackedBehaviorOptions } from '@/relisten/realm/network_backed_behavior';
 import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_network_backed_behavior';
+import { CatalogRetirementState } from '@/relisten/realm/catalog_retirement_schema';
 
 export class NetworkBackedModelArrayBehavior<
-  TModel extends AnyRealmObject & RequiredProperties & RequiredRelationships,
+  TModel extends AnyRealmObject &
+    RequiredProperties &
+    RequiredRelationships &
+    CatalogRetirementState,
   TApi extends RelistenApiUpdatableObject,
   RequiredProperties extends RelistenObjectRequiredProperties,
   RequiredRelationships extends object,
@@ -20,13 +28,17 @@ export class NetworkBackedModelArrayBehavior<
       api: RelistenApiClient,
       forcedRefresh: boolean
     ) => Promise<RelistenApiResponse<TApi[]>>,
-    options?: NetworkBackedBehaviorOptions
+    options?: NetworkBackedBehaviorOptions,
+    private readonly retainedAccessSite?: string
   ) {
     super(realm, options);
   }
 
   override createLocalUpdatingResults(): ValueStream<Realm.Results<TModel>> {
-    return new RealmQueryValueStream<TModel>(this.realm, this.fetchFromRealm(this.realm));
+    const results = this.fetchFromRealm(this.realm);
+    return this.retainedAccessSite
+      ? new RetainedCatalogResultsValueStream(this.realm, results, this.retainedAccessSite)
+      : new RealmQueryValueStream<TModel>(this.realm, results);
   }
 
   fetchFromApi(
@@ -41,6 +53,6 @@ export class NetworkBackedModelArrayBehavior<
   }
 
   override upsert(localData: Realm.Results<TModel>, apiData: TApi[]): void {
-    this.repository.upsertMultiple(this.realm, apiData, localData, true, true);
+    this.repository.upsertMultiple(this.realm, apiData, localData);
   }
 }

--- a/relisten/realm/network_backed_model_behavior.ts
+++ b/relisten/realm/network_backed_model_behavior.ts
@@ -2,12 +2,16 @@ import Realm, { AnyRealmObject } from 'realm';
 import { RelistenApiUpdatableObject, Repository } from '@/relisten/realm/repository';
 import { RelistenObjectRequiredProperties } from '@/relisten/realm/relisten_object';
 import { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
-import { RealmObjectValueStream, ValueStream } from '@/relisten/realm/value_streams';
+import { ActiveCatalogObjectValueStream, ValueStream } from '@/relisten/realm/value_streams';
 import { NetworkBackedBehaviorOptions } from '@/relisten/realm/network_backed_behavior';
 import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_network_backed_behavior';
+import { CatalogRetirementState } from '@/relisten/realm/catalog_retirement_schema';
 
 export class NetworkBackedModelBehavior<
-  TModel extends AnyRealmObject & RequiredProperties & RequiredRelationships,
+  TModel extends AnyRealmObject &
+    RequiredProperties &
+    RequiredRelationships &
+    CatalogRetirementState,
   TApi extends RelistenApiUpdatableObject,
   RequiredProperties extends RelistenObjectRequiredProperties,
   RequiredRelationships extends object,
@@ -34,14 +38,19 @@ export class NetworkBackedModelBehavior<
 
   override createLocalUpdatingResults(): ValueStream<TModel | null> {
     const [type, primaryKey] = this.fetchFromRealm();
-    return new RealmObjectValueStream<TModel>(this.realm, type, primaryKey);
+    return new ActiveCatalogObjectValueStream<TModel>(
+      this.realm,
+      type,
+      String(primaryKey),
+      'network-backed-model.root'
+    );
   }
 
   isLocalDataShowable(localData: TModel | null): boolean {
     return localData !== null;
   }
 
-  override upsert(localData: TModel, apiData: TApi): void {
-    this.repository.upsert(this.realm, apiData, localData);
+  override upsert(localData: TModel | null, apiData: TApi): void {
+    this.repository.upsert(this.realm, apiData, localData ?? undefined);
   }
 }

--- a/relisten/realm/realm_filters.ts
+++ b/relisten/realm/realm_filters.ts
@@ -6,8 +6,10 @@ import { RelistenObject } from '../api/models/relisten';
 
 export const checkIfOfflineSourceTrackExists = (items: Realm.List<SourceTrack>) => {
   return (
-    items.filtered('offlineInfo.status == $0 LIMIT(1)', SourceTrackOfflineInfoStatus.Succeeded)
-      .length >= 1
+    items.filtered(
+      'offlineInfo.deletedAt == nil AND offlineInfo.status == $0 LIMIT(1)',
+      SourceTrackOfflineInfoStatus.Succeeded
+    ).length >= 1
   );
 };
 
@@ -16,7 +18,7 @@ export const useRealmTabsFilter = <T extends RelistenObject>(items: Realm.Result
 
   if (isOfflineTab) {
     return items.filtered(
-      'SUBQUERY(sourceTracks, $item, $item.offlineInfo.status == $0).@count > 0',
+      'SUBQUERY(sourceTracks, $item, $item.offlineInfo.deletedAt == nil AND $item.offlineInfo.status == $0).@count > 0',
       SourceTrackOfflineInfoStatus.Succeeded
     );
   }
@@ -43,7 +45,7 @@ export function filterForUser<T extends RelistenObject>(
   }
   if (isPlayableOffline !== null) {
     filters.push(
-      `SUBQUERY(sourceTracks, $item, $item.offlineInfo.status == ${SourceTrackOfflineInfoStatus.Succeeded}).@count ${isPlayableOffline ? '>' : '='} 0`
+      `SUBQUERY(sourceTracks, $item, $item.offlineInfo.deletedAt == nil AND $item.offlineInfo.status == ${SourceTrackOfflineInfoStatus.Succeeded}).@count ${isPlayableOffline ? '>' : '='} 0`
     );
   }
 

--- a/relisten/realm/repository.ts
+++ b/relisten/realm/repository.ts
@@ -1,10 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import Realm from 'realm';
+import Realm, { AnyRealmObject } from 'realm';
 import { RelistenObjectRequiredProperties } from './relisten_object';
 import dayjs from 'dayjs';
 import * as R from 'remeda';
 import { log } from '../util/logging';
 import { groupByUuid } from '@/relisten/util/group_by';
+import { reportCatalogMaintenance } from '@/relisten/realm/catalog_access_monitor';
+import {
+  MissingCatalogObjectBehavior,
+  restoreCatalogObject,
+} from '@/relisten/realm/catalog_retirement';
+import { CatalogRetirementState } from '@/relisten/realm/catalog_retirement_schema';
+import {
+  CatalogObject,
+  CATALOG_MODEL_NAMES,
+  emptyCatalogModelCounts,
+  retireCatalogGraph,
+} from '@/relisten/realm/catalog_retirement_graph';
 // @ts-expect-error tsc doesn't like it but this works? AnyRealmObject is exported from 'realm' but RealmObject is not
 import { RealmObject } from 'realm/dist/public-types/Object';
 
@@ -26,25 +38,36 @@ export interface RelistenApiUpdatableObject {
 export interface UpsertResults<T> {
   created: number;
   updated: number;
-  deleted: number;
+  retired: number;
+  restored: number;
   updatedModels: T[];
   createdModels: T[];
+  retiredModels: T[];
+  restoredModels: T[];
   allModels: T[];
+}
+
+export interface UpsertMultipleOptions {
+  missingObjectBehavior?: MissingCatalogObjectBehavior;
+  retiredAt?: Date;
 }
 
 function combinedUpsertResults<T>(acc: UpsertResults<T>, b: UpsertResults<T>): UpsertResults<T> {
   acc.created += b.created;
   acc.updated += b.updated;
-  acc.deleted += b.deleted;
+  acc.retired += b.retired;
+  acc.restored += b.restored;
   acc.updatedModels.push(...b.updatedModels);
   acc.createdModels.push(...b.createdModels);
+  acc.retiredModels.push(...b.retiredModels);
+  acc.restoredModels.push(...b.restoredModels);
   acc.allModels.push(...b.allModels);
 
   return acc;
 }
 
 function humanizeUpsertResults(a: UpsertResults<unknown>) {
-  return `created=${a.created}, updated=${a.updated}, deleted=${a.deleted}; all=${a.allModels.length}`;
+  return `created=${a.created}, updated=${a.updated}, retired=${a.retired}, restored=${a.restored}; all=${a.allModels.length}`;
 }
 
 function getUpdatedAt<T extends { updated_at: string }>(obj: T): dayjs.Dayjs {
@@ -61,7 +84,10 @@ function getUpdatedAt<T extends { updated_at: string }>(obj: T): dayjs.Dayjs {
 }
 
 export class Repository<
-  TModel extends RequiredProperties & RequiredRelationships,
+  TModel extends AnyRealmObject &
+    RequiredProperties &
+    RequiredRelationships &
+    CatalogRetirementState,
   TApi extends RelistenApiUpdatableObject,
   RequiredProperties extends RelistenObjectRequiredProperties,
   RequiredRelationships extends object,
@@ -72,7 +98,20 @@ export class Repository<
     realm: Realm,
     uuids?: ReadonlyArray<string>
   ): Realm.Results<RealmObject<TModel, never> & TModel> {
-    let query = realm.objects<TModel>(this.klass.name);
+    let query = realm.objects<TModel>(this.klass.schema.name);
+
+    if (uuids) {
+      query = query.filtered('uuid in $0', uuids);
+    }
+
+    return query.filtered('retiredAt == nil');
+  }
+
+  public forUuidsIncludingRetired(
+    realm: Realm,
+    uuids?: ReadonlyArray<string>
+  ): Realm.Results<RealmObject<TModel, never> & TModel> {
+    let query = realm.objects<TModel>(this.klass.schema.name);
 
     if (uuids) {
       query = query.filtered('uuid in $0', uuids);
@@ -114,13 +153,8 @@ export class Repository<
     return model;
   }
 
-  public upsert(
-    realm: Realm,
-    api: TApi,
-    model: TModel | undefined,
-    queryForModel = false
-  ): UpsertResults<TModel> {
-    const writeHandler = () => this.upsertWithinWrite(realm, api, model, queryForModel);
+  public upsert(realm: Realm, api: TApi, model?: TModel): UpsertResults<TModel> {
+    const writeHandler = () => this.upsertWithinWrite(realm, api, model);
 
     let res: UpsertResults<TModel>;
 
@@ -141,24 +175,23 @@ export class Repository<
     return res;
   }
 
-  private upsertWithinWrite(
-    realm: Realm,
-    api: TApi,
-    model: TModel | undefined,
-    queryForModel = true
-  ): UpsertResults<TModel> {
-    if (queryForModel && !model) {
+  private upsertWithinWrite(realm: Realm, api: TApi, model?: TModel): UpsertResults<TModel> {
+    // Catalog UUIDs are global. Active-only callers intentionally cannot see a tombstone, so
+    // always resolve a missing model from the complete table before deciding to create it.
+    if (!model) {
       model =
-        realm.objectForPrimaryKey<TModel>(this.klass.name, api.uuid as unknown as any) || undefined;
+        realm.objectForPrimaryKey<TModel>(this.klass.schema.name, api.uuid as unknown as any) ||
+        undefined;
     }
 
     if (model) {
       if (api.uuid !== model.uuid) {
         logger.error(
-          `upsertWithinWrite with mismatched ${this.klass.name}: api.uuid=${api.uuid}, model.uuid=${model.uuid}`
+          `upsertWithinWrite with mismatched ${this.klass.schema.name}: api.uuid=${api.uuid}, model.uuid=${model.uuid}`
         );
       }
 
+      const restored = restoreCatalogObject(model);
       const shouldUpdateFromApi = this.klass.shouldUpdateFromApi?.(model, api) ?? false;
 
       if (getUpdatedAt(api).toDate() > model.updatedAt || shouldUpdateFromApi) {
@@ -167,9 +200,12 @@ export class Repository<
         return {
           created: 0,
           updated: 1,
-          deleted: 0,
+          retired: 0,
+          restored: restored ? 1 : 0,
           updatedModels: [model],
           createdModels: [],
+          retiredModels: [],
+          restoredModels: restored ? [model] : [],
           allModels: [model],
         };
       }
@@ -177,9 +213,12 @@ export class Repository<
       return {
         created: 0,
         updated: 0,
-        deleted: 0,
+        retired: 0,
+        restored: restored ? 1 : 0,
         createdModels: [],
         updatedModels: [],
+        retiredModels: [],
+        restoredModels: restored ? [model] : [],
         allModels: [model],
       };
     } else {
@@ -188,9 +227,12 @@ export class Repository<
       return {
         created: 1,
         updated: 0,
-        deleted: 0,
+        retired: 0,
+        restored: 0,
         createdModels: [newModel],
         updatedModels: [],
+        retiredModels: [],
+        restoredModels: [],
         allModels: [newModel],
       };
     }
@@ -200,10 +242,10 @@ export class Repository<
     realm: Realm,
     api: ReadonlyArray<TApi>,
     models: ReadonlyArray<TModel> | Realm.List<TModel> | Realm.Results<TModel>,
-    performDeletes: boolean = true,
-    queryForModel = false,
-    shouldPreserve?: (model: TModel) => boolean
+    options: UpsertMultipleOptions = {}
   ): UpsertResults<TModel> {
+    const { missingObjectBehavior = MissingCatalogObjectBehavior.Retire, retiredAt = new Date() } =
+      options;
     const dbIds = [...new Set(models.map((m) => m.uuid))];
     const networkUuids = [...new Set(api.map((a) => a.uuid))];
 
@@ -215,31 +257,43 @@ export class Repository<
     const modelsById = groupByUuid(models as ReadonlyArray<TModel>);
     const networkApisByUuid = groupByUuid(api);
 
-    const acc = {
+    const acc: UpsertResults<TModel> = {
       created: 0,
       updated: 0,
-      deleted: 0,
+      retired: 0,
+      restored: 0,
       updatedModels: [],
       createdModels: [],
+      retiredModels: [],
+      restoredModels: [],
       allModels: [],
     };
+    const retirementCounts = emptyCatalogModelCounts();
 
     const writeHandler = () => {
-      if (performDeletes) {
+      if (missingObjectBehavior === MissingCatalogObjectBehavior.Retire) {
         for (const uuid of dbIdsToRemove) {
           const model = modelsById[uuid];
-          if (shouldPreserve?.(model)) {
-            continue;
+          const result = retireCatalogGraph(realm, model as unknown as CatalogObject, {
+            reason: 'api-reconciliation',
+            retiredAt,
+            report: false,
+          });
+          // A Venue or Tour can be protected by an active Show. Only return actual tombstones;
+          // already-retired children remain included so retained parent memberships can preserve
+          // them during reconciliation.
+          if (model.retiredAt) acc.retiredModels.push(model);
+          acc.retired += result.total;
+          for (const modelName of CATALOG_MODEL_NAMES) {
+            retirementCounts[modelName] += result.counts[modelName];
           }
-          realm.delete(model);
-          acc.deleted += 1;
         }
       }
 
       for (const uuid of networkUuidsToUpsert) {
         combinedUpsertResults(
           acc,
-          this.upsertWithinWrite(realm, networkApisByUuid[uuid], modelsById[uuid], queryForModel)
+          this.upsertWithinWrite(realm, networkApisByUuid[uuid], modelsById[uuid])
         );
       }
     };
@@ -255,6 +309,14 @@ export class Repository<
       this.klass.schema.name,
       `api length=${networkUuids.length}, ${humanizeUpsertResults(acc)}`
     );
+
+    for (const modelName of CATALOG_MODEL_NAMES) {
+      reportCatalogMaintenance('retired', modelName, retirementCounts[modelName], {
+        reason: 'api-reconciliation',
+        reconciledModel: this.klass.schema.name,
+      });
+    }
+    reportCatalogMaintenance('restored', this.klass.schema.name, acc.restored);
 
     return acc;
   }

--- a/relisten/realm/schema.ts
+++ b/relisten/realm/schema.ts
@@ -23,6 +23,7 @@ import {
   PopularityWindows,
 } from '@/relisten/realm/models/popularity';
 import { isVerboseProfileLoggingEnabled } from '@/relisten/util/profile_logging';
+import { runRealmStartupMaintenance } from '@/relisten/realm/startup_maintenance';
 
 if (isVerboseProfileLoggingEnabled()) {
   Realm.setLogger(({ category, level, message }) => {
@@ -34,7 +35,7 @@ if (isVerboseProfileLoggingEnabled()) {
   Realm.setLogLevel('debug', 'Realm.Storage.Notification');
 }
 
-const realmConfig: Realm.Configuration = {
+export const realmConfig: Realm.Configuration = {
   schema: [
     Artist,
     Year,
@@ -57,7 +58,7 @@ const realmConfig: Realm.Configuration = {
     PopularityWindow,
     PopularityWindows,
   ],
-  schemaVersion: 12,
+  schemaVersion: 13,
   // As to not conflict with the prior versions default.realm that isn't readable with this version of the SDK
   path: './relisten.realm',
 };
@@ -82,6 +83,7 @@ export async function openRealm(): Promise<Realm> {
   if (!realmOpenPromise) {
     realmOpenPromise = Realm.open(realmConfig)
       .then((openedRealm) => {
+        runRealmStartupMaintenance(openedRealm);
         setRealm(openedRealm);
         return openedRealm;
       })

--- a/relisten/realm/startup_maintenance.ts
+++ b/relisten/realm/startup_maintenance.ts
@@ -1,0 +1,50 @@
+import * as Sentry from '@sentry/react-native';
+import Realm from 'realm';
+
+import {
+  auditCatalogRetirementGraph,
+  runColdStartCatalogGarbageCollection,
+} from '@/relisten/realm/catalog_gc';
+import { repairCatalogIntegrityAtStartup } from '@/relisten/realm/catalog_integrity';
+import { cleanupPlaybackHistoryAtStartup } from '@/relisten/realm/models/history/playback_history_lifecycle';
+import { collectTransientTombstonesAtStartup } from '@/relisten/realm/transient_tombstone_lifecycle';
+import { log } from '@/relisten/util/logging';
+
+const logger = log.extend('realm-startup-maintenance');
+const completedRealmPaths = new Set<string>();
+
+function runMaintenancePhase(phase: string, operation: () => unknown): void {
+  try {
+    operation();
+  } catch (error) {
+    logger.error(`Realm startup maintenance phase failed: ${phase}`, error);
+    Sentry.captureException(error, {
+      fingerprint: ['realm-startup-maintenance', phase],
+      tags: { realm_maintenance_phase: phase },
+    });
+  }
+}
+
+/**
+ * Runs destructive Realm maintenance before any app service, React tree, or
+ * CarPlay template can retain managed objects. A failed phase is reported and
+ * skipped for the rest of this JS session; retrying after consumers start would
+ * violate the collector's safety contract.
+ */
+export function runRealmStartupMaintenance(realm: Realm): void {
+  if (completedRealmPaths.has(realm.path)) return;
+
+  runMaintenancePhase('catalog-integrity-repair', () => repairCatalogIntegrityAtStartup(realm));
+  runMaintenancePhase('playback-history', () => cleanupPlaybackHistoryAtStartup(realm));
+  runMaintenancePhase('transient-tombstones', () => collectTransientTombstonesAtStartup(realm));
+  runMaintenancePhase('catalog-graph-audit', () => auditCatalogRetirementGraph(realm));
+  runMaintenancePhase('catalog-garbage-collection', () =>
+    runColdStartCatalogGarbageCollection(realm, { auditGraph: false })
+  );
+
+  completedRealmPaths.add(realm.path);
+}
+
+export function resetRealmStartupMaintenanceForTests() {
+  completedRealmPaths.clear();
+}

--- a/relisten/realm/transient_tombstone_lifecycle.ts
+++ b/relisten/realm/transient_tombstone_lifecycle.ts
@@ -1,0 +1,157 @@
+import * as Sentry from '@sentry/react-native';
+import Realm from 'realm';
+import { File, Paths } from 'expo-file-system';
+import { LastFmScrobbleEntry } from '@/relisten/realm/models/lastfm_scrobble_entry';
+import { PlayerState } from '@/relisten/realm/models/player_state';
+import { OFFLINE_DIRECTORY } from '@/relisten/realm/models/source_track';
+import { SourceTrackOfflineInfo } from '@/relisten/realm/models/source_track_offline_info';
+import { log } from '@/relisten/util/logging';
+
+const logger = log.extend('transient-tombstone-lifecycle');
+const DELETED_QUERY = 'deletedAt != nil';
+
+export const DEFAULT_TRANSIENT_TOMBSTONE_STARTUP_CLEANUP_BATCH_LIMIT = 250;
+
+interface TransientTombstoneCounts {
+  sourceTrackOfflineInfos: number;
+  playerStates: number;
+  lastFmScrobbleEntries: number;
+}
+
+export interface TransientTombstoneCollectionResult extends TransientTombstoneCounts {
+  deferred: TransientTombstoneCounts;
+}
+
+export interface TransientTombstoneCollectionOptions {
+  batchLimitPerModel?: number;
+  now?: Date;
+}
+
+/**
+ * Physically collects transient tombstones. The startup gate must call this
+ * before services, download callbacks, or React consumers acquire managed
+ * objects from this Realm.
+ */
+export function collectTransientTombstonesAtStartup(
+  realm: Realm,
+  {
+    batchLimitPerModel = DEFAULT_TRANSIENT_TOMBSTONE_STARTUP_CLEANUP_BATCH_LIMIT,
+    now = new Date(),
+  }: TransientTombstoneCollectionOptions = {}
+): TransientTombstoneCollectionResult {
+  if (!Number.isInteger(batchLimitPerModel) || batchLimitPerModel < 0) {
+    throw new Error('Transient tombstone cleanup batchLimitPerModel must be non-negative');
+  }
+
+  const allSourceTrackOfflineInfos = realm
+    .objects(SourceTrackOfflineInfo)
+    .filtered(DELETED_QUERY)
+    .sorted('deletedAt');
+  const allPlayerStates = realm.objects(PlayerState).filtered(DELETED_QUERY).sorted('deletedAt');
+  const allLastFmScrobbleEntries = realm
+    .objects(LastFmScrobbleEntry)
+    .filtered(DELETED_QUERY)
+    .sorted('deletedAt');
+  const sourceTrackOfflineInfos = allSourceTrackOfflineInfos
+    .snapshot()
+    .slice(0, batchLimitPerModel);
+  const playerStates = allPlayerStates.snapshot().slice(0, batchLimitPerModel);
+  const lastFmScrobbleEntries = allLastFmScrobbleEntries.snapshot().slice(0, batchLimitPerModel);
+
+  const collectableSourceTrackOfflineInfos: SourceTrackOfflineInfo[] = [];
+  const retryableSourceTrackOfflineInfos: SourceTrackOfflineInfo[] = [];
+
+  for (const offlineInfo of sourceTrackOfflineInfos) {
+    const path = Paths.join(OFFLINE_DIRECTORY, `${offlineInfo.sourceTrackUuid}.mp3`);
+
+    try {
+      const downloadedFile = new File(path);
+      if (downloadedFile.exists) {
+        downloadedFile.delete();
+      }
+
+      if (new File(path).exists) {
+        logger.warn(
+          `${offlineInfo.sourceTrackUuid}: deferring offline-info collection because its file still exists`
+        );
+        retryableSourceTrackOfflineInfos.push(offlineInfo);
+        continue;
+      }
+
+      collectableSourceTrackOfflineInfos.push(offlineInfo);
+    } catch (error) {
+      logger.warn(
+        `${offlineInfo.sourceTrackUuid}: deferring offline-info collection after file cleanup failed`,
+        error
+      );
+      retryableSourceTrackOfflineInfos.push(offlineInfo);
+    }
+  }
+
+  const result = {
+    sourceTrackOfflineInfos: collectableSourceTrackOfflineInfos.length,
+    playerStates: playerStates.length,
+    lastFmScrobbleEntries: lastFmScrobbleEntries.length,
+    deferred: {
+      sourceTrackOfflineInfos:
+        allSourceTrackOfflineInfos.length - collectableSourceTrackOfflineInfos.length,
+      playerStates: allPlayerStates.length - playerStates.length,
+      lastFmScrobbleEntries: allLastFmScrobbleEntries.length - lastFmScrobbleEntries.length,
+    },
+  };
+  const totalCollected =
+    result.sourceTrackOfflineInfos + result.playerStates + result.lastFmScrobbleEntries;
+  const totalDeferred =
+    result.deferred.sourceTrackOfflineInfos +
+    result.deferred.playerStates +
+    result.deferred.lastFmScrobbleEntries;
+
+  if (totalCollected === 0 && totalDeferred === 0) return result;
+
+  realm.write(() => {
+    // Move failed file-cleanup attempts to the back of the oldest-first queue
+    // so a permanently blocked path cannot starve later tombstones forever.
+    for (const offlineInfo of retryableSourceTrackOfflineInfos) {
+      if (offlineInfo.isValid() && offlineInfo.deletedAt != null) offlineInfo.deletedAt = now;
+    }
+
+    for (const offlineInfo of collectableSourceTrackOfflineInfos) {
+      for (const sourceTrack of Array.from(offlineInfo.sourceTracks)) {
+        if (!sourceTrack.isValid()) {
+          continue;
+        }
+
+        const linkedOfflineInfo = sourceTrack.offlineInfo;
+        if (
+          linkedOfflineInfo?.isValid() &&
+          linkedOfflineInfo.sourceTrackUuid === offlineInfo.sourceTrackUuid
+        ) {
+          sourceTrack.offlineInfo = undefined;
+        }
+      }
+    }
+
+    if (collectableSourceTrackOfflineInfos.length > 0) {
+      realm.delete(collectableSourceTrackOfflineInfos);
+    }
+    if (playerStates.length > 0) {
+      realm.delete(playerStates);
+    }
+    if (lastFmScrobbleEntries.length > 0) {
+      realm.delete(lastFmScrobbleEntries);
+    }
+  });
+
+  logger.info('Collected or deferred transient Realm tombstones at startup.', result);
+
+  if (totalDeferred > 0) {
+    Sentry.addBreadcrumb({
+      category: 'realm.transient-tombstone.cleanup',
+      level: 'info',
+      message: 'Transient Realm tombstone collection deferred to a later reboot',
+      data: { batchLimitPerModel, ...result.deferred },
+    });
+  }
+
+  return result;
+}

--- a/relisten/realm/value_streams.ts
+++ b/relisten/realm/value_streams.ts
@@ -2,6 +2,11 @@ import Realm, { AnyRealmObject } from 'realm';
 import { CollectionCallback } from '@realm/react/src/helpers';
 import { createCachedObject } from '@realm/react/src/cachedObject';
 import { createCachedCollection } from '@realm/react/src/cachedCollection';
+import { CatalogRetirementState } from '@/relisten/realm/catalog_retirement_schema';
+import {
+  readActiveCatalogObject,
+  readRetainedCatalogObject,
+} from '@/relisten/realm/catalog_retirement';
 
 export abstract class ValueStream<T> {
   protected listeners: ((nextValue: T) => void)[] = [];
@@ -122,6 +127,115 @@ export class RealmQueryValueStream<T extends AnyRealmObject> extends ValueStream
   tearDown() {
     super.tearDown();
     this.cachedCollectionTearDown();
+  }
+}
+
+export class RetainedCatalogResultsValueStream<
+  T extends AnyRealmObject & CatalogRetirementState & { uuid: string },
+> extends ValueStream<Realm.Results<T>> {
+  public currentValue: Realm.Results<T>;
+  private readonly resultsStream: RealmQueryValueStream<T>;
+  private readonly tearDownResultsListener: () => void;
+
+  constructor(
+    realm: Realm.Realm,
+    collection: Realm.Results<T>,
+    private readonly accessSite: string
+  ) {
+    super();
+
+    this.resultsStream = new RealmQueryValueStream(realm, collection);
+    this.currentValue = this.resultsStream.currentValue;
+    this.reportRetainedMembers();
+
+    let addingListener = true;
+    this.tearDownResultsListener = this.resultsStream.addListener((results) => {
+      // The subscription synchronously replays the value that was reported above.
+      if (addingListener) return;
+
+      this.currentValue = results;
+      this.reportRetainedMembers();
+      this.emitCurrentValue();
+    });
+    addingListener = false;
+  }
+
+  override tearDown() {
+    super.tearDown();
+    this.tearDownResultsListener();
+    this.resultsStream.tearDown();
+  }
+
+  private reportRetainedMembers() {
+    for (const object of this.currentValue.filtered('retiredAt != nil')) {
+      readRetainedCatalogObject(object, this.accessSite);
+    }
+  }
+}
+
+class RealmSingleResultValueStream<T extends AnyRealmObject> extends ValueStream<T | null> {
+  public currentValue: T | null;
+  private readonly resultsStream: RealmQueryValueStream<T>;
+  private readonly tearDownResultsListener: () => void;
+
+  constructor(
+    realm: Realm.Realm,
+    query: Realm.Results<T>,
+    private readonly resolveCurrentObject: (results: Realm.Results<T>) => T | null = (results) =>
+      results[0] ?? null
+  ) {
+    super();
+
+    this.resultsStream = new RealmQueryValueStream(realm, query);
+    this.currentValue = this.resolveCurrentObject(this.resultsStream.currentValue);
+    let addingListener = true;
+    this.tearDownResultsListener = this.resultsStream.addListener((results) => {
+      // ValueStream subscriptions synchronously replay their current value. The value above is
+      // already resolved, and retained resolvers have access-reporting side effects.
+      if (addingListener) return;
+
+      this.currentValue = this.resolveCurrentObject(results);
+      this.emitCurrentValue();
+    });
+    addingListener = false;
+  }
+
+  override tearDown() {
+    super.tearDown();
+    this.tearDownResultsListener();
+    this.resultsStream.tearDown();
+  }
+}
+
+export class ActiveCatalogObjectValueStream<
+  T extends AnyRealmObject & CatalogRetirementState & { uuid: string },
+> extends RealmSingleResultValueStream<T> {
+  constructor(
+    realm: Realm.Realm,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type: string | (new (...args: any) => T),
+    uuid: string,
+    accessSite: string
+  ) {
+    super(realm, realm.objects<T>(type as never).filtered('uuid == $0', uuid), (results) => {
+      return readActiveCatalogObject(results[0], accessSite) ?? null;
+    });
+  }
+}
+
+export class RetainedCatalogObjectValueStream<
+  T extends AnyRealmObject & CatalogRetirementState & { uuid: string },
+> extends RealmSingleResultValueStream<T> {
+  constructor(
+    realm: Realm.Realm,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type: string | (new (...args: any) => T),
+    uuid: string,
+    accessSite: string
+  ) {
+    super(realm, realm.objects<T>(type as never).filtered('uuid == $0', uuid), (results) => {
+      return readRetainedCatalogObject(results[0], accessSite) ?? null;
+    });
   }
 }
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['relisten/**/*.test.ts'],
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,31 @@
+import { vi } from 'vitest';
+
+const logger = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+vi.mock('@/relisten/util/logging', () => ({
+  log: Object.assign(logger, { extend: () => logger }),
+}));
+
+vi.mock('@sentry/react-native', () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('expo-file-system', () => ({
+  Paths: {
+    document: '/tmp',
+    join: (...parts: string[]) => parts.join('/'),
+  },
+}));
+
+vi.mock('@/relisten/events', () => ({
+  sharedStatsigClient: () => ({
+    getDynamicConfig: () => ({ get: (_key: string, fallback: unknown) => fallback }),
+  }),
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,6 +2166,11 @@
   dependencies:
     which "^4.0.0"
 
+"@oxc-project/types@=0.146.0":
+  version "0.146.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.146.0.tgz#d57a2591abbf1f6e50981b07ee24ab269530d87a"
+  integrity sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -2582,6 +2587,86 @@
     "@babel/runtime" ">=7"
     react-native ">=0.68"
 
+"@rolldown/binding-android-arm-eabi@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz#165b80910de7cd33f772d5b7b045b259acb7420c"
+  integrity sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==
+
+"@rolldown/binding-android-arm64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz#5ed74d4b8fa56c68eb1aeb81d0d207a85b6de05c"
+  integrity sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==
+
+"@rolldown/binding-darwin-arm64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz#6f27c7060e58ca03061fa7d50f9dc409bc377fe1"
+  integrity sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==
+
+"@rolldown/binding-darwin-x64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz#74ab897d134ede4072fdc6108f00193e6167ee28"
+  integrity sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==
+
+"@rolldown/binding-freebsd-x64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz#7d337f9ae4b739674e1938747118ab0676c8ef8a"
+  integrity sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz#a8195dc1091ade0f912b0613ef6500941e5615f4"
+  integrity sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==
+
+"@rolldown/binding-linux-arm64-gnu@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz#40fbbb97072b1acaa3e0e8fe9774fe524e860bba"
+  integrity sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==
+
+"@rolldown/binding-linux-arm64-musl@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz#3cfe8b0f7c13de29dace9a9fc6c03081164176ab"
+  integrity sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==
+
+"@rolldown/binding-linux-ppc64-gnu@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz#3bd890d96ae29f93718aa142ed0982f2ee2978ad"
+  integrity sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==
+
+"@rolldown/binding-linux-s390x-gnu@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz#0959a0d5af22741d5787918e27aef70dc8602804"
+  integrity sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==
+
+"@rolldown/binding-linux-x64-gnu@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz#7baa94e826328ac6f457d9e1abacffa0353e8d22"
+  integrity sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==
+
+"@rolldown/binding-linux-x64-musl@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz#5f37597eaf0e22313d1e3d4be7d1be1fd332904e"
+  integrity sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==
+
+"@rolldown/binding-openharmony-arm64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz#d096567af3f738cbe6aa858ab0a01aae9f357ef4"
+  integrity sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==
+
+"@rolldown/binding-win32-arm64-msvc@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz#d53b911aa4e6b547b789c07747fabab2ac8c237d"
+  integrity sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==
+
+"@rolldown/binding-win32-x64-msvc@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz#7bbd08cfda6a98de9b756472c772a36ebb7229bc"
+  integrity sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==
+
+"@rolldown/pluginutils@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
+
 "@sentry-internal/browser-utils@10.37.0":
   version "10.37.0"
   resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-10.37.0.tgz#18271f3d56dad87bc65e9e8042d966bf752a3a98"
@@ -2746,6 +2831,11 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
 "@statsig/client-core@3.31.0":
   version "3.31.0"
   resolved "https://registry.yarnpkg.com/@statsig/client-core/-/client-core-3.31.0.tgz#decec1aaf147f5e283fe1dda2239368ec4ad3ea4"
@@ -2855,6 +2945,14 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
 "@types/concat-stream@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/concat-stream/-/concat-stream-2.0.3.tgz#1f5c2ad26525716c181191f7ed53408f78eb758e"
@@ -2868,6 +2966,11 @@
   integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
   dependencies:
     "@types/ms" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/estree-jsx@^1.0.0":
   version "1.0.5"
@@ -3122,6 +3225,66 @@
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+
+"@vitest/expect@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.11.tgz#5f580d1f9cdbba314dbf23b2d911f8eb23878f5f"
+  integrity sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.11"
+    "@vitest/utils" "4.1.11"
+    chai "^6.2.2"
+    tinyrainbow "^3.1.0"
+
+"@vitest/mocker@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.11.tgz#8e2906361bc5dfa271757a858ae80643118fcbb4"
+  integrity sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==
+  dependencies:
+    "@vitest/spy" "4.1.11"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.11.tgz#8b28eb8240771d6ea970e33beaeb41384b51868e"
+  integrity sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==
+  dependencies:
+    tinyrainbow "^3.1.0"
+
+"@vitest/runner@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.11.tgz#bfbad98c8d6c3f1fb4df12056ad569821ff77f21"
+  integrity sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==
+  dependencies:
+    "@vitest/utils" "4.1.11"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.11.tgz#df461eb165924a3155986dde68e13360f53f3d4c"
+  integrity sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==
+  dependencies:
+    "@vitest/pretty-format" "4.1.11"
+    "@vitest/utils" "4.1.11"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.11.tgz#0add45cae953afed9c88f98e2f6fc9164558c32a"
+  integrity sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==
+
+"@vitest/utils@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.11.tgz#9b27a4293b827942b223539bfab1bd9f7eada31b"
+  integrity sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==
+  dependencies:
+    "@vitest/pretty-format" "4.1.11"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.1.0"
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.10"
@@ -3378,6 +3541,11 @@ asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 async-function@^1.0.0:
   version "1.0.0"
@@ -3830,6 +3998,11 @@ ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chalk@^2.0.1, chalk@^2.4.2:
   version "2.4.2"
@@ -4628,6 +4801,11 @@ es-iterator-helpers@^1.2.1:
     iterator.prototype "^1.1.4"
     safe-array-concat "^1.1.3"
 
+es-module-lexer@^2.0.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.3.2.tgz#311fa4f40168c1975c505477c51b23234d41ad55"
+  integrity sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==
+
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
@@ -4899,6 +5077,13 @@ estree-util-visit@^2.0.0:
     "@types/estree-jsx" "^1.0.0"
     "@types/unist" "^3.0.0"
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -4918,6 +5103,11 @@ expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
+expect-type@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
 
 expo-application@~57.0.0:
   version "57.0.0"
@@ -5429,7 +5619,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -6474,55 +6664,110 @@ lightningcss-android-arm64@1.30.2:
   resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz#6966b7024d39c94994008b548b71ab360eb3a307"
   integrity sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==
 
+lightningcss-android-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz#9a6841f88ae50fc83502903892b41af41bc2b907"
+  integrity sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==
+
 lightningcss-darwin-arm64@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz#a5fa946d27c029e48c7ff929e6e724a7de46eb2c"
   integrity sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==
+
+lightningcss-darwin-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz#c0f2c31c0bfd19fa4dd3f18e957a1f1a152097d6"
+  integrity sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==
 
 lightningcss-darwin-x64@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz#5ce87e9cd7c4f2dcc1b713f5e8ee185c88d9b7cd"
   integrity sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==
 
+lightningcss-darwin-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz#cb0705965acb538c6683949ce6925fb3cdf7c361"
+  integrity sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==
+
 lightningcss-freebsd-x64@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz#6ae1d5e773c97961df5cff57b851807ef33692a5"
   integrity sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==
+
+lightningcss-freebsd-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz#763538828b26bab2680dadafcc84ee78b0eb502b"
+  integrity sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==
 
 lightningcss-linux-arm-gnueabihf@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz#62c489610c0424151a6121fa99d77731536cdaeb"
   integrity sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==
 
+lightningcss-linux-arm-gnueabihf@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz#6862e3176a331aedbdec1ed352b4d7d0dd0784de"
+  integrity sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==
+
 lightningcss-linux-arm64-gnu@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz#2a3661b56fe95a0cafae90be026fe0590d089298"
   integrity sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==
+
+lightningcss-linux-arm64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz#c6a3a2ed15141daf6bdc2628930f8e39bdf473aa"
+  integrity sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==
 
 lightningcss-linux-arm64-musl@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz#d7ddd6b26959245e026bc1ad9eb6aa983aa90e6b"
   integrity sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==
 
+lightningcss-linux-arm64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz#7fa1334971fc82845f9827df6ef8a0b20914bac6"
+  integrity sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==
+
 lightningcss-linux-x64-gnu@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz#5a89814c8e63213a5965c3d166dff83c36152b1a"
   integrity sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==
+
+lightningcss-linux-x64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz#8b927862ea8c2bbc6831a46509244b50d9936e55"
+  integrity sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==
 
 lightningcss-linux-x64-musl@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz#808c2e91ce0bf5d0af0e867c6152e5378c049728"
   integrity sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==
 
+lightningcss-linux-x64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz#0c525bb077dfd94404c059cfe42dad797e96aeaf"
+  integrity sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==
+
 lightningcss-win32-arm64-msvc@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz#ab4a8a8a2e6a82a4531e8bbb6bf0ff161ee6625a"
   integrity sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==
 
+lightningcss-win32-arm64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz#850ee1103dac989cfab50e3ac22d1a69e394e63d"
+  integrity sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==
+
 lightningcss-win32-x64-msvc@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz#f01f382c8e0a27e1c018b0bee316d210eac43b6e"
   integrity sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==
+
+lightningcss-win32-x64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz#e343ae152eed3609dc6e11949d1a3bf39a1c946f"
+  integrity sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==
 
 lightningcss@^1.30.1:
   version "1.30.2"
@@ -6542,6 +6787,25 @@ lightningcss@^1.30.1:
     lightningcss-linux-x64-musl "1.30.2"
     lightningcss-win32-arm64-msvc "1.30.2"
     lightningcss-win32-x64-msvc "1.30.2"
+
+lightningcss@^1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.33.0.tgz#c08867d71a79385c6e190214fd72fef3e5f95f0b"
+  integrity sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.33.0"
+    lightningcss-darwin-arm64 "1.33.0"
+    lightningcss-darwin-x64 "1.33.0"
+    lightningcss-freebsd-x64 "1.33.0"
+    lightningcss-linux-arm-gnueabihf "1.33.0"
+    lightningcss-linux-arm64-gnu "1.33.0"
+    lightningcss-linux-arm64-musl "1.33.0"
+    lightningcss-linux-x64-gnu "1.33.0"
+    lightningcss-linux-x64-musl "1.33.0"
+    lightningcss-win32-arm64-msvc "1.33.0"
+    lightningcss-win32-x64-msvc "1.33.0"
 
 lilconfig@^2.1.0:
   version "2.1.0"
@@ -6653,6 +6917,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -7630,6 +7901,11 @@ nanoid@^3.3.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.15.tgz#36c490fad8c6e86c824c940dfdde999b69ed4316"
   integrity sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==
 
+nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
+
 napi-build-utils@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-2.0.0.tgz#13c22c0187fcfccce1461844136372a47ddc027e"
@@ -7853,6 +8129,11 @@ object.values@^1.1.6, object.values@^1.2.1:
     call-bound "^1.0.3"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
+
+obug@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.4.tgz#9090d8a548a522517915d2aa6aae907197ac6cf8"
+  integrity sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==
 
 on-finished@2.4.1:
   version "2.4.1"
@@ -8090,6 +8371,11 @@ path-scurry@^2.0.0:
     lru-cache "^11.0.0"
     minipass "^7.1.2"
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -8099,6 +8385,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.3, picomatch@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
 picomatch@^4.0.4:
   version "4.0.4"
@@ -8257,6 +8548,15 @@ postcss@^8.5.14:
   integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
   dependencies:
     nanoid "^3.3.12"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@^8.5.26:
+  version "8.5.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
+  dependencies:
+    nanoid "^3.3.17"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -9019,6 +9319,30 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rolldown@~1.2.4:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.2.5.tgz#1f504a7d05260a769e617d950410bbb051498c50"
+  integrity sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==
+  dependencies:
+    "@oxc-project/types" "=0.146.0"
+    "@rolldown/pluginutils" "^1.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm-eabi" "1.2.5"
+    "@rolldown/binding-android-arm64" "1.2.5"
+    "@rolldown/binding-darwin-arm64" "1.2.5"
+    "@rolldown/binding-darwin-x64" "1.2.5"
+    "@rolldown/binding-freebsd-x64" "1.2.5"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.2.5"
+    "@rolldown/binding-linux-arm64-gnu" "1.2.5"
+    "@rolldown/binding-linux-arm64-musl" "1.2.5"
+    "@rolldown/binding-linux-ppc64-gnu" "1.2.5"
+    "@rolldown/binding-linux-s390x-gnu" "1.2.5"
+    "@rolldown/binding-linux-x64-gnu" "1.2.5"
+    "@rolldown/binding-linux-x64-musl" "1.2.5"
+    "@rolldown/binding-openharmony-arm64" "1.2.5"
+    "@rolldown/binding-win32-arm64-msvc" "1.2.5"
+    "@rolldown/binding-win32-x64-msvc" "1.2.5"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -9262,6 +9586,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.2, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -9388,6 +9717,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
@@ -9414,6 +9748,11 @@ statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+std-env@^4.0.0-rc.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.2.0.tgz#8ebe0ec60485668ab47227b312f4254cdf80c9d3"
+  integrity sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -9800,13 +10139,28 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-tinyglobby@^0.2.15:
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.3.0.tgz#aacc1dbb1d4e93e6ad8dd64944e09f9ad147a474"
+  integrity sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==
+
+tinyglobby@^0.2.15, tinyglobby@^0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
   integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.4"
+
+tinyrainbow@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.1.tgz#c0168387d3d8d70b6b3c2c0936de5fee738cea20"
+  integrity sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==
 
 tmp@^0.2.4:
   version "0.2.5"
@@ -10258,6 +10612,45 @@ vfile@^6.0.0, vfile@^6.0.3:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.2.2.tgz#399aefad3656145145be110d137a07ea5bb55014"
+  integrity sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==
+  dependencies:
+    lightningcss "^1.33.0"
+    picomatch "^4.0.5"
+    postcss "^8.5.26"
+    rolldown "~1.2.4"
+    tinyglobby "^0.2.17"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^4.1.9:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.11.tgz#1653c1521ae917f960d9b21877797c47dfd8bf21"
+  integrity sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==
+  dependencies:
+    "@vitest/expect" "4.1.11"
+    "@vitest/mocker" "4.1.11"
+    "@vitest/pretty-format" "4.1.11"
+    "@vitest/runner" "4.1.11"
+    "@vitest/snapshot" "4.1.11"
+    "@vitest/spy" "4.1.11"
+    "@vitest/utils" "4.1.11"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.1.0"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running "^2.3.0"
+
 vlq@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
@@ -10376,6 +10769,14 @@ which@^4.0.0:
   integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
   dependencies:
     isexe "^3.1.1"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
## Summary

Replace normal Realm deletions with soft deletion so stale managed references remain valid instead of crashing. Retired objects are hidden from active browsing while history, favorites, downloads, and playback queues can continue resolving them safely.

## Behavior

- Add tombstone fields to catalog, playback-history, offline, queue-state, and Last.fm models.
- Retire and resurrect catalog graphs without changing primary keys.
- Keep active queries tombstone-free while explicitly retained paths can access deleted objects.
- Convert history clears, download cleanup, queue cleanup, and Last.fm cleanup to tombstoning.
- Update app and CarPlay consumers to use explicit active or retained access policies.
- Leave physical Realm deletion only in cold-start maintenance collectors.

## Garbage collection and telemetry

- Run bounded physical collection only during cold-start maintenance.
- Keep catalog tombstones for at least 30 days.
- Protect objects still reachable from favorites, history, active downloads, queues, or catalog references.
- Delay transient and history collection until a later cold start.
- Report unexpected tombstone access, incomplete objects, integrity repairs, and collector failures through grouped Sentry diagnostics.

## Legacy data repair

Cold-start integrity maintenance repairs recoverable catalog links from stored UUIDs and quarantines unrecoverable legacy graphs as tombstones before application consumers start.

## Verification

Run with Node 22.21.1:

- `yarn lint`
- `yarn ts:check`
- `yarn test` — 22 tests passed
- iOS production bundle export

## Rollout warning

**This changes the Realm schema from 12 to 13.** It must ship in a new native runtime whose embedded bundle already understands schema 13. Do not publish this change as an OTA to an older runtime, and do not roll the new runtime back to a schema-12 bundle.