### PR TITLE
Keep catalog rows as permanent tombstones

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     },
     "name": "Relisten",
     "slug": "relisten",
-    "version": "6.1.3",
+    "version": "6.1.4",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -27,7 +27,7 @@
           "audio"
         ]
       },
-      "buildNumber": "6045"
+      "buildNumber": "6047"
     },
     "android": {
       "playStoreUrl": "https://play.google.com/store/apps/details?id=net.relisten.android",
@@ -60,7 +60,7 @@
       },
       "icon": "./assets/ic_playstore.png",
       "package": "net.relisten.android",
-      "versionCode": 6045
+      "versionCode": 6047
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,7 +21,7 @@ import { RelistenBlue } from '@/relisten/relisten_blue';
 import { StatusBar } from 'expo-status-bar';
 
 import '@/relisten/util/dayjs_setup';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
 import useCacheAssets from './useCacheAssets';
 
 import { RelistenPlayerProvider } from '@/relisten/player/relisten_player_hooks';
@@ -50,6 +50,7 @@ import {
   isVerboseProfileLoggingEnabled,
   logRouteDebug,
 } from '@/relisten/util/profile_logging';
+import { repairCatalogAtStartup } from '@/relisten/realm/catalog_startup_repair';
 
 // c.f. https://github.com/meliorence/react-native-render-html/issues/661#issuecomment-2453476566
 LogBox.ignoreLogs([/Support for defaultProps will be removed/]);
@@ -89,11 +90,15 @@ if (!__DEV__) {
   Sentry.init({});
 }
 
-function RealmBridge() {
+function RealmStartupGate({ children }: PropsWithChildren) {
   const realm = useRealm();
+  const [readyRealm, setReadyRealm] = useState<Realm>();
 
   useEffect(() => {
+    // Root services install live Realm listeners, so repair must finish before they mount.
+    repairCatalogAtStartup(realm);
     setRealm(realm);
+    setReadyRealm(realm);
 
     return () => {
       // React Strict Mode runs effect cleanup during the initial mount cycle in development.
@@ -104,7 +109,7 @@ function RealmBridge() {
     };
   }, [realm]);
 
-  return null;
+  return readyRealm === realm ? children : null;
 }
 
 function CarPlayBootstrap() {
@@ -196,42 +201,43 @@ function TabLayout() {
 
   return (
     <RealmProvider realmRef={realmRef} closeOnUnmount={false}>
-      <RootServicesProvider>
-        <RelistenApiProvider>
-          <RelistenPlayerProvider>
-            <RelistenCastProvider>
-              <PlaybackHistoryReporterComponent />
-              <LastFmReporterComponent />
-              <LastFmAuthListener />
-              <RealmBridge />
-              <CarPlayBootstrap />
-              <ThemeProvider
-                value={{
-                  dark: true,
-                  colors: {
-                    ...DarkTheme.colors,
-                    primary: 'rgb(0,157,193)',
-                    background: RelistenBlue[900],
-                    card: '#001114',
-                  },
-                  fonts: DefaultTheme.fonts,
-                }}
-              >
-                <RelistenPlayerBottomBarProvider>
-                  <GestureHandlerRootView style={{ flex: 1 }} onLayout={onLayoutRootView}>
-                    <SafeAreaProvider>
-                      {/* */}
-                      <StatusBar style="light" />
-                      <Slot />
-                      <FlashMessage position="top" />
-                    </SafeAreaProvider>
-                  </GestureHandlerRootView>
-                </RelistenPlayerBottomBarProvider>
-              </ThemeProvider>
-            </RelistenCastProvider>
-          </RelistenPlayerProvider>
-        </RelistenApiProvider>
-      </RootServicesProvider>
+      <RealmStartupGate>
+        <RootServicesProvider>
+          <RelistenApiProvider>
+            <RelistenPlayerProvider>
+              <RelistenCastProvider>
+                <PlaybackHistoryReporterComponent />
+                <LastFmReporterComponent />
+                <LastFmAuthListener />
+                <CarPlayBootstrap />
+                <ThemeProvider
+                  value={{
+                    dark: true,
+                    colors: {
+                      ...DarkTheme.colors,
+                      primary: 'rgb(0,157,193)',
+                      background: RelistenBlue[900],
+                      card: '#001114',
+                    },
+                    fonts: DefaultTheme.fonts,
+                  }}
+                >
+                  <RelistenPlayerBottomBarProvider>
+                    <GestureHandlerRootView style={{ flex: 1 }} onLayout={onLayoutRootView}>
+                      <SafeAreaProvider>
+                        {/* */}
+                        <StatusBar style="light" />
+                        <Slot />
+                        <FlashMessage position="top" />
+                      </SafeAreaProvider>
+                    </GestureHandlerRootView>
+                  </RelistenPlayerBottomBarProvider>
+                </ThemeProvider>
+              </RelistenCastProvider>
+            </RelistenPlayerProvider>
+          </RelistenApiProvider>
+        </RootServicesProvider>
+      </RealmStartupGate>
     </RealmProvider>
   );
 }

--- a/app/relisten/tabs/(artists,myLibrary,offline)/history/tracks.tsx
+++ b/app/relisten/tabs/(artists,myLibrary,offline)/history/tracks.tsx
@@ -70,12 +70,8 @@ export default function Page() {
       confirmLabel: 'Clear History',
       message: 'This will permanently delete your listening history.',
       onConfirm: () => {
-        const history = realm.objects(PlaybackHistoryEntry);
-
         realm.write(() => {
-          for (const entry of history) {
-            realm.delete(entry);
-          }
+          realm.delete(realm.objects(PlaybackHistoryEntry));
         });
       },
       title: 'Clear Listening History?',

--- a/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
+++ b/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
@@ -47,7 +47,7 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - [x] (2026-08-20) Complete consistency, crash-invariant, and minimality reviews of the revised plan.
 - [x] (2026-08-21 01:18Z) Approve the revised plan and start implementation from `origin/main` at `7c1b74d`.
 - [x] (2026-08-21 01:22Z) Add catalog tombstones, repository soft deletion and resurrection, and four focused real-Realm tests.
-- [ ] Add active filters at normal catalog query roots.
+- [x] (2026-08-21 01:29Z) Add active filters at normal catalog query roots while keeping owned and historical routes retained.
 - [ ] Add startup repair and focused leaf-consumer safety fixes.
 - [ ] Add focused tests, run repository checks, and complete manual crash scenarios.
 - [ ] Review the implementation, then simplify the changed code without changing behavior.
@@ -63,6 +63,7 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - Observation: `PlaybackHistoryReporter` reads a managed history entry after an `await`. History clear can physically delete that leaf entry during the request. This boundary needs a plain UUID snapshot and a fresh lookup after the request.
 - Observation: the React Realm provider and the non-React `openRealm()` path can expose Realm. Both paths must run the same idempotent startup repair before returning consumers.
 - Observation: a managed optional Realm date reads as `null` when empty, although the TypeScript model uses an optional property. Evidence: the real-Realm repository tests pass by using `== null` in lifecycle code and asserting `null` at the managed read boundary.
+- Observation: active detail queries can hide the local tombstone that a positive API response must restore. Evidence: Show, Venue, Tour, and Song detail writers previously received only the displayed root object. They now use the repository's existing `queryForModel` flag so refresh reuses the hidden primary-key row.
 
 ## Decision Log
 
@@ -325,6 +326,14 @@ Repository checkpoint evidence from Node 22.21.1:
     yarn ts:check: passed
     focused ESLint: passed
 
+Active-query checkpoint evidence from Node 22.21.1:
+
+    Test Files  1 passed (1)
+         Tests  4 passed (4)
+    yarn ts:check: passed
+    focused ESLint: passed
+    git diff --check: passed
+
 ## Interfaces and Dependencies
 
 Do not add a catalog lifecycle service or a general read API.
@@ -363,3 +372,5 @@ Add only one development dependency: Vitest. Do not add a runtime dependency.
 Plan revision note, 2026-08-21: implementation started after the user approved the simplified design. The recorded base commit was updated to the current `origin/main`; the lifecycle design did not change.
 
 Plan revision note, 2026-08-21 01:22Z: the schema and repository milestone is complete. Real Realm tests now prove tombstoning, stable links, same-timestamp resurrection, merge-only behavior, and the additive schema migration.
+
+Plan revision note, 2026-08-21 01:29Z: normal catalog query roots now exclude tombstones. Shared offline and My Library Artist, Year, Show, and Source readers remain retained, as do history, queue, download, and CarPlay ownership paths. No general query abstraction was added.

--- a/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
+++ b/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
@@ -49,7 +49,7 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - [x] (2026-08-21 01:22Z) Add catalog tombstones, repository soft deletion and resurrection, and four focused real-Realm tests.
 - [x] (2026-08-21 01:29Z) Add active filters at normal catalog query roots while keeping owned and historical routes retained.
 - [x] (2026-08-21 01:36Z) Add the shared startup repair gate and writer-side required-link enforcement.
-- [ ] Make the confirmed asynchronous history leaf holders safe.
+- [x] (2026-08-21 01:40Z) Make the confirmed asynchronous history leaf holders safe.
 - [ ] Add focused tests, run repository checks, and complete manual crash scenarios.
 - [ ] Review the implementation, then simplify the changed code without changing behavior.
 
@@ -66,6 +66,7 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - Observation: a managed optional Realm date reads as `null` when empty, although the TypeScript model uses an optional property. Evidence: the real-Realm repository tests pass by using `== null` in lifecycle code and asserting `null` at the managed read boundary.
 - Observation: active detail queries can hide the local tombstone that a positive API response must restore. Evidence: Show, Venue, Tour, and Song detail writers previously received only the displayed root object. They now use the repository's existing `queryForModel` flag so refresh reuses the hidden primary-key row.
 - Observation: the React provider can open Realm without using `openRealm()`. Evidence: `app/_layout.tsx` mounts `RealmProvider` directly, while early CarPlay setup may call `openRealm()`. Both paths now run the same idempotent repair before installing consumers.
+- Observation: the top-played history scan also crossed an asynchronous boundary by keeping a live Realm result across `setTimeout()` chunks. Evidence: it cached the result length and later indexed the same live collection. It now snapshots UUIDs and resolves each leaf immediately before reading it.
 
 ## Decision Log
 
@@ -344,6 +345,14 @@ Startup-repair checkpoint evidence from Node 22.21.1:
     focused ESLint: passed
     git diff --check: passed
 
+Async-leaf checkpoint evidence from Node 22.21.1:
+
+    Test Files  3 passed (3)
+         Tests  7 passed (7)
+    yarn ts:check: passed
+    focused ESLint: passed
+    git diff --check: passed
+
 ## Interfaces and Dependencies
 
 Do not add a catalog lifecycle service or a general read API.
@@ -386,3 +395,5 @@ Plan revision note, 2026-08-21 01:22Z: the schema and repository milestone is co
 Plan revision note, 2026-08-21 01:29Z: normal catalog query roots now exclude tombstones. Shared offline and My Library Artist, Year, Show, and Source readers remain retained, as do history, queue, download, and CarPlay ownership paths. No general query abstraction was added.
 
 Plan revision note, 2026-08-21 01:36Z: one explicit startup transaction now repairs recoverable catalog links and quarantines irreparable rows before React or CarPlay consumers mount. Two production-schema Realm tests cover repair, legacy hard-delete damage, leaf cleanup, queue cleanup, and idempotence.
+
+Plan revision note, 2026-08-21 01:40Z: history reporting, chunked statistics, and CarPlay selection now cross asynchronous boundaries with UUIDs rather than managed history leaves. A focused real-Realm test clears a history row while its publish request is in flight.

--- a/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
+++ b/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
@@ -50,8 +50,9 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - [x] (2026-08-21 01:29Z) Add active filters at normal catalog query roots while keeping owned and historical routes retained.
 - [x] (2026-08-21 01:36Z) Add the shared startup repair gate and writer-side required-link enforcement.
 - [x] (2026-08-21 01:40Z) Make the confirmed asynchronous history leaf holders safe.
-- [ ] Add focused tests, run repository checks, and complete manual crash scenarios.
-- [ ] Review the implementation, then simplify the changed code without changing behavior.
+- [x] (2026-08-21 01:48Z) Add focused tests, run the repository checks, and audit every physical Realm deletion.
+- [x] (2026-08-21 01:48Z) Review and simplify the changed code. Keep structurally incomplete Tracks out of current SourceSet membership.
+- [ ] Run the manual crash scenarios on a simulator database at schema version 13. The configured simulator currently contains a schema version 14 Realm from another development build, so Realm rejects this branch's version 13 schema before startup runs. Its data was not reset.
 
 ## Surprises & Discoveries
 
@@ -67,6 +68,8 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - Observation: active detail queries can hide the local tombstone that a positive API response must restore. Evidence: Show, Venue, Tour, and Song detail writers previously received only the displayed root object. They now use the repository's existing `queryForModel` flag so refresh reuses the hidden primary-key row.
 - Observation: the React provider can open Realm without using `openRealm()`. Evidence: `app/_layout.tsx` mounts `RealmProvider` directly, while early CarPlay setup may call `openRealm()`. Both paths now run the same idempotent repair before installing consumers.
 - Observation: the top-played history scan also crossed an asynchronous boundary by keeping a live Realm result across `setTimeout()` chunks. Evidence: it cached the result length and later indexed the same live collection. It now snapshots UUIDs and resolves each leaf immediately before reading it.
+- Observation: the full Show writer could tombstone a Track with a missing required dependency and still add that Track to the current SourceSet membership. Evidence: relationship attachment and list replacement happened in separate steps. The writer now builds the current list only from structurally complete Tracks; the tombstone remains available for later repair or resurrection.
+- Observation: the configured iPhone 17 simulator already contains a Realm at schema version 14 from another development build. Realm correctly rejects this fresh-main branch's version 13 schema as a downgrade. The simulator data was preserved.
 
 ## Decision Log
 
@@ -78,10 +81,17 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - Decision: filter `deletedAt` only at normal catalog query roots. Do not wrap Realm objects or inspect every linked object. Rationale: tombstoned links remain valid and may show stale metadata without crashing. Date: 2026-08-20.
 - Decision: keep physical deletion for history, offline metadata, Last.fm queue rows, and `PlayerState`. Rationale: these are leaf or singleton records. Known asynchronous holders must copy identifiers before deletion can occur. Date: 2026-08-20.
 - Decision: do not add catalog garbage collection, reference counting, graph traversal, per-access telemetry, proxies, or a persistent repair-state table. Rationale: none is required to stop catalog invalidation. Date: 2026-08-20.
+- Decision: exclude a structurally incomplete Track from current SourceSet membership at write time. Keep its row as a tombstone. Rationale: normal playback code traverses membership directly and should never receive a Track that failed the writer invariant. Date: 2026-08-21.
 
 ## Outcomes & Retrospective
 
-Implementation is in progress. Catalog writes, active query roots, and startup repair are complete. Async leaf safety, final review, and manual scenarios remain.
+The implementation is complete. Catalog rows are now permanent Realm objects with a reversible `deletedAt` marker. Normal catalog roots hide tombstones, while history, queue, offline, favorites, and My Library retain the old metadata they need. One startup transaction repairs legacy links or removes unsafe leaf entry points before consumers mount. Confirmed asynchronous history code now carries UUIDs rather than deletable managed leaf objects.
+
+The final implementation keeps the existing repository and query structure. It adds no catalog garbage collector, generic graph validator, read wrapper, access telemetry system, or second reconciliation API. The low-level repair and reconciliation paths contain comments where the lifecycle rule is not obvious from the code.
+
+Automated validation passes with real Realm files: 3 test files and 7 tests, plus full lint and TypeScript checks. The deletion audit found no production path that physically deletes a catalog row. The remaining manual verification gap is environmental: the configured simulator contains a schema version 14 Realm, so this branch's version 13 schema cannot open it without deleting or replacing that data. The simulator was not reset.
+
+Permanent tombstones intentionally allow catalog storage to grow. The startup repair handles the known required links in this schema; a future required relationship must be added to the same explicit repair transaction and its focused test.
 
 ## Context and Orientation
 
@@ -210,7 +220,7 @@ Also delete legacy leaf rows that are already malformed:
 
 Do not create placeholder catalog rows to preserve malformed leaf data.
 
-Log one summary after repair. Include counts by model and action. Do not log one event per row. Do not add read-time tombstone diagnostics.
+Log one summary after repair with aggregate counts by action. Do not log one event per row. Do not add read-time tombstone diagnostics.
 
 Replace the current `RealmBridge` with a small `RealmStartupGate` inside the React `RealmProvider` in `app/_layout.tsx`. It runs the synchronous repair, sets the shared Realm reference, and only then mounts `RootServicesProvider` and the other consumers.
 
@@ -289,7 +299,7 @@ Use real Realm tests for these behaviors:
 10. Running startup repair twice produces no further changes on the second run.
 11. Clearing history during an in-flight report does not access the deleted history object after the request completes.
 
-Run these manual scenarios on the iPhone 17 simulator:
+When a clean schema version 13 simulator database is available, run these manual scenarios on the iPhone 17 simulator:
 
 - Start playback. Refresh the full Show so the current SourceTrack is omitted. Confirm playback and queue rendering continue.
 - Restore a queue that contains a tombstoned SourceTrack. Confirm the track remains playable when its media is available.
@@ -299,7 +309,7 @@ Run these manual scenarios on the iPhone 17 simulator:
 - Open a copied Realm with an irreparable SourceTrack. Confirm the app removes its leaf and queue entry points and does not crash.
 - Clear history while a report request is in flight. Confirm the request completion does not throw an invalid-object error.
 
-Acceptance requires `yarn test`, `yarn lint`, and `yarn ts:check` to pass. The final deletion audit must show no catalog `realm.delete()` call.
+Code acceptance requires `yarn test`, `yarn lint`, and `yarn ts:check` to pass. The final deletion audit must show no catalog `realm.delete()` call. Record manual scenarios separately because they require controlled API omissions and legacy database fixtures.
 
 ## Idempotence and Recovery
 
@@ -353,6 +363,22 @@ Async-leaf checkpoint evidence from Node 22.21.1:
     focused ESLint: passed
     git diff --check: passed
 
+Final simplification and correctness evidence from Node 22.21.1:
+
+    Test Files  3 passed (3)
+         Tests  7 passed (7)
+    yarn lint: passed
+    yarn ts:check: passed
+    git diff --check: passed
+    physical deletion audit: no production catalog realm.delete call
+
+Simulator startup check:
+
+    JavaScript bundle: built and loaded from the current branch
+    startup: stopped before Realm consumers mounted
+    reason: existing schema version 14 is newer than this branch's version 13
+    action: preserved the existing simulator database
+
 ## Interfaces and Dependencies
 
 Do not add a catalog lifecycle service or a general read API.
@@ -397,3 +423,5 @@ Plan revision note, 2026-08-21 01:29Z: normal catalog query roots now exclude to
 Plan revision note, 2026-08-21 01:36Z: one explicit startup transaction now repairs recoverable catalog links and quarantines irreparable rows before React or CarPlay consumers mount. Two production-schema Realm tests cover repair, legacy hard-delete damage, leaf cleanup, queue cleanup, and idempotence.
 
 Plan revision note, 2026-08-21 01:40Z: history reporting, chunked statistics, and CarPlay selection now cross asynchronous boundaries with UUIDs rather than managed history leaves. A focused real-Realm test clears a history row while its publish request is in flight.
+
+Plan revision note, 2026-08-21 01:48Z: the final review removed a needless per-row history deletion loop and fixed the full Show writer so an incomplete tombstoned Track cannot enter current membership. Automated checks are green. The configured simulator could not run the manual scenarios because its existing Realm schema is newer; its data was preserved.

--- a/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
+++ b/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
@@ -8,11 +8,11 @@ An API refresh may remove an artist, show, source, or track from the current cat
 
 Most catalog screens hide rows with `deletedAt != nil`. Playback history, the current queue, downloads, favorites, My Library, and the matching CarPlay views may still use those rows. A tombstoned catalog row remains a valid Realm object, so those features can keep old metadata without an invalid-object crash.
 
-Older app versions may already have deleted catalog rows and left missing Realm links behind. A small startup repair runs before Realm consumers mount. It restores known links when the target still exists. It hides catalog rows that cannot be repaired and deletes malformed leaf rows.
+Older app versions may already have deleted catalog rows and left missing Realm links behind. A versioned startup repair runs once per Realm before consumers mount. It restores known links when the target still exists. It hides catalog rows that cannot be repaired and deletes malformed leaf rows.
 
 The steady-state rule is simple:
 
-> Repair the database at startup. Never hard-delete catalog rows. Trust catalog links after startup.
+> Complete each repair version once. Never hard-delete catalog rows. Trust catalog links after startup.
 
 ## Terms
 
@@ -52,7 +52,10 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - [x] (2026-08-21 01:40Z) Make the confirmed asynchronous history leaf holders safe.
 - [x] (2026-08-21 01:48Z) Add focused tests, run the repository checks, and audit every physical Realm deletion.
 - [x] (2026-08-21 01:48Z) Review and simplify the changed code. Keep structurally incomplete Tracks out of current SourceSet membership.
-- [ ] Run the manual crash scenarios on a simulator database at schema version 13. The configured simulator currently contains a schema version 14 Realm from another development build, so Realm rejects this branch's version 13 schema before startup runs. Its data was not reset.
+- [x] (2026-08-21) Batch relationship cleanup, replace unbounded history UUID arrays with Realm snapshots, and complete the adversarial performance review.
+- [x] (2026-08-21) Add a versioned completion row and non-zero Statsig repair event. Remove the synthetic migration test.
+- [x] (2026-08-21) Run a one-off production-schema benchmark with damage in every repair branch.
+- [ ] Run the manual crash scenarios on the configured simulator without deleting its existing schema version 14 data.
 
 ## Surprises & Discoveries
 
@@ -67,9 +70,10 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - Observation: a managed optional Realm date reads as `null` when empty, although the TypeScript model uses an optional property. Evidence: the real-Realm repository tests pass by using `== null` in lifecycle code and asserting `null` at the managed read boundary.
 - Observation: active detail queries can hide the local tombstone that a positive API response must restore. Evidence: Show, Venue, Tour, and Song detail writers previously received only the displayed root object. They now use the repository's existing `queryForModel` flag so refresh reuses the hidden primary-key row.
 - Observation: the React provider can open Realm without using `openRealm()`. Evidence: `app/_layout.tsx` mounts `RealmProvider` directly, while early CarPlay setup may call `openRealm()`. Both paths now run the same idempotent repair before installing consumers.
-- Observation: the top-played history scan also crossed an asynchronous boundary by keeping a live Realm result across `setTimeout()` chunks. Evidence: it cached the result length and later indexed the same live collection. It now snapshots UUIDs and resolves each leaf immediately before reading it.
+- Observation: the top-played history scan also crossed an asynchronous boundary by keeping a live Realm result across `setTimeout()` chunks. Evidence: it cached the result length and later indexed the same live collection. It now uses a stable Realm snapshot and skips slots whose leaf row was deleted.
 - Observation: the full Show writer could tombstone a Track with a missing required dependency and still add that Track to the current SourceSet membership. Evidence: relationship attachment and list replacement happened in separate steps. The writer now builds the current list only from structurally complete Tracks; the tombstone remains available for later repair or resurrection.
 - Observation: the configured iPhone 17 simulator already contains a Realm at schema version 14 from another development build. Realm correctly rejects this fresh-main branch's version 13 schema as a downgrade. The simulator data was preserved.
+- Observation: a heterogeneous 7 MiB Realm with 20,000 Tracks, 12,500 history rows, 6,000 offline rows, 200 SourceSets, 500 Songs, and damage in every repair branch took 1,000.84 ms to repair on a Mac. The completion flag reduced the second call to 0.027 ms and the next ten calls to a 0.00158 ms median.
 
 ## Decision Log
 
@@ -77,19 +81,20 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - Decision: use one optional indexed field named `deletedAt` on every catalog model. Rationale: the field states the remote catalog condition and supports active queries. Date: 2026-08-20.
 - Decision: keep `Repository.upsertMultiple()` and its existing omission controls. Rationale: the current API already expresses merge-only and complete-list behavior. New method names add no capability. Date: 2026-08-20.
 - Decision: keep `Source.sourceSets` and `SourceSet.sourceTracks` as current API membership. Rationale: historical membership would force every list reader to understand two meanings. Date: 2026-08-20.
-- Decision: repair known legacy damage once at startup. Do not validate every catalog relationship at every read. Rationale: a startup invariant keeps lifecycle code in one place. Date: 2026-08-20.
+- Decision: run each version of the legacy repair once per Realm. Do not validate every catalog relationship at every read. Rationale: a startup invariant keeps lifecycle code in one place, while the persisted version row removes the repeated startup scan. Date: 2026-08-21.
 - Decision: filter `deletedAt` only at normal catalog query roots. Do not wrap Realm objects or inspect every linked object. Rationale: tombstoned links remain valid and may show stale metadata without crashing. Date: 2026-08-20.
 - Decision: keep physical deletion for history, offline metadata, Last.fm queue rows, and `PlayerState`. Rationale: these are leaf or singleton records. Known asynchronous holders must copy identifiers before deletion can occur. Date: 2026-08-20.
-- Decision: do not add catalog garbage collection, reference counting, graph traversal, per-access telemetry, proxies, or a persistent repair-state table. Rationale: none is required to stop catalog invalidation. Date: 2026-08-20.
+- Decision: do not add catalog garbage collection, reference counting, graph traversal, per-access telemetry, or proxies. Add one `CatalogStartupRepairState` row per completed repair version. Rationale: the one-time damaged repair can take about one second, while a primary-key completion check is effectively free. Date: 2026-08-21.
+- Decision: emit one `catalog_startup_repair` Statsig event only when a repair changes data. Include aggregate action counts, duration, and repair version. Rationale: the event shows whether supported clients still need the legacy repair without logging individual catalog identifiers. Date: 2026-08-21.
 - Decision: exclude a structurally incomplete Track from current SourceSet membership at write time. Keep its row as a tombstone. Rationale: normal playback code traverses membership directly and should never receive a Track that failed the writer invariant. Date: 2026-08-21.
 
 ## Outcomes & Retrospective
 
-The implementation is complete. Catalog rows are now permanent Realm objects with a reversible `deletedAt` marker. Normal catalog roots hide tombstones, while history, queue, offline, favorites, and My Library retain the old metadata they need. One startup transaction repairs legacy links or removes unsafe leaf entry points before consumers mount. Confirmed asynchronous history code now carries UUIDs rather than deletable managed leaf objects.
+The implementation is complete. Catalog rows are now permanent Realm objects with a reversible `deletedAt` marker. Normal catalog roots hide tombstones, while history, queue, offline, favorites, and My Library retain the old metadata they need. One startup transaction repairs legacy links or removes unsafe leaf entry points before consumers mount. The same transaction records the completed repair version. Confirmed asynchronous history code now uses stable Realm snapshots and copies scalar UUIDs before awaiting network work.
 
 The final implementation keeps the existing repository and query structure. It adds no catalog garbage collector, generic graph validator, read wrapper, access telemetry system, or second reconciliation API. The low-level repair and reconciliation paths contain comments where the lifecycle rule is not obvious from the code.
 
-Automated validation passes with real Realm files: 3 test files and 7 tests, plus full lint and TypeScript checks. The deletion audit found no production path that physically deletes a catalog row. The remaining manual verification gap is environmental: the configured simulator contains a schema version 14 Realm, so this branch's version 13 schema cannot open it without deleting or replacing that data. The simulator was not reset.
+Automated validation passes with real Realm files: 3 test files and 10 tests, plus full lint and TypeScript checks. The deletion audit found no production path that physically deletes a catalog row. The configured simulator still cannot run this branch because its unrelated schema version 14 Realm is newer than this branch's unreleased schema version 13. That simulator data has not been reset.
 
 Permanent tombstones intentionally allow catalog storage to grow. The startup repair handles the known required links in this schema; a future required relationship must be added to the same explicit repair transaction and its focused test.
 
@@ -101,7 +106,7 @@ Permanent tombstones intentionally allow catalog storage to grow. The startup re
 
 `relisten/realm/models/show_repo.ts` writes a full Show response. It replaces `Source.sourceSets` and `SourceSet.sourceTracks` with the current API order. That behavior remains.
 
-`relisten/realm/schema.ts` owns schema version 12 and the non-React `openRealm()` function. `app/_layout.tsx` mounts the React `RealmProvider`, then constructs the library index, player, history reporter, and CarPlay services.
+`relisten/realm/schema.ts` owns schema version 13 and the non-React `openRealm()` function. `app/_layout.tsx` mounts the React `RealmProvider`, then constructs the library index, player, history reporter, and CarPlay services.
 
 `relisten/playback_history_reporter.ts` and `relisten/offline/download_manager.ts` own the two leaf lifecycles that can overlap asynchronous work. Offline callbacks already re-check or re-fetch deleted metadata. History reporting does not.
 
@@ -127,7 +132,7 @@ Repeat the one-line schema property in each model. Do not create a schema-proper
 
 Add optional `deletedAt` to the existing `RelistenObjectRequiredProperties` interface so `Repository` can read and write the field without casts. Do not add another model hierarchy.
 
-Increase `schemaVersion` in `relisten/realm/schema.ts` from 12 to 13. The field is optional, so existing catalog rows open with `deletedAt == nil`.
+Increase `schemaVersion` in `relisten/realm/schema.ts` from 12 to 13. The catalog field is optional, so existing catalog rows open with `deletedAt == nil`. The same unreleased version also adds `CatalogStartupRepairState`; do not spend another schema version on this state row.
 
 Keep the name and call pattern of `Repository.upsertMultiple()`.
 
@@ -220,11 +225,11 @@ Also delete legacy leaf rows that are already malformed:
 
 Do not create placeholder catalog rows to preserve malformed leaf data.
 
-Log one summary after repair with aggregate counts by action. Do not log one event per row. Do not add read-time tombstone diagnostics.
+After a repair changes data, log one `catalog_startup_repair` Statsig event with aggregate counts, duration, and repair version. Do not log one event per row. Do not add read-time tombstone diagnostics.
 
 Replace the current `RealmBridge` with a small `RealmStartupGate` inside the React `RealmProvider` in `app/_layout.tsx`. It runs the synchronous repair, sets the shared Realm reference, and only then mounts `RootServicesProvider` and the other consumers.
 
-Call the same repair from `openRealm()` before it stores or returns the opened Realm. The repair is idempotent, so it may run once for each Realm instance without a version flag.
+Call the same repair from `openRealm()` before it stores or returns the opened Realm. Before scanning, check `CatalogStartupRepairState` for the current repair version. Write the completion row in the repair transaction so a failed transaction is retried on the next launch.
 
 After startup, the existing centralized catalog writers must not publish a row as active when they have left one of the required links above as `nil`. If a writer cannot attach a required target, set `deletedAt` on that row. Do this in the existing relationship-attachment code. Do not add read-time guards throughout the UI.
 
@@ -237,7 +242,7 @@ Keep the current history-clear, download-removal, Last.fm, and PlayerState delet
 Make the known asynchronous history boundaries safe:
 
 - In `PlaybackHistoryReporter`, copy the history UUID and SourceTrack UUID before the API request. After the request, look up the history row again before setting `publishedAt`. If the user cleared history, there is nothing to update.
-- Before the retry loop awaits network work, snapshot the history UUIDs that it plans to publish. Resolve each UUID immediately before use.
+- Before the retry loop awaits network work, snapshot the pending Realm results. Read only the current UUID before each request and skip snapshot slots whose leaf row was deleted.
 - In CarPlay history selection, keep plain UUIDs in the selection map or copy the needed UUIDs before the first `await`. Do not hold a `PlaybackHistoryEntry` across asynchronous work.
 
 Keep the DownloadManager's existing deletion checks and metadata re-fetch. Do not introduce another offline lifecycle in this change.
@@ -287,19 +292,19 @@ Run all commands from `/Users/alecgorge/code/relisten/relisten-mobile` with the 
 
 Use real Realm tests for these behaviors:
 
-1. A version 12 Realm opens at version 13. Existing catalog rows have `deletedAt == nil`.
-2. An authoritative omission sets `deletedAt` and leaves a held managed catalog object valid.
-3. Tombstoning a SourceTrack preserves its direct Artist, Year, Show, and Source links.
-4. Current membership replacement may remove the SourceTrack from `SourceSet.sourceTracks` without invalidating the SourceTrack.
-5. A same-timestamp API response clears `deletedAt` and reuses the same primary-key row.
-6. A merge-only `upsertMultiple()` call does not tombstone omitted rows.
-7. A normal browse query hides a tombstone. A history or queue lookup can still return it.
-8. Startup repair restores each known missing link when the target row exists.
-9. Startup repair tombstones an irreparable catalog row and removes its history, offline, favorite, membership, and queue entry points.
-10. Running startup repair twice produces no further changes on the second run.
-11. Clearing history during an in-flight report does not access the deleted history object after the request completes.
+1. An authoritative omission sets `deletedAt` and leaves a held managed catalog object valid.
+2. Tombstoning a SourceTrack preserves its direct Artist, Year, Show, and Source links.
+3. Current membership replacement may remove the SourceTrack from `SourceSet.sourceTracks` without invalidating the SourceTrack.
+4. A same-timestamp API response clears `deletedAt` and reuses the same primary-key row.
+5. A merge-only `upsertMultiple()` call does not tombstone omitted rows.
+6. A normal browse query hides a tombstone. A history or queue lookup can still return it.
+7. Startup repair restores each known missing link when the target row exists.
+8. Startup repair tombstones an irreparable catalog row and removes its history, offline, favorite, membership, and queue entry points.
+9. A successful repair records its version in the same transaction. A second call skips the repair.
+10. Clearing history during an in-flight report does not access the deleted history object after the request completes.
+11. A repair that changes data emits one aggregate Statsig event. A clean repair emits no event.
 
-When a clean schema version 13 simulator database is available, run these manual scenarios on the iPhone 17 simulator:
+When a compatible schema version 13 simulator database is available, run these manual scenarios on the iPhone 17 simulator:
 
 - Start playback. Refresh the full Show so the current SourceTrack is omitted. Confirm playback and queue rendering continue.
 - Restore a queue that contains a tombstoned SourceTrack. Confirm the track remains playable when its media is available.
@@ -317,9 +322,9 @@ Setting `deletedAt` is idempotent. Repeated omissions keep the original date.
 
 Positive API data clears `deletedAt`. A false tombstone can therefore recover without creating a second primary-key row.
 
-Startup repair is idempotent. A restored row no longer matches its missing-link query. An irreparable catalog row remains a valid tombstone, and its leaf references are already gone.
+Startup repair is versioned. A successful repair and its completion row commit together. A failed transaction leaves no completion row, so the same repair version runs again on the next launch.
 
-Schema version 13 is one-way. Ship the change in a native runtime whose embedded bundle also uses schema version 13. A rollback bundle for that runtime must keep schema version 13 and the nine `deletedAt` properties.
+Schema version 13 is one-way. Ship the change in a native runtime whose embedded bundle also uses schema version 13. A rollback bundle for that runtime must keep schema version 13, the nine `deletedAt` properties, and `CatalogStartupRepairState`.
 
 Do not use `deleteRealmIfMigrationNeeded` as recovery. It would delete local history, downloads, settings, and queue state.
 
@@ -376,8 +381,20 @@ Simulator startup check:
 
     JavaScript bundle: built and loaded from the current branch
     startup: stopped before Realm consumers mounted
-    reason: existing schema version 14 is newer than this branch's version 13
+    reason at the time of the check: existing schema version 14 was newer than the branch's version 13
     action: preserved the existing simulator database
+
+Cross-schema startup benchmark from Node 22.21.1 on a Mac:
+
+    Realm size: 7 MiB
+    fixture: 20,000 Tracks; 12,500 history rows; 6,000 offline rows
+    membership: 200 SourceSets; 500 Songs; healthy neighbors in every parent
+    damage: every repairable and irreparable link branch, leaf cleanup, and both queues
+    first repair: 1,000.84 ms
+    summary: repairedLinks=1,500; tombstonedRows=1,500; deletedLeafRows=4,500; removedQueueEntries=1,000
+    second flagged call: 0.027 ms
+    next ten flagged calls: median=0.00158 ms; p95=0.00596 ms
+    integrity checks: passed
 
 ## Interfaces and Dependencies
 
@@ -399,7 +416,7 @@ class Repository<...> {
 }
 ```
 
-The only new runtime interface is the startup repair:
+The startup repair exposes its aggregate result and stores one completion row per repair version:
 
 ```ts
 interface CatalogRepairSummary {
@@ -410,6 +427,11 @@ interface CatalogRepairSummary {
 }
 
 function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary;
+
+class CatalogStartupRepairState {
+  version: number;
+  completedAt: Date;
+}
 ```
 
 Add only one development dependency: Vitest. Do not add a runtime dependency.
@@ -425,3 +447,5 @@ Plan revision note, 2026-08-21 01:36Z: one explicit startup transaction now repa
 Plan revision note, 2026-08-21 01:40Z: history reporting, chunked statistics, and CarPlay selection now cross asynchronous boundaries with UUIDs rather than managed history leaves. A focused real-Realm test clears a history row while its publish request is in flight.
 
 Plan revision note, 2026-08-21 01:48Z: the final review removed a needless per-row history deletion loop and fixed the full Show writer so an incomplete tombstoned Track cannot enter current membership. Automated checks are green. The configured simulator could not run the manual scenarios because its existing Realm schema is newer; its data was preserved.
+
+Plan revision note, 2026-08-21: the performance audit replaced per-row membership queries with batched native predicates and removed full JavaScript UUID copies from the history paths. A later review added a versioned `CatalogStartupRepairState` row so each repair version runs once per Realm. Non-zero repairs emit one aggregate Statsig event. The synthetic migration test was removed because it tested a made-up schema rather than the app configuration.

--- a/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
+++ b/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
@@ -40,13 +40,13 @@ The implementation may keep stale catalog rows when the API does not provide a c
 
 ## Progress
 
-- [x] (2026-08-20) Start `codex/permanent-catalog-tombstones` from `origin/main` at `e588385`.
+- [x] (2026-08-20) Start `codex/permanent-catalog-tombstones` from `origin/main`.
 - [x] (2026-08-20) Audit Realm deletion sites, catalog relationships, read sites, and startup paths on the fresh branch.
 - [x] (2026-08-20) Write the first plan. No production code changed.
 - [x] (2026-08-20) Simplify the plan after design review. Keep the current repository API and membership behavior. Replace read-time graph validation with startup repair.
 - [x] (2026-08-20) Complete consistency, crash-invariant, and minimality reviews of the revised plan.
-- [ ] Approve this plan before implementation.
-- [ ] Add catalog tombstones and change repository deletion behavior.
+- [x] (2026-08-21 01:18Z) Approve the revised plan and start implementation from `origin/main` at `7c1b74d`.
+- [x] (2026-08-21 01:22Z) Add catalog tombstones, repository soft deletion and resurrection, and four focused real-Realm tests.
 - [ ] Add active filters at normal catalog query roots.
 - [ ] Add startup repair and focused leaf-consumer safety fixes.
 - [ ] Add focused tests, run repository checks, and complete manual crash scenarios.
@@ -62,6 +62,7 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - Observation: Realm object links can become `nil` after an older build physically deleted their target, even when TypeScript treats the property as required. A `deletedAt` migration cannot restore those links.
 - Observation: `PlaybackHistoryReporter` reads a managed history entry after an `await`. History clear can physically delete that leaf entry during the request. This boundary needs a plain UUID snapshot and a fresh lookup after the request.
 - Observation: the React Realm provider and the non-React `openRealm()` path can expose Realm. Both paths must run the same idempotent startup repair before returning consumers.
+- Observation: a managed optional Realm date reads as `null` when empty, although the TypeScript model uses an optional property. Evidence: the real-Realm repository tests pass by using `== null` in lifecycle code and asserting `null` at the managed read boundary.
 
 ## Decision Log
 
@@ -240,7 +241,7 @@ Run all commands from `/Users/alecgorge/code/relisten/relisten-mobile` with the 
    git rev-parse origin/main
    ```
 
-   Expected branch: `codex/permanent-catalog-tombstones`. Before implementation, `HEAD` and `origin/main` are both `e588385`.
+   Expected branch: `codex/permanent-catalog-tombstones`. The implementation base is `origin/main` at `7c1b74d`.
 
 2. Add a small Vitest harness with real Realm. Keep tests close to the Realm lifecycle modules. Run Realm tests in one worker and call `Realm.shutdown()` after the suite.
 
@@ -317,6 +318,13 @@ Keep these artifacts with the implementation:
 - the final `realm.delete` audit;
 - a short manual record for playback, queue restoration, startup repair, retained history, and in-flight history clear.
 
+Repository checkpoint evidence from Node 22.21.1:
+
+    Test Files  1 passed (1)
+         Tests  4 passed (4)
+    yarn ts:check: passed
+    focused ESLint: passed
+
 ## Interfaces and Dependencies
 
 Do not add a catalog lifecycle service or a general read API.
@@ -351,3 +359,7 @@ function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary;
 ```
 
 Add only one development dependency: Vitest. Do not add a runtime dependency.
+
+Plan revision note, 2026-08-21: implementation started after the user approved the simplified design. The recorded base commit was updated to the current `origin/main`; the lifecycle design did not change.
+
+Plan revision note, 2026-08-21 01:22Z: the schema and repository milestone is complete. Real Realm tests now prove tombstoning, stable links, same-timestamp resurrection, merge-only behavior, and the additive schema migration.

--- a/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
+++ b/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
@@ -1,0 +1,353 @@
+# Keep Realm catalog objects valid with permanent tombstones
+
+This ExecPlan is a living document. Keep the sections Progress, Surprises & Discoveries, Decision Log, and Outcomes & Retrospective up to date as work proceeds.
+
+## Purpose / Big Picture
+
+An API refresh may remove an artist, show, source, or track from the current catalog. The app must mark that Realm row with `deletedAt`. It must never physically delete the row.
+
+Most catalog screens hide rows with `deletedAt != nil`. Playback history, the current queue, downloads, favorites, My Library, and the matching CarPlay views may still use those rows. A tombstoned catalog row remains a valid Realm object, so those features can keep old metadata without an invalid-object crash.
+
+Older app versions may already have deleted catalog rows and left missing Realm links behind. A small startup repair runs before Realm consumers mount. It restores known links when the target still exists. It hides catalog rows that cannot be repaired and deletes malformed leaf rows.
+
+The steady-state rule is simple:
+
+> Repair the database at startup. Never hard-delete catalog rows. Trust catalog links after startup.
+
+## Terms
+
+**Catalog row** means an `Artist`, `Year`, `Show`, `Venue`, `Tour`, `Song`, `Source`, `SourceSet`, or `SourceTrack` Realm object.
+
+**Active row** means a catalog row with `deletedAt == nil`.
+
+**Tombstone** means a catalog row with `deletedAt != nil`. A catalog tombstone remains in Realm permanently.
+
+**Retained read** means a read that may return a tombstone because the feature represents earlier user activity or local ownership.
+
+**Leaf row** means a row that no catalog object depends on for its identity. `PlaybackHistoryEntry`, `SourceTrackOfflineInfo`, and `LastFmScrobbleEntry` are leaf rows. `PlayerState` is a singleton that stores UUID strings. These rows may still be physically deleted.
+
+## Priorities
+
+Use this order when two goals conflict:
+
+1. Do not invalidate a catalog object.
+2. Keep the implementation easy to read and change.
+3. Do not expose a catalog row with a missing required link.
+4. Hide tombstones from normal browsing.
+5. Match every remote deletion exactly.
+
+The implementation may keep stale catalog rows when the API does not provide a clear complete list. Stale data is preferable to more reconciliation machinery.
+
+## Progress
+
+- [x] (2026-08-20) Start `codex/permanent-catalog-tombstones` from `origin/main` at `e588385`.
+- [x] (2026-08-20) Audit Realm deletion sites, catalog relationships, read sites, and startup paths on the fresh branch.
+- [x] (2026-08-20) Write the first plan. No production code changed.
+- [x] (2026-08-20) Simplify the plan after design review. Keep the current repository API and membership behavior. Replace read-time graph validation with startup repair.
+- [x] (2026-08-20) Complete consistency, crash-invariant, and minimality reviews of the revised plan.
+- [ ] Approve this plan before implementation.
+- [ ] Add catalog tombstones and change repository deletion behavior.
+- [ ] Add active filters at normal catalog query roots.
+- [ ] Add startup repair and focused leaf-consumer safety fixes.
+- [ ] Add focused tests, run repository checks, and complete manual crash scenarios.
+- [ ] Review the implementation, then simplify the changed code without changing behavior.
+
+## Surprises & Discoveries
+
+- Observation: `Repository.upsertMultiple()` is the only current source of physical catalog deletion. Evidence: `relisten/realm/repository.ts` calls `realm.delete()` for models missing from an API response.
+- Observation: every current `Repository` instance manages one of the nine catalog types. Evidence: the repositories in `relisten/realm/models/` instantiate `Repository` only for those types.
+- Observation: `upsertMultiple()` already supports both required omission rules. `performDeletes=false` preserves omitted rows. `performDeletes=true` treats omissions as deletions. A second repository API would duplicate this behavior.
+- Observation: `Source.sourceSets` and `SourceSet.sourceTracks` are current ordered memberships. Replacing either Realm list does not delete or invalidate its former members. Evidence: `relisten/realm/models/show_repo.ts` replaces the lists with `splice()`, while physical deletion occurs separately in `Repository`.
+- Observation: some list behaviors use the same filtered Realm results for display and reconciliation. This can cause a missed tombstone. It cannot invalidate an object after repository deletion becomes soft. The first implementation accepts this stale-data case.
+- Observation: Realm object links can become `nil` after an older build physically deleted their target, even when TypeScript treats the property as required. A `deletedAt` migration cannot restore those links.
+- Observation: `PlaybackHistoryReporter` reads a managed history entry after an `await`. History clear can physically delete that leaf entry during the request. This boundary needs a plain UUID snapshot and a fresh lookup after the request.
+- Observation: the React Realm provider and the non-React `openRealm()` path can expose Realm. Both paths must run the same idempotent startup repair before returning consumers.
+
+## Decision Log
+
+- Decision: never physically delete a catalog row. Rationale: React, CarPlay, the player, and asynchronous callbacks can keep managed catalog objects after reconciliation. Date: 2026-08-20.
+- Decision: use one optional indexed field named `deletedAt` on every catalog model. Rationale: the field states the remote catalog condition and supports active queries. Date: 2026-08-20.
+- Decision: keep `Repository.upsertMultiple()` and its existing omission controls. Rationale: the current API already expresses merge-only and complete-list behavior. New method names add no capability. Date: 2026-08-20.
+- Decision: keep `Source.sourceSets` and `SourceSet.sourceTracks` as current API membership. Rationale: historical membership would force every list reader to understand two meanings. Date: 2026-08-20.
+- Decision: repair known legacy damage once at startup. Do not validate every catalog relationship at every read. Rationale: a startup invariant keeps lifecycle code in one place. Date: 2026-08-20.
+- Decision: filter `deletedAt` only at normal catalog query roots. Do not wrap Realm objects or inspect every linked object. Rationale: tombstoned links remain valid and may show stale metadata without crashing. Date: 2026-08-20.
+- Decision: keep physical deletion for history, offline metadata, Last.fm queue rows, and `PlayerState`. Rationale: these are leaf or singleton records. Known asynchronous holders must copy identifiers before deletion can occur. Date: 2026-08-20.
+- Decision: do not add catalog garbage collection, reference counting, graph traversal, per-access telemetry, proxies, or a persistent repair-state table. Rationale: none is required to stop catalog invalidation. Date: 2026-08-20.
+
+## Outcomes & Retrospective
+
+No implementation has started. Complete this section after the code and manual scenarios are finished.
+
+## Context and Orientation
+
+`relisten/realm/repository.ts` creates, updates, and currently deletes all nine catalog model types. Its `upsertMultiple()` method receives API rows, a local comparison set, `performDeletes`, `queryForModel`, and an optional preservation callback.
+
+`relisten/realm/network_backed_model_array_behavior.ts` passes list results to `upsertMultiple()`. The existing call structure remains. This plan does not split display and reconciliation into separate repository operations.
+
+`relisten/realm/models/show_repo.ts` writes a full Show response. It replaces `Source.sourceSets` and `SourceSet.sourceTracks` with the current API order. That behavior remains.
+
+`relisten/realm/schema.ts` owns schema version 12 and the non-React `openRealm()` function. `app/_layout.tsx` mounts the React `RealmProvider`, then constructs the library index, player, history reporter, and CarPlay services.
+
+`relisten/playback_history_reporter.ts` and `relisten/offline/download_manager.ts` own the two leaf lifecycles that can overlap asynchronous work. Offline callbacks already re-check or re-fetch deleted metadata. History reporting does not.
+
+## Plan of Work
+
+The implementation has four requirements:
+
+1. A catalog row is never passed to `realm.delete()`.
+2. A successful API response restores a tombstone with the same UUID.
+3. Normal catalog queries hide their own tombstoned rows.
+4. Startup repair establishes required-link invariants before any Realm consumer mounts.
+
+### 1. Add the catalog field and change repository deletion
+
+In each of the nine catalog model files, add this Realm property and TypeScript field:
+
+```ts
+deletedAt: { type: 'date', optional: true, indexed: true }
+deletedAt?: Date;
+```
+
+Repeat the one-line schema property in each model. Do not create a schema-property factory or a catalog base class for this change.
+
+Add optional `deletedAt` to the existing `RelistenObjectRequiredProperties` interface so `Repository` can read and write the field without casts. Do not add another model hierarchy.
+
+Increase `schemaVersion` in `relisten/realm/schema.ts` from 12 to 13. The field is optional, so existing catalog rows open with `deletedAt == nil`.
+
+Keep the name and call pattern of `Repository.upsertMultiple()`.
+
+Change its `performDeletes` branch as follows:
+
+- Set `deletedAt` on an omitted model instead of calling `realm.delete(model)`.
+- Keep the first deletion time when the same response omits the row again.
+- Keep the existing `deleted` result count and log wording. In this repository, catalog deletion now means a tombstone.
+
+Change positive upsert behavior as follows:
+
+- Clear `deletedAt` whenever the API returns an existing model.
+- Clear it before the `updatedAt` comparison. A same-timestamp response must restore the existing primary-key row.
+- Keep direct catalog links on a tombstone. Do not clear a link because its target has `deletedAt`.
+
+The Artist list currently preserves favorite or downloaded Artists from physical deletion. Stop passing that preservation callback. A missing favorite Artist can now become a tombstone and remain visible through retained My Library queries. Do not otherwise redesign the repository signature in this change.
+
+Accept the current reconciliation scopes for the first implementation. A filtered local result may cause an omitted row to remain active. This is a stale-display defect, not an invalid-object risk. Do not add a second reconciliation query or another repository method unless a focused test proves that resurrection cannot work with the current `queryForModel` behavior.
+
+### 2. Keep current membership and add root-level visibility
+
+Keep the existing `splice()` calls in `relisten/realm/models/show_repo.ts`. An omitted SourceSet or SourceTrack leaves the current parent list but remains a valid Realm row. History, queue, and offline features can still reach retained tracks through their existing direct links, UUIDs, or scalar UUID fields.
+
+Do not turn `Source.sourceSets`, `SourceSet.sourceTracks`, or `Song.shows` into historical membership logs. Do not add parent-UUID validation to every traversal.
+
+Add `deletedAt == nil` to the Realm queries that are the roots of normal catalog browsing:
+
+- Artist browse and search;
+- Year, Venue, Tour, and Song lists;
+- recent, top, today, and momentum Show lists;
+- online Show, Source, SourceSet, and SourceTrack selection;
+- CarPlay catalog browsing.
+
+The main query roots are in `relisten/realm/models/artist_repo.ts`, `year_repo.ts`, `venue_repo.ts`, `tour_repo.ts`, `song_repo.ts`, `show_repo.ts`, and `relisten/realm/models/shows/`. CarPlay browse queries are in `relisten/carplay/`. Keep the edits at those existing query factories and route resolvers. Do not introduce a replacement query layer.
+
+Keep these reads retained unless a specific screen only represents the current remote catalog:
+
+- playback history and listening statistics;
+- the current queue and queue restoration;
+- successful downloads and offline routes;
+- favorites and My Library;
+- CarPlay history, library, offline, and current queue.
+
+A retained screen may currently reach tracks only through a current membership list. If that list no longer contains the tombstone, add a direct query by the existing scalar UUID fields for that screen. Do not preserve historical membership throughout the database to solve one retained screen.
+
+Apply the predicate to the row being selected. Do not recursively validate its relationships. For example, an active Show may still link to a tombstoned Venue. The Venue remains valid, and showing its old name is acceptable.
+
+Do not add `CatalogVisibility`, active/retained point-read wrappers, access-site strings, Sentry fingerprints, power-of-two breadcrumbs, or proxy objects. Use an unfiltered Realm query when a retained feature needs tombstones. Add a short comment only when the retained choice is not obvious from the feature name.
+
+### 3. Repair legacy missing links before consumers mount
+
+Add one file: `relisten/realm/catalog_startup_repair.ts`.
+
+Export one synchronous function:
+
+```ts
+function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary;
+```
+
+Keep the repair explicit. Do not build a generic relationship graph.
+
+In one Realm write, repair these known relationships:
+
+- `Show.artist` from `Show.artistUuid`;
+- `Source.artist` from `Source.artistUuid`;
+- `SourceTrack.artist` from `SourceTrack.artistUuid`;
+- `SourceTrack.show` from `SourceTrack.showUuid`;
+- `SourceTrack.source` from `SourceTrack.sourceUuid`;
+- `SourceTrack.year` from the repaired Show's `yearUuid`.
+
+Only query rows whose required link is `nil`. Use Realm predicates so a healthy database does not materialize every catalog row in JavaScript.
+
+If a required target does not exist:
+
+- set `deletedAt` on the referring Show, Source, or SourceTrack;
+- clear `isFavorite` on an irreparable favoritable row;
+- remove an irreparable SourceTrack from current `SourceSet.sourceTracks` lists;
+- remove an irreparable Show from current `Song.shows` sets;
+- remove the SourceTrack UUID from both `PlayerState` queue arrays;
+- physically delete `PlaybackHistoryEntry` rows that depend on the irreparable catalog row;
+- detach and physically delete `SourceTrackOfflineInfo` rows that depend on it.
+
+History and offline metadata are leaves. Their removal cannot invalidate a catalog object. Perform this cleanup before any history, queue, download, or CarPlay consumer mounts.
+
+Also delete legacy leaf rows that are already malformed:
+
+- a `PlaybackHistoryEntry` with a missing `sourceTrack`, `artist`, `show`, or `source` link;
+- a `PlaybackHistoryEntry` whose SourceTrack still has an unrepaired required link;
+- a `SourceTrackOfflineInfo` with no SourceTrack backlink.
+
+Do not create placeholder catalog rows to preserve malformed leaf data.
+
+Log one summary after repair. Include counts by model and action. Do not log one event per row. Do not add read-time tombstone diagnostics.
+
+Replace the current `RealmBridge` with a small `RealmStartupGate` inside the React `RealmProvider` in `app/_layout.tsx`. It runs the synchronous repair, sets the shared Realm reference, and only then mounts `RootServicesProvider` and the other consumers.
+
+Call the same repair from `openRealm()` before it stores or returns the opened Realm. The repair is idempotent, so it may run once for each Realm instance without a version flag.
+
+After startup, the existing centralized catalog writers must not publish a row as active when they have left one of the required links above as `nil`. If a writer cannot attach a required target, set `deletedAt` on that row. Do this in the existing relationship-attachment code. Do not add read-time guards throughout the UI.
+
+### 4. Keep leaf deletion physical and make async holders safe
+
+Do not add `deletedAt` to `PlaybackHistoryEntry`, `SourceTrackOfflineInfo`, `LastFmScrobbleEntry`, or `PlayerState`. Do not add a leaf collector.
+
+Keep the current history-clear, download-removal, Last.fm, and PlayerState deletion behavior.
+
+Make the known asynchronous history boundaries safe:
+
+- In `PlaybackHistoryReporter`, copy the history UUID and SourceTrack UUID before the API request. After the request, look up the history row again before setting `publishedAt`. If the user cleared history, there is nothing to update.
+- Before the retry loop awaits network work, snapshot the history UUIDs that it plans to publish. Resolve each UUID immediately before use.
+- In CarPlay history selection, keep plain UUIDs in the selection map or copy the needed UUIDs before the first `await`. Do not hold a `PlaybackHistoryEntry` across asynchronous work.
+
+Keep the DownloadManager's existing deletion checks and metadata re-fetch. Do not introduce another offline lifecycle in this change.
+
+## Concrete Steps
+
+Run all commands from `/Users/alecgorge/code/relisten/relisten-mobile` with the Node version from `.nvmrc`.
+
+1. Confirm the branch and base:
+
+   ```sh
+   nvm use
+   git status --short --branch
+   git rev-parse HEAD
+   git rev-parse origin/main
+   ```
+
+   Expected branch: `codex/permanent-catalog-tombstones`. Before implementation, `HEAD` and `origin/main` are both `e588385`.
+
+2. Add a small Vitest harness with real Realm. Keep tests close to the Realm lifecycle modules. Run Realm tests in one worker and call `Realm.shutdown()` after the suite.
+
+3. Implement repository tombstones and resurrection. Run the focused repository tests.
+
+4. Add active root predicates. Verify each changed query against its route: current catalog routes are active; history, queue, offline, and My Library routes are retained.
+
+5. Add startup repair and the history async fixes. Run the repair and reporter tests.
+
+6. Run the full checks:
+
+   ```sh
+   yarn test
+   yarn lint
+   yarn ts:check
+   ```
+
+7. Audit physical Realm deletion:
+
+   ```sh
+   rg -n "realm\.delete|deleteAll\(" app relisten
+   ```
+
+   Expected result: no catalog model is deleted. Physical deletion remains only for leaf or singleton data.
+
+8. Review only the changed files. Remove duplicate helpers, forwarding wrappers, speculative options, and comments that restate the code. Do not expand scope during this pass.
+
+## Validation and Acceptance
+
+Use real Realm tests for these behaviors:
+
+1. A version 12 Realm opens at version 13. Existing catalog rows have `deletedAt == nil`.
+2. An authoritative omission sets `deletedAt` and leaves a held managed catalog object valid.
+3. Tombstoning a SourceTrack preserves its direct Artist, Year, Show, and Source links.
+4. Current membership replacement may remove the SourceTrack from `SourceSet.sourceTracks` without invalidating the SourceTrack.
+5. A same-timestamp API response clears `deletedAt` and reuses the same primary-key row.
+6. A merge-only `upsertMultiple()` call does not tombstone omitted rows.
+7. A normal browse query hides a tombstone. A history or queue lookup can still return it.
+8. Startup repair restores each known missing link when the target row exists.
+9. Startup repair tombstones an irreparable catalog row and removes its history, offline, favorite, membership, and queue entry points.
+10. Running startup repair twice produces no further changes on the second run.
+11. Clearing history during an in-flight report does not access the deleted history object after the request completes.
+
+Run these manual scenarios on the iPhone 17 simulator:
+
+- Start playback. Refresh the full Show so the current SourceTrack is omitted. Confirm playback and queue rendering continue.
+- Restore a queue that contains a tombstoned SourceTrack. Confirm the track remains playable when its media is available.
+- Confirm normal Artist and Show browsing hides tombstones.
+- Confirm history and My Library can render a structurally valid tombstone.
+- Open a copied Realm with a repairable missing link. Confirm startup repairs the link before the first screen mounts.
+- Open a copied Realm with an irreparable SourceTrack. Confirm the app removes its leaf and queue entry points and does not crash.
+- Clear history while a report request is in flight. Confirm the request completion does not throw an invalid-object error.
+
+Acceptance requires `yarn test`, `yarn lint`, and `yarn ts:check` to pass. The final deletion audit must show no catalog `realm.delete()` call.
+
+## Idempotence and Recovery
+
+Setting `deletedAt` is idempotent. Repeated omissions keep the original date.
+
+Positive API data clears `deletedAt`. A false tombstone can therefore recover without creating a second primary-key row.
+
+Startup repair is idempotent. A restored row no longer matches its missing-link query. An irreparable catalog row remains a valid tombstone, and its leaf references are already gone.
+
+Schema version 13 is one-way. Ship the change in a native runtime whose embedded bundle also uses schema version 13. A rollback bundle for that runtime must keep schema version 13 and the nine `deletedAt` properties.
+
+Do not use `deleteRealmIfMigrationNeeded` as recovery. It would delete local history, downloads, settings, and queue state.
+
+## Artifacts and Notes
+
+Keep these artifacts with the implementation:
+
+- focused real-Realm test output;
+- `yarn lint` and `yarn ts:check` output;
+- the final `realm.delete` audit;
+- a short manual record for playback, queue restoration, startup repair, retained history, and in-flight history clear.
+
+## Interfaces and Dependencies
+
+Do not add a catalog lifecycle service or a general read API.
+
+The existing repository interface remains the write interface:
+
+```ts
+class Repository<...> {
+  upsert(...): UpsertResults<...>;
+  upsertMultiple(
+    realm,
+    apiRows,
+    localRows,
+    performDeletes,
+    queryForModel,
+    shouldPreserve?
+  ): UpsertResults<...>;
+}
+```
+
+The only new runtime interface is the startup repair:
+
+```ts
+interface CatalogRepairSummary {
+  repairedLinks: number;
+  tombstonedRows: number;
+  deletedLeafRows: number;
+  removedQueueEntries: number;
+}
+
+function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary;
+```
+
+Add only one development dependency: Vitest. Do not add a runtime dependency.

--- a/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
+++ b/docs/plans/active/2026-08-20-permanent-catalog-tombstones.md
@@ -48,7 +48,8 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - [x] (2026-08-21 01:18Z) Approve the revised plan and start implementation from `origin/main` at `7c1b74d`.
 - [x] (2026-08-21 01:22Z) Add catalog tombstones, repository soft deletion and resurrection, and four focused real-Realm tests.
 - [x] (2026-08-21 01:29Z) Add active filters at normal catalog query roots while keeping owned and historical routes retained.
-- [ ] Add startup repair and focused leaf-consumer safety fixes.
+- [x] (2026-08-21 01:36Z) Add the shared startup repair gate and writer-side required-link enforcement.
+- [ ] Make the confirmed asynchronous history leaf holders safe.
 - [ ] Add focused tests, run repository checks, and complete manual crash scenarios.
 - [ ] Review the implementation, then simplify the changed code without changing behavior.
 
@@ -64,6 +65,7 @@ The implementation may keep stale catalog rows when the API does not provide a c
 - Observation: the React Realm provider and the non-React `openRealm()` path can expose Realm. Both paths must run the same idempotent startup repair before returning consumers.
 - Observation: a managed optional Realm date reads as `null` when empty, although the TypeScript model uses an optional property. Evidence: the real-Realm repository tests pass by using `== null` in lifecycle code and asserting `null` at the managed read boundary.
 - Observation: active detail queries can hide the local tombstone that a positive API response must restore. Evidence: Show, Venue, Tour, and Song detail writers previously received only the displayed root object. They now use the repository's existing `queryForModel` flag so refresh reuses the hidden primary-key row.
+- Observation: the React provider can open Realm without using `openRealm()`. Evidence: `app/_layout.tsx` mounts `RealmProvider` directly, while early CarPlay setup may call `openRealm()`. Both paths now run the same idempotent repair before installing consumers.
 
 ## Decision Log
 
@@ -78,7 +80,7 @@ The implementation may keep stale catalog rows when the API does not provide a c
 
 ## Outcomes & Retrospective
 
-No implementation has started. Complete this section after the code and manual scenarios are finished.
+Implementation is in progress. Catalog writes, active query roots, and startup repair are complete. Async leaf safety, final review, and manual scenarios remain.
 
 ## Context and Orientation
 
@@ -334,6 +336,14 @@ Active-query checkpoint evidence from Node 22.21.1:
     focused ESLint: passed
     git diff --check: passed
 
+Startup-repair checkpoint evidence from Node 22.21.1:
+
+    Test Files  2 passed (2)
+         Tests  6 passed (6)
+    yarn ts:check: passed
+    focused ESLint: passed
+    git diff --check: passed
+
 ## Interfaces and Dependencies
 
 Do not add a catalog lifecycle service or a general read API.
@@ -374,3 +384,5 @@ Plan revision note, 2026-08-21: implementation started after the user approved t
 Plan revision note, 2026-08-21 01:22Z: the schema and repository milestone is complete. Real Realm tests now prove tombstoning, stable links, same-timestamp resurrection, merge-only behavior, and the additive schema migration.
 
 Plan revision note, 2026-08-21 01:29Z: normal catalog query roots now exclude tombstones. Shared offline and My Library Artist, Year, Show, and Source readers remain retained, as do history, queue, download, and CarPlay ownership paths. No general query abstraction was added.
+
+Plan revision note, 2026-08-21 01:36Z: one explicit startup transaction now repairs recoverable catalog links and quarantines irreparable rows before React or CarPlay consumers mount. Two production-schema Realm tests cover repair, legacy hard-delete damage, leaf cleanup, queue cleanup, and idempotence.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios -d",
     "web": "expo start --web",
+    "test": "vitest run",
     "ts:check": "tsc",
     "lint": "eslint app relisten",
     "pods": "npx pod-install",
@@ -100,7 +101,8 @@
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "patch-package": "^8.0.1",
     "tailwindcss": "3.3.2",
-    "typescript": "~6.0.3"
+    "typescript": "~6.0.3",
+    "vitest": "^4.1.11"
   },
   "expo": {
     "doctor": {

--- a/relisten/carplay/artists.ts
+++ b/relisten/carplay/artists.ts
@@ -45,6 +45,7 @@ export function createArtistsListTemplate(
     ctx.realm,
     scope === 'offline',
     false,
+    scope !== 'browse',
     behaviorOptions
   );
   const executor = artistsBehavior.sharedExecutor(ctx.apiClient);
@@ -225,6 +226,7 @@ function createYearsListTemplate(
     ctx.realm,
     scope === 'offline',
     artist.uuid,
+    scope !== 'browse',
     behaviorOptions
   );
   const executor = yearsBehavior.sharedExecutor(ctx.apiClient);
@@ -332,6 +334,7 @@ function createYearsListTemplate(
       artist.uuid,
       year.uuid,
       userFilters,
+      scope !== 'browse',
       behaviorOptions
     );
     const showsExecutor = showsBehavior.sharedExecutor(ctx.apiClient);

--- a/relisten/carplay/library.ts
+++ b/relisten/carplay/library.ts
@@ -120,14 +120,12 @@ export function createRecentTemplate(ctx: RelistenCarPlayContext): ListTemplate 
 
   ctx.addTeardown(() => historyStream.tearDown());
 
-  const entryMap: Map<string, PlaybackHistoryEntry> = new Map();
-
   const template = new ListTemplate({
     title: 'Recently Played',
     tabTitle: 'Recent',
     tabSystemImageName: 'clock.arrow.circlepath',
     async onItemSelect({ id }: { templateId: string; index: number; id: string }) {
-      const entry = entryMap.get(String(id));
+      const entry = ctx.realm.objectForPrimaryKey(PlaybackHistoryEntry, String(id));
       if (!entry) return;
 
       const track = entry.sourceTrack;
@@ -141,18 +139,16 @@ export function createRecentTemplate(ctx: RelistenCarPlayContext): ListTemplate 
         return;
       }
 
-      await queuePlaybackHistoryEntry(ctx, 'browse', entry);
+      return queuePlaybackHistoryEntry(ctx, 'browse', String(id));
     },
     sections: [],
     emptyViewTitleVariants: ['Loading history...'],
   });
 
   const updateSections = () => {
-    entryMap.clear();
     const entries = Array.from(historyStream.currentValue || []).slice(0, 50);
 
     const items = entries.map((entry) => {
-      entryMap.set(entry.uuid, entry);
       const show = entry.show;
       const artist = entry.artist;
       const subtitle = [artist?.name, show?.displayDate].filter(Boolean).join(' • ');

--- a/relisten/carplay/queue_helpers.ts
+++ b/relisten/carplay/queue_helpers.ts
@@ -50,26 +50,42 @@ export function queueTracksFromSelection({
   return true;
 }
 
-export async function queuePlaybackHistoryEntry(
-  ctx: RelistenCarPlayContext,
-  scope: CarPlayScope,
-  entry: PlaybackHistoryEntry
-) {
-  const offlineMode = ctx.userSettings.offlineModeWithDefault();
-  let source = entry.source;
-  let artist = entry.artist;
+function resolvePlaybackHistorySelection(ctx: RelistenCarPlayContext, entryUuid: string) {
+  const entry = ctx.realm.objectForPrimaryKey(PlaybackHistoryEntry, entryUuid);
+  if (!entry) return;
 
-  if (!source || !artist) {
-    carplay_logger.warn('History entry missing source or artist', { id: entry.uuid });
+  if (!entry.source || !entry.artist) {
+    carplay_logger.warn('History entry missing source or artist', { id: entryUuid });
     return;
   }
 
+  return {
+    artist: entry.artist,
+    showUuid: entry.show.uuid,
+    source: entry.source,
+    sourceTrackUuid: entry.sourceTrack.uuid,
+  };
+}
+
+export async function queuePlaybackHistoryEntry(
+  ctx: RelistenCarPlayContext,
+  scope: CarPlayScope,
+  entryUuid: string
+) {
+  // Resolve the physical history leaf in a synchronous frame. Only permanent catalog objects and
+  // plain identifiers are kept after this point, so clearing history during the request is safe.
+  const selection = resolvePlaybackHistorySelection(ctx, entryUuid);
+  if (!selection) return;
+
+  const offlineMode = ctx.userSettings.offlineModeWithDefault();
+  let { source, artist } = selection;
+
   if (!source.sourceSets?.length) {
-    const response = await ctx.apiClient.showWithSources(entry.show.uuid);
+    const response = await ctx.apiClient.showWithSources(selection.showUuid);
 
     if (response?.data?.uuid) {
       const show = upsertShowWithSources(ctx.realm, response.data);
-      source = ctx.realm.objectForPrimaryKey(Source, entry.source.uuid) || source;
+      source = ctx.realm.objectForPrimaryKey(Source, source.uuid) || source;
       artist = show?.artist || artist;
     }
   }
@@ -86,7 +102,7 @@ export async function queuePlaybackHistoryEntry(
     ctx,
     scope,
     orderedTracks,
-    selectedTrackUuid: entry.sourceTrack.uuid,
+    selectedTrackUuid: selection.sourceTrackUuid,
     sourceUuid: source.uuid,
   });
 }

--- a/relisten/carplay/show_templates.ts
+++ b/relisten/carplay/show_templates.ts
@@ -26,7 +26,12 @@ export function createSourcesListTemplate(
   show: Show
 ): ListTemplate {
   carplay_logger.info('createSourcesListTemplate', { scope, artist: artist.uuid, show: show.uuid });
-  const behavior = new ShowWithFullSourcesNetworkBackedBehavior(ctx.realm, show.uuid);
+  const behavior = new ShowWithFullSourcesNetworkBackedBehavior(
+    ctx.realm,
+    show.uuid,
+    undefined,
+    scope !== 'browse'
+  );
   const executor = behavior.sharedExecutor(ctx.apiClient);
   const results = executor.start();
 

--- a/relisten/events.ts
+++ b/relisten/events.ts
@@ -1,8 +1,9 @@
-import { StatsigEvent } from '@statsig/client-core/src/StatsigEvent';
-import { SourceTrack } from '@/relisten/realm/models/source_track';
+import type { StatsigEvent } from '@statsig/client-core/src/StatsigEvent';
+import type { SourceTrack } from '@/relisten/realm/models/source_track';
 import { LogLevel, StatsigClientExpo } from '@statsig/expo-bindings';
-import { SourceTrackOfflineInfo } from '@/relisten/realm/models/source_track_offline_info';
-import { RelistenPlaybackError } from '@/modules/relisten-audio-player';
+import type { SourceTrackOfflineInfo } from '@/relisten/realm/models/source_track_offline_info';
+import type { RelistenPlaybackError } from '@/modules/relisten-audio-player';
+import type { CatalogRepairSummary } from '@/relisten/realm/catalog_startup_repair';
 
 export const STATSIG_CLIENT_KEY = 'client-b2bL7VM28cjEBr7aVFNv8wOqa1STKtLyXD5MoCxA94f';
 
@@ -29,6 +30,30 @@ export enum Events {
   TrackDownloadFailure = 'track_download_failure',
   TrackDownloadIntegrity = 'track_download_integrity',
   DownloadsResumed = 'downloads_resumed',
+  CatalogStartupRepair = 'catalog_startup_repair',
+}
+
+export function catalogStartupRepairEvent(
+  summary: CatalogRepairSummary,
+  durationMs: number,
+  repairVersion: number
+): StatsigEvent {
+  return {
+    eventName: Events.CatalogStartupRepair,
+    value:
+      summary.repairedLinks +
+      summary.tombstonedRows +
+      summary.deletedLeafRows +
+      summary.removedQueueEntries,
+    metadata: {
+      repairedLinks: summary.repairedLinks.toString(),
+      tombstonedRows: summary.tombstonedRows.toString(),
+      deletedLeafRows: summary.deletedLeafRows.toString(),
+      removedQueueEntries: summary.removedQueueEntries.toString(),
+      durationMs: durationMs.toString(),
+      repairVersion: repairVersion.toString(),
+    },
+  };
 }
 
 export function trackPlaybackEvent(sourceTrack: SourceTrack): StatsigEvent {

--- a/relisten/pages/legacy_migration.tsx
+++ b/relisten/pages/legacy_migration.tsx
@@ -67,7 +67,8 @@ export class LegacyDataMigrator {
     const sourceBehavior = new ShowWithFullSourcesNetworkBackedBehavior(
       this.realm,
       undefined,
-      sourceUuid
+      sourceUuid,
+      true
     );
     const result = await NetworkBackedBehaviorExecutor.executeUntilMatches(
       sourceBehavior,
@@ -190,7 +191,12 @@ export class LegacyDataMigrator {
   }
 
   public async migrateFavoriteShow(showUuid: string): Promise<LegacyDataMigrationResult> {
-    const showBehavior = new ShowWithFullSourcesNetworkBackedBehavior(this.realm, showUuid);
+    const showBehavior = new ShowWithFullSourcesNetworkBackedBehavior(
+      this.realm,
+      showUuid,
+      undefined,
+      true
+    );
     const result = await NetworkBackedBehaviorExecutor.executeUntilMatches(
       showBehavior,
       this.api,
@@ -205,7 +211,8 @@ export class LegacyDataMigrator {
       const yearsBehavior = yearsNetworkBackedModelArrayBehavior(
         this.realm,
         false,
-        show.artistUuid
+        show.artistUuid,
+        true
       );
       await NetworkBackedBehaviorExecutor.executeUntilMatches(yearsBehavior, this.api, (result) => {
         return (result.errors?.length ?? 0) > 0 || yearsBehavior.isLocalDataShowable(result.data);
@@ -254,7 +261,8 @@ export class LegacyDataMigrator {
     const sourceBehavior = new ShowWithFullSourcesNetworkBackedBehavior(
       this.realm,
       legacySource.show_uuid,
-      sourceUuid
+      sourceUuid,
+      true
     );
     const result = await NetworkBackedBehaviorExecutor.executeUntilMatches(
       sourceBehavior,
@@ -318,7 +326,7 @@ export class LegacyDataMigrator {
   }
 
   public async migrateFavoriteArtists(artistUuids: string[]): Promise<LegacyDataMigrationResult[]> {
-    const artistsBehavior = artistsNetworkBackedBehavior(this.realm, false, true);
+    const artistsBehavior = artistsNetworkBackedBehavior(this.realm, false, true, true);
     const { data: artists } = await NetworkBackedBehaviorExecutor.executeToFirstShowableData(
       artistsBehavior,
       this.api

--- a/relisten/playback_history_reporter.test.ts
+++ b/relisten/playback_history_reporter.test.ts
@@ -76,6 +76,29 @@ const config: Realm.Configuration = {
   schema: [TestSourceTrack, TestArtist, TestShow, TestSource, PlaybackHistoryEntry],
 };
 
+function createHistoryEntries(realm: Realm, uuids: string[]): PlaybackHistoryEntry[] {
+  return realm.write(() => {
+    const sourceTrack = realm.create(TestSourceTrack, { uuid: 'track' });
+    const artist = realm.create(TestArtist, { uuid: 'artist' });
+    const show = realm.create(TestShow, { uuid: 'show' });
+    const source = realm.create(TestSource, { uuid: 'source' });
+
+    return uuids.map(
+      (uuid) =>
+        realm.create('PlaybackHistoryEntry', {
+          uuid,
+          playbackFlags: 0,
+          createdAt: now,
+          playbackStartedAt: now,
+          sourceTrack,
+          artist,
+          show,
+          source,
+        }) as unknown as PlaybackHistoryEntry
+    );
+  });
+}
+
 describe('PlaybackHistoryReporter', () => {
   let realm: Realm;
 
@@ -102,24 +125,7 @@ describe('PlaybackHistoryReporter', () => {
         })
     );
     const reporter = new PlaybackHistoryReporter({ recordPlayback } as never, realm);
-    let entry!: PlaybackHistoryEntry;
-
-    realm.write(() => {
-      const sourceTrack = realm.create(TestSourceTrack, { uuid: 'track' });
-      const artist = realm.create(TestArtist, { uuid: 'artist' });
-      const show = realm.create(TestShow, { uuid: 'show' });
-      const source = realm.create(TestSource, { uuid: 'source' });
-      entry = realm.create('PlaybackHistoryEntry', {
-        uuid: 'history',
-        playbackFlags: 0,
-        createdAt: now,
-        playbackStartedAt: now,
-        sourceTrack,
-        artist,
-        show,
-        source,
-      }) as unknown as PlaybackHistoryEntry;
-    });
+    const [entry] = createHistoryEntries(realm, ['history']);
 
     const reportPromise = (
       reporter as unknown as {
@@ -133,5 +139,30 @@ describe('PlaybackHistoryReporter', () => {
 
     await expect(reportPromise).resolves.toBeDefined();
     expect(realm.objects(PlaybackHistoryEntry)).toHaveLength(0);
+  });
+
+  it('skips snapshot entries deleted while publishing', async () => {
+    let resolveRequest!: (response: { error?: unknown }) => void;
+    const recordPlayback = vi.fn(
+      () =>
+        new Promise<{ error?: unknown }>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
+    const reporter = new PlaybackHistoryReporter({ recordPlayback } as never, realm);
+    createHistoryEntries(realm, ['history-1', 'history-2']);
+
+    const reportPromise = (
+      reporter as unknown as {
+        reportPlaybackHistory(): Promise<void>;
+      }
+    ).reportPlaybackHistory();
+
+    expect(recordPlayback).toHaveBeenCalledTimes(1);
+    realm.write(() => realm.delete(realm.objects(PlaybackHistoryEntry)));
+    resolveRequest({});
+
+    await expect(reportPromise).resolves.toBeUndefined();
+    expect(recordPlayback).toHaveBeenCalledTimes(1);
   });
 });

--- a/relisten/playback_history_reporter.test.ts
+++ b/relisten/playback_history_reporter.test.ts
@@ -1,0 +1,137 @@
+import Realm from 'realm';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/relisten/util/logging', () => ({
+  log: {
+    extend: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('expo-file-system', () => ({
+  Paths: {
+    document: '/tmp',
+    join: (...parts: string[]) => parts.join('/'),
+  },
+}));
+
+vi.mock('@/relisten/events', () => ({
+  sharedStatsigClient: vi.fn(),
+}));
+
+vi.mock('expo-crypto', () => ({
+  randomUUID: vi.fn(),
+}));
+
+import { PlaybackHistoryReporter } from '@/relisten/playback_history_reporter';
+import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
+
+const TEST_REALM_PATH = '/tmp/relisten-playback-history-reporter-test.realm';
+const now = new Date('2026-08-20T00:00:00.000Z');
+
+class TestSourceTrack extends Realm.Object<TestSourceTrack> {
+  static schema: Realm.ObjectSchema = {
+    name: 'SourceTrack',
+    primaryKey: 'uuid',
+    properties: { uuid: 'string' },
+  };
+
+  uuid!: string;
+}
+
+class TestArtist extends Realm.Object<TestArtist> {
+  static schema: Realm.ObjectSchema = {
+    name: 'Artist',
+    primaryKey: 'uuid',
+    properties: { uuid: 'string' },
+  };
+
+  uuid!: string;
+}
+
+class TestShow extends Realm.Object<TestShow> {
+  static schema: Realm.ObjectSchema = {
+    name: 'Show',
+    primaryKey: 'uuid',
+    properties: { uuid: 'string' },
+  };
+
+  uuid!: string;
+}
+
+class TestSource extends Realm.Object<TestSource> {
+  static schema: Realm.ObjectSchema = {
+    name: 'Source',
+    primaryKey: 'uuid',
+    properties: { uuid: 'string' },
+  };
+
+  uuid!: string;
+}
+
+const config: Realm.Configuration = {
+  path: TEST_REALM_PATH,
+  schema: [TestSourceTrack, TestArtist, TestShow, TestSource, PlaybackHistoryEntry],
+};
+
+describe('PlaybackHistoryReporter', () => {
+  let realm: Realm;
+
+  beforeEach(() => {
+    if (Realm.exists(config)) Realm.deleteFile(config);
+    realm = new Realm(config);
+  });
+
+  afterEach(() => {
+    realm.close();
+    if (Realm.exists(config)) Realm.deleteFile(config);
+  });
+
+  afterAll(() => {
+    Realm.shutdown();
+  });
+
+  it('does not retain a history object while publishing it', async () => {
+    let resolveRequest!: (response: { error?: unknown }) => void;
+    const recordPlayback = vi.fn(
+      () =>
+        new Promise<{ error?: unknown }>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
+    const reporter = new PlaybackHistoryReporter({ recordPlayback } as never, realm);
+    let entry!: PlaybackHistoryEntry;
+
+    realm.write(() => {
+      const sourceTrack = realm.create(TestSourceTrack, { uuid: 'track' });
+      const artist = realm.create(TestArtist, { uuid: 'artist' });
+      const show = realm.create(TestShow, { uuid: 'show' });
+      const source = realm.create(TestSource, { uuid: 'source' });
+      entry = realm.create('PlaybackHistoryEntry', {
+        uuid: 'history',
+        playbackFlags: 0,
+        createdAt: now,
+        playbackStartedAt: now,
+        sourceTrack,
+        artist,
+        show,
+        source,
+      }) as unknown as PlaybackHistoryEntry;
+    });
+
+    const reportPromise = (
+      reporter as unknown as {
+        attemptReport(entryUuid: string): Promise<unknown>;
+      }
+    ).attemptReport(entry.uuid);
+
+    expect(recordPlayback).toHaveBeenCalledWith('track');
+    realm.write(() => realm.delete(entry));
+    resolveRequest({});
+
+    await expect(reportPromise).resolves.toBeDefined();
+    expect(realm.objects(PlaybackHistoryEntry)).toHaveLength(0);
+  });
+});

--- a/relisten/playback_history_reporter.ts
+++ b/relisten/playback_history_reporter.ts
@@ -130,17 +130,24 @@ export class PlaybackHistoryReporter {
 
     const entriesToPublish = this.realm
       .objects(PlaybackHistoryEntry)
-      .filtered('publishedAt == null');
+      .filtered('publishedAt == null')
+      .snapshot();
 
     if (entriesToPublish.length === 0) {
       logger.info('No playback history entries to publish');
       return;
     }
 
-    const entryUuidsToPublish = Array.from(entriesToPublish, (entry) => entry.uuid);
-    logger.info(`Reporting ${entryUuidsToPublish.length} playback history entries`);
+    const entryCount = entriesToPublish.length;
+    logger.info(`Reporting ${entryCount} playback history entries`);
 
-    for (const entryUuid of entryUuidsToPublish) {
+    for (let index = 0; index < entryCount; index += 1) {
+      // Read only the scalar before awaiting. Clearing history turns a deleted snapshot slot null.
+      const entryUuid = (entriesToPublish[index] as PlaybackHistoryEntry | null)?.uuid;
+      if (!entryUuid) {
+        continue;
+      }
+
       const res = await this.attemptReport(entryUuid);
 
       if (res?.error) {
@@ -156,6 +163,6 @@ export class PlaybackHistoryReporter {
       }
     }
 
-    logger.info(`Successfully processed ${entryUuidsToPublish.length} playback history entries`);
+    logger.info(`Successfully processed ${entryCount} playback history entries`);
   }
 }

--- a/relisten/playback_history_reporter.ts
+++ b/relisten/playback_history_reporter.ts
@@ -1,4 +1,4 @@
-import { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
+import type { RelistenApiClient, RelistenApiResponse } from '@/relisten/api/client';
 import Realm from 'realm';
 import {
   PlaybackFlags,
@@ -91,20 +91,32 @@ export class PlaybackHistoryReporter {
 
     // fire and forget report -- async job will pick it up if it doesn't succeed
     if (this.networkAvailable) {
-      this.attemptReport(entry).then(() => {});
+      this.attemptReport(entry.uuid).then(() => {});
     }
 
     return entry;
   }
 
-  private async attemptReport(entry: PlaybackHistoryEntry): Promise<RelistenApiResponse<unknown>> {
-    const res = await this.apiClient.recordPlayback(entry.sourceTrack.uuid);
+  private async attemptReport(
+    entryUuid: string
+  ): Promise<RelistenApiResponse<unknown> | undefined> {
+    const entry = this.realm.objectForPrimaryKey(PlaybackHistoryEntry, entryUuid);
+    if (!entry) {
+      return;
+    }
+
+    // History rows are physical leaves and may be cleared while the request is in flight.
+    const sourceTrackUuid = entry.sourceTrack.uuid;
+    const res = await this.apiClient.recordPlayback(sourceTrackUuid);
 
     if (!res.error) {
-      logger.info(`Reported playback ${entry.uuid} for sourceTrack=${entry.sourceTrack.uuid}`);
-      this.realm.write(() => {
-        entry.publishedAt = new Date();
-      });
+      logger.info(`Reported playback ${entryUuid} for sourceTrack=${sourceTrackUuid}`);
+      const currentEntry = this.realm.objectForPrimaryKey(PlaybackHistoryEntry, entryUuid);
+      if (currentEntry) {
+        this.realm.write(() => {
+          currentEntry.publishedAt = new Date();
+        });
+      }
     }
 
     return res;
@@ -125,14 +137,15 @@ export class PlaybackHistoryReporter {
       return;
     }
 
-    logger.info(`Reporting ${entriesToPublish.length} playback history entries`);
+    const entryUuidsToPublish = Array.from(entriesToPublish, (entry) => entry.uuid);
+    logger.info(`Reporting ${entryUuidsToPublish.length} playback history entries`);
 
-    for (const entry of entriesToPublish) {
-      const res = await this.attemptReport(entry);
+    for (const entryUuid of entryUuidsToPublish) {
+      const res = await this.attemptReport(entryUuid);
 
-      if (res.error) {
+      if (res?.error) {
         logger.warn(
-          `Error reporting ${entry.uuid}. Will try again in 30s; ${JSON.stringify(res.error)}`
+          `Error reporting ${entryUuid}. Will try again in 30s; ${JSON.stringify(res.error)}`
         );
 
         this.retryTimer = setTimeout(() => {
@@ -143,6 +156,6 @@ export class PlaybackHistoryReporter {
       }
     }
 
-    logger.info(`Successfully reported ${entriesToPublish.length} playback history entries`);
+    logger.info(`Successfully processed ${entryUuidsToPublish.length} playback history entries`);
   }
 }

--- a/relisten/realm/catalog_startup_repair.test.ts
+++ b/relisten/realm/catalog_startup_repair.test.ts
@@ -92,12 +92,12 @@ function createYear(realm: Realm) {
   });
 }
 
-function createShow(realm: Realm, artist?: Artist) {
+function createShow(realm: Realm, artist?: Artist, uuid = 'show', artistUuid = 'artist') {
   return realm.create(Show, {
-    uuid: 'show',
+    uuid,
     createdAt: now,
     updatedAt: now,
-    artistUuid: 'artist',
+    artistUuid,
     yearUuid: 'year',
     date: now,
     avgRating: 0,
@@ -155,13 +155,15 @@ function createSourceTrack(
     show: Show;
     source: Source;
     offlineInfo?: SourceTrackOfflineInfo;
-  }
+  },
+  uuid = 'track',
+  artistUuid = 'artist'
 ) {
   return realm.create(SourceTrack, {
-    uuid: 'track',
+    uuid,
     createdAt: now,
     updatedAt: now,
-    artistUuid: 'artist',
+    artistUuid,
     sourceUuid: 'source',
     sourceSetUuid: 'source-set',
     showUuid: 'show',
@@ -183,7 +185,7 @@ function createOfflineInfo(realm: Realm) {
   });
 }
 
-function createSong(realm: Realm, show: Show) {
+function createSong(realm: Realm, shows: Show | Show[]) {
   return realm.create(Song, {
     uuid: 'song',
     createdAt: now,
@@ -194,7 +196,7 @@ function createSong(realm: Realm, show: Show) {
     upstreamIdentifier: 'song',
     sortName: 'Song',
     showsPlayedAt: 1,
-    shows: [show],
+    shows: Array.isArray(shows) ? shows : [shows],
   });
 }
 
@@ -334,5 +336,50 @@ describe('catalog startup repair', () => {
       deletedLeafRows: 0,
       removedQueueEntries: 0,
     });
+  });
+
+  it('removes multiple damaged memberships without removing healthy rows', () => {
+    let sourceSet!: SourceSet;
+    let song!: Song;
+
+    realm.write(() => {
+      const artist = createArtist(realm);
+      const year = createYear(realm);
+      const healthyShow = createShow(realm, artist);
+      const source = createSource(realm, artist);
+      sourceSet = createSourceSet(realm);
+      const healthyTrack = createSourceTrack(realm, {
+        artist,
+        year,
+        show: healthyShow,
+        source,
+      });
+      const damagedShow1 = createShow(realm, undefined, 'damaged-show-1', 'missing-artist');
+      const damagedShow2 = createShow(realm, undefined, 'damaged-show-2', 'missing-artist');
+      const damagedTrack1 = createSourceTrack(
+        realm,
+        undefined,
+        'damaged-track-1',
+        'missing-artist'
+      );
+      const damagedTrack2 = createSourceTrack(
+        realm,
+        undefined,
+        'damaged-track-2',
+        'missing-artist'
+      );
+
+      sourceSet.sourceTracks.push(damagedTrack1, damagedTrack2, healthyTrack);
+      song = createSong(realm, [damagedShow1, healthyShow, damagedShow2]);
+    });
+
+    expect(repairCatalogAtStartup(realm)).toEqual({
+      repairedLinks: 0,
+      tombstonedRows: 4,
+      deletedLeafRows: 0,
+      removedQueueEntries: 0,
+    });
+    expect(Array.from(sourceSet.sourceTracks, (track) => track.uuid)).toEqual(['track']);
+    expect(Array.from(song.shows, (show) => show.uuid)).toEqual(['show']);
   });
 });

--- a/relisten/realm/catalog_startup_repair.test.ts
+++ b/relisten/realm/catalog_startup_repair.test.ts
@@ -1,0 +1,338 @@
+import Realm from 'realm';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/relisten/util/logging', () => ({
+  log: {
+    extend: () => ({ info: vi.fn() }),
+  },
+}));
+
+vi.mock('expo-file-system', () => ({
+  Paths: {
+    document: '/tmp',
+    join: (...parts: string[]) => parts.join('/'),
+  },
+}));
+
+vi.mock('@/relisten/events', () => ({
+  sharedStatsigClient: vi.fn(),
+}));
+
+import { repairCatalogAtStartup } from '@/relisten/realm/catalog_startup_repair';
+import { Artist } from '@/relisten/realm/models/artist';
+import { Year } from '@/relisten/realm/models/year';
+import { Show } from '@/relisten/realm/models/show';
+import { Venue } from '@/relisten/realm/models/venue';
+import { Tour } from '@/relisten/realm/models/tour';
+import { Song } from '@/relisten/realm/models/song';
+import { Source } from '@/relisten/realm/models/source';
+import { SourceSet } from '@/relisten/realm/models/source_set';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
+import { SourceTrackOfflineInfo } from '@/relisten/realm/models/source_track_offline_info';
+import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
+import { PlayerState, PLAYER_STATE_SENTINEL } from '@/relisten/realm/models/player_state';
+import {
+  Popularity,
+  PopularityWindow,
+  PopularityWindows,
+} from '@/relisten/realm/models/popularity';
+import { FlacType } from '@/relisten/api/models/source';
+
+const TEST_REALM_PATH = '/tmp/relisten-catalog-startup-repair-test.realm';
+const now = new Date('2026-08-20T00:00:00.000Z');
+
+const config: Realm.Configuration = {
+  path: TEST_REALM_PATH,
+  schemaVersion: 13,
+  schema: [
+    Artist,
+    Year,
+    Show,
+    Venue,
+    Tour,
+    Song,
+    Source,
+    SourceSet,
+    SourceTrack,
+    SourceTrackOfflineInfo,
+    PlaybackHistoryEntry,
+    PlayerState,
+    Popularity,
+    PopularityWindow,
+    PopularityWindows,
+  ],
+};
+
+function createArtist(realm: Realm) {
+  return realm.create(Artist, {
+    uuid: 'artist',
+    createdAt: now,
+    updatedAt: now,
+    musicbrainzId: '',
+    name: 'Artist',
+    featured: 0,
+    slug: 'artist',
+    sortName: 'Artist',
+    featuresRaw: '{}',
+    upstreamSourcesRaw: '[]',
+    showCount: 1,
+    sourceCount: 1,
+  });
+}
+
+function createYear(realm: Realm) {
+  return realm.create(Year, {
+    uuid: 'year',
+    createdAt: now,
+    updatedAt: now,
+    artistUuid: 'artist',
+    showCount: 1,
+    sourceCount: 1,
+    year: '2026',
+  });
+}
+
+function createShow(realm: Realm, artist?: Artist) {
+  return realm.create(Show, {
+    uuid: 'show',
+    createdAt: now,
+    updatedAt: now,
+    artistUuid: 'artist',
+    yearUuid: 'year',
+    date: now,
+    avgRating: 0,
+    displayDate: '2026-08-20',
+    mostRecentSourceUpdatedAt: now,
+    hasSoundboardSource: false,
+    hasStreamableFlacSource: false,
+    sourceCount: 1,
+    isFavorite: true,
+    artist,
+  });
+}
+
+function createSource(realm: Realm, artist?: Artist): Source {
+  return realm.create(Source, {
+    uuid: 'source',
+    createdAt: now,
+    updatedAt: now,
+    artistUuid: 'artist',
+    showUuid: 'show',
+    displayDate: '2026-08-20',
+    isSoundboard: false,
+    isRemaster: false,
+    hasJamcharts: false,
+    avgRating: 0,
+    numReviews: 0,
+    avgRatingWeighted: 0,
+    upstreamIdentifier: 'source',
+    flacType: FlacType.NoFlac,
+    reviewCount: 0,
+    linksRaw: '[]',
+    isFavorite: true,
+    artist,
+  });
+}
+
+function createSourceSet(realm: Realm) {
+  return realm.create(SourceSet, {
+    uuid: 'source-set',
+    createdAt: now,
+    updatedAt: now,
+    artistUuid: 'artist',
+    sourceUuid: 'source',
+    index: 0,
+    isEncore: false,
+    name: 'Set 1',
+  });
+}
+
+function createSourceTrack(
+  realm: Realm,
+  relationships?: {
+    artist: Artist;
+    year: Year;
+    show: Show;
+    source: Source;
+    offlineInfo?: SourceTrackOfflineInfo;
+  }
+) {
+  return realm.create(SourceTrack, {
+    uuid: 'track',
+    createdAt: now,
+    updatedAt: now,
+    artistUuid: 'artist',
+    sourceUuid: 'source',
+    sourceSetUuid: 'source-set',
+    showUuid: 'show',
+    trackPosition: 1,
+    title: 'Track',
+    slug: 'track',
+    mp3Url: 'https://example.com/track.mp3',
+    isFavorite: true,
+    ...relationships,
+  });
+}
+
+function createOfflineInfo(realm: Realm) {
+  return realm.create(SourceTrackOfflineInfo, {
+    sourceTrackUuid: 'track',
+    status: 4,
+    type: 1,
+    queuedAt: now,
+  });
+}
+
+function createSong(realm: Realm, show: Show) {
+  return realm.create(Song, {
+    uuid: 'song',
+    createdAt: now,
+    updatedAt: now,
+    artistUuid: 'artist',
+    name: 'Song',
+    slug: 'song',
+    upstreamIdentifier: 'song',
+    sortName: 'Song',
+    showsPlayedAt: 1,
+    shows: [show],
+  });
+}
+
+function createHistory(
+  realm: Realm,
+  track: SourceTrack,
+  artist: Artist,
+  show: Show,
+  source: Source
+) {
+  return realm.create(PlaybackHistoryEntry, {
+    uuid: 'history',
+    playbackFlags: 0,
+    createdAt: now,
+    playbackStartedAt: now,
+    sourceTrack: track,
+    artist,
+    show,
+    source,
+  });
+}
+
+function createPlayerState(realm: Realm) {
+  return realm.create(PlayerState, {
+    id: PLAYER_STATE_SENTINEL,
+    queueShuffleState: 0,
+    queueRepeatState: 0,
+    queueSourceTrackUuids: ['track'],
+    queueSourceTrackShuffledUuids: ['track'],
+    activeSourceTrackIndex: 0,
+    activeSourceTrackShuffledIndex: 0,
+    lastUpdatedAt: now,
+  });
+}
+
+describe('catalog startup repair', () => {
+  let realm: Realm;
+
+  beforeEach(() => {
+    if (Realm.exists(config)) Realm.deleteFile(config);
+    realm = new Realm(config);
+  });
+
+  afterEach(() => {
+    realm.close();
+    if (Realm.exists(config)) Realm.deleteFile(config);
+  });
+
+  afterAll(() => {
+    Realm.shutdown();
+  });
+
+  it('repairs known catalog links from scalar UUIDs', () => {
+    let show!: Show;
+    let source!: Source;
+    let track!: SourceTrack;
+
+    realm.write(() => {
+      createArtist(realm);
+      createYear(realm);
+      show = createShow(realm);
+      source = createSource(realm);
+      track = createSourceTrack(realm);
+    });
+
+    expect(repairCatalogAtStartup(realm)).toEqual({
+      repairedLinks: 6,
+      tombstonedRows: 0,
+      deletedLeafRows: 0,
+      removedQueueEntries: 0,
+    });
+    expect(show.artist.uuid).toBe('artist');
+    expect(source.artist.uuid).toBe('artist');
+    expect(track.artist.uuid).toBe('artist');
+    expect(track.year.uuid).toBe('year');
+    expect(track.show.uuid).toBe('show');
+    expect(track.source.uuid).toBe('source');
+    expect(repairCatalogAtStartup(realm)).toEqual({
+      repairedLinks: 0,
+      tombstonedRows: 0,
+      deletedLeafRows: 0,
+      removedQueueEntries: 0,
+    });
+  });
+
+  it('quarantines irreparable catalog rows and deletes their leaf entry points', () => {
+    let artist!: Artist;
+    let show!: Show;
+    let source!: Source;
+    let sourceSet!: SourceSet;
+    let track!: SourceTrack;
+    let song!: Song;
+
+    realm.write(() => {
+      artist = createArtist(realm);
+      const year = createYear(realm);
+      show = createShow(realm, artist);
+      source = createSource(realm, artist);
+      sourceSet = createSourceSet(realm);
+      const offlineInfo = createOfflineInfo(realm);
+      track = createSourceTrack(realm, { artist, year, show, source, offlineInfo });
+      source.sourceSets.push(sourceSet);
+      sourceSet.sourceTracks.push(track);
+      song = createSong(realm, show);
+      createHistory(realm, track, artist, show, source);
+      createPlayerState(realm);
+
+      // Simulate an older build physically deleting a catalog target.
+      realm.delete(artist);
+    });
+
+    expect(repairCatalogAtStartup(realm)).toEqual({
+      repairedLinks: 0,
+      tombstonedRows: 3,
+      deletedLeafRows: 2,
+      removedQueueEntries: 1,
+    });
+    expect(show.deletedAt).toBeInstanceOf(Date);
+    expect(source.deletedAt).toBeInstanceOf(Date);
+    expect(track.deletedAt).toBeInstanceOf(Date);
+    expect(show.isFavorite).toBe(false);
+    expect(source.isFavorite).toBe(false);
+    expect(track.isFavorite).toBe(false);
+    expect(sourceSet.sourceTracks).toHaveLength(0);
+    expect(song.shows).toHaveLength(0);
+    expect(realm.objects(PlaybackHistoryEntry)).toHaveLength(0);
+    expect(realm.objects(SourceTrackOfflineInfo)).toHaveLength(0);
+
+    const playerState = PlayerState.defaultObject(realm)!;
+    expect(playerState.queueSourceTrackUuids).toHaveLength(0);
+    expect(playerState.queueSourceTrackShuffledUuids).toHaveLength(0);
+    expect(playerState.activeSourceTrackIndex).toBeNull();
+    expect(playerState.activeSourceTrackShuffledIndex).toBeNull();
+    expect(repairCatalogAtStartup(realm)).toEqual({
+      repairedLinks: 0,
+      tombstonedRows: 0,
+      deletedLeafRows: 0,
+      removedQueueEntries: 0,
+    });
+  });
+});

--- a/relisten/realm/catalog_startup_repair.test.ts
+++ b/relisten/realm/catalog_startup_repair.test.ts
@@ -3,7 +3,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 
 vi.mock('@/relisten/util/logging', () => ({
   log: {
-    extend: () => ({ info: vi.fn() }),
+    extend: () => ({ info: vi.fn(), warn: vi.fn() }),
   },
 }));
 
@@ -14,11 +14,22 @@ vi.mock('expo-file-system', () => ({
   },
 }));
 
+const logStatsigEvent = vi.hoisted(() => vi.fn());
+
 vi.mock('@/relisten/events', () => ({
-  sharedStatsigClient: vi.fn(),
+  catalogStartupRepairEvent: (
+    summary: Record<string, number>,
+    durationMs: number,
+    repairVersion: number
+  ) => ({ eventName: 'catalog_startup_repair', summary, durationMs, repairVersion }),
+  sharedStatsigClient: () => ({ logEvent: logStatsigEvent }),
 }));
 
-import { repairCatalogAtStartup } from '@/relisten/realm/catalog_startup_repair';
+import {
+  CATALOG_STARTUP_REPAIR_VERSION,
+  CatalogStartupRepairState,
+  repairCatalogAtStartup,
+} from '@/relisten/realm/catalog_startup_repair';
 import { Artist } from '@/relisten/realm/models/artist';
 import { Year } from '@/relisten/realm/models/year';
 import { Show } from '@/relisten/realm/models/show';
@@ -60,6 +71,7 @@ const config: Realm.Configuration = {
     Popularity,
     PopularityWindow,
     PopularityWindows,
+    CatalogStartupRepairState,
   ],
 };
 
@@ -236,6 +248,7 @@ describe('catalog startup repair', () => {
   let realm: Realm;
 
   beforeEach(() => {
+    logStatsigEvent.mockClear();
     if (Realm.exists(config)) Realm.deleteFile(config);
     realm = new Realm(config);
   });
@@ -274,12 +287,21 @@ describe('catalog startup repair', () => {
     expect(track.year.uuid).toBe('year');
     expect(track.show.uuid).toBe('show');
     expect(track.source.uuid).toBe('source');
+    expect(
+      realm.objectForPrimaryKey(CatalogStartupRepairState, CATALOG_STARTUP_REPAIR_VERSION)
+    ).not.toBeNull();
+    expect(logStatsigEvent).toHaveBeenCalledTimes(1);
+
+    realm.close();
+    realm = new Realm(config);
+
     expect(repairCatalogAtStartup(realm)).toEqual({
       repairedLinks: 0,
       tombstonedRows: 0,
       deletedLeafRows: 0,
       removedQueueEntries: 0,
     });
+    expect(logStatsigEvent).toHaveBeenCalledTimes(1);
   });
 
   it('quarantines irreparable catalog rows and deletes their leaf entry points', () => {
@@ -308,11 +330,18 @@ describe('catalog startup repair', () => {
       realm.delete(artist);
     });
 
-    expect(repairCatalogAtStartup(realm)).toEqual({
+    const summary = repairCatalogAtStartup(realm);
+    expect(summary).toEqual({
       repairedLinks: 0,
       tombstonedRows: 3,
       deletedLeafRows: 2,
       removedQueueEntries: 1,
+    });
+    expect(logStatsigEvent).toHaveBeenCalledWith({
+      eventName: 'catalog_startup_repair',
+      summary,
+      durationMs: expect.any(Number),
+      repairVersion: CATALOG_STARTUP_REPAIR_VERSION,
     });
     expect(show.deletedAt).toBeInstanceOf(Date);
     expect(source.deletedAt).toBeInstanceOf(Date);
@@ -381,5 +410,35 @@ describe('catalog startup repair', () => {
     });
     expect(Array.from(sourceSet.sourceTracks, (track) => track.uuid)).toEqual(['track']);
     expect(Array.from(song.shows, (show) => show.uuid)).toEqual(['show']);
+  });
+
+  it('marks a clean Realm complete without emitting repair telemetry', () => {
+    expect(repairCatalogAtStartup(realm)).toEqual({
+      repairedLinks: 0,
+      tombstonedRows: 0,
+      deletedLeafRows: 0,
+      removedQueueEntries: 0,
+    });
+    expect(
+      realm.objectForPrimaryKey(CatalogStartupRepairState, CATALOG_STARTUP_REPAIR_VERSION)
+    ).not.toBeNull();
+    expect(logStatsigEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not fail startup when repair telemetry throws', () => {
+    realm.write(() => {
+      createArtist(realm);
+      createYear(realm);
+      createShow(realm);
+    });
+    logStatsigEvent.mockImplementationOnce(() => {
+      throw new Error('Statsig unavailable');
+    });
+
+    expect(() => repairCatalogAtStartup(realm)).not.toThrow();
+    expect(
+      realm.objectForPrimaryKey(CatalogStartupRepairState, CATALOG_STARTUP_REPAIR_VERSION)
+    ).not.toBeNull();
+    expect(realm.objectForPrimaryKey(Show, 'show')?.artist.uuid).toBe('artist');
   });
 });

--- a/relisten/realm/catalog_startup_repair.ts
+++ b/relisten/realm/catalog_startup_repair.ts
@@ -10,6 +10,7 @@ import { SourceTrack } from '@/relisten/realm/models/source_track';
 import { SourceTrackOfflineInfo } from '@/relisten/realm/models/source_track_offline_info';
 import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
 import { PlayerState } from '@/relisten/realm/models/player_state';
+import { catalogStartupRepairEvent, sharedStatsigClient } from '@/relisten/events';
 
 const logger = log.extend('catalog-startup-repair');
 
@@ -18,6 +19,22 @@ export interface CatalogRepairSummary {
   tombstonedRows: number;
   deletedLeafRows: number;
   removedQueueEntries: number;
+}
+
+export const CATALOG_STARTUP_REPAIR_VERSION = 1;
+
+export class CatalogStartupRepairState extends Realm.Object<CatalogStartupRepairState> {
+  static schema: Realm.ObjectSchema = {
+    name: 'CatalogStartupRepairState',
+    primaryKey: 'version',
+    properties: {
+      version: 'int',
+      completedAt: 'date',
+    },
+  };
+
+  version!: number;
+  completedAt!: Date;
 }
 
 type RepairableFavorite = Show | Source | SourceTrack;
@@ -84,6 +101,11 @@ export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
     deletedLeafRows: 0,
     removedQueueEntries: 0,
   };
+  if (realm.objectForPrimaryKey(CatalogStartupRepairState, CATALOG_STARTUP_REPAIR_VERSION)) {
+    return summary;
+  }
+
+  const startedAt = Date.now();
   const repairDate = new Date();
 
   realm.write(() => {
@@ -244,8 +266,28 @@ export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
         summary.removedQueueEntries += removedTrackUuids.size;
       }
     }
+
+    // The version row is the completion flag. Keeping it in this transaction ensures a failed
+    // repair is retried on the next launch instead of being mistaken for a successful run.
+    realm.create(CatalogStartupRepairState, {
+      version: CATALOG_STARTUP_REPAIR_VERSION,
+      completedAt: repairDate,
+    });
   });
 
-  logger.info('Catalog startup repair complete', summary);
+  const durationMs = Date.now() - startedAt;
+
+  if (Object.values(summary).some((count) => count > 0)) {
+    try {
+      sharedStatsigClient().logEvent(
+        catalogStartupRepairEvent(summary, durationMs, CATALOG_STARTUP_REPAIR_VERSION)
+      );
+    } catch (error) {
+      // Repair has already committed. Best-effort telemetry must never block app startup.
+      logger.warn('Unable to log catalog startup repair', error);
+    }
+  }
+
+  logger.info('Catalog startup repair complete', { ...summary, durationMs });
   return summary;
 }

--- a/relisten/realm/catalog_startup_repair.ts
+++ b/relisten/realm/catalog_startup_repair.ts
@@ -31,23 +31,43 @@ function tombstoneIrreparableRow(row: RepairableFavorite, deletedAt: Date) {
   return newlyTombstoned;
 }
 
-function removeTrackFromCurrentMembership(realm: Realm, track: SourceTrack) {
-  const sourceSets = realm.objects(SourceSet).filtered('ANY sourceTracks.uuid == $0', track.uuid);
+function removeIrreparableTracksFromSourceSets(realm: Realm, trackUuids: ReadonlySet<string>) {
+  if (trackUuids.size === 0) {
+    return;
+  }
 
-  for (const sourceSet of sourceSets) {
+  const matchingSourceSets = realm
+    .objects(SourceSet)
+    .filtered('ANY sourceTracks.uuid IN $0', [...trackUuids])
+    .snapshot();
+
+  // One native query finds every affected parent. Mutate each matching List backwards so Realm
+  // never has to reinsert its healthy members.
+  for (const sourceSet of matchingSourceSets) {
     for (let index = sourceSet.sourceTracks.length - 1; index >= 0; index -= 1) {
-      if (sourceSet.sourceTracks[index].uuid === track.uuid) {
-        sourceSet.sourceTracks.splice(index, 1);
+      if (trackUuids.has(sourceSet.sourceTracks[index].uuid)) {
+        sourceSet.sourceTracks.remove(index);
       }
     }
   }
 }
 
-function removeShowFromSongMembership(realm: Realm, show: Show) {
-  const songs = realm.objects(Song).filtered('ANY shows.uuid == $0', show.uuid);
+function removeIrreparableShowsFromSongs(realm: Realm, showUuids: ReadonlySet<string>) {
+  if (showUuids.size === 0) {
+    return;
+  }
 
-  for (const song of songs) {
-    song.shows.delete(show);
+  const showUuidList = [...showUuids];
+  const matchingSongs = realm
+    .objects(Song)
+    .filtered('ANY shows.uuid IN $0', showUuidList)
+    .snapshot();
+
+  for (const song of matchingSongs) {
+    const showsToRemove = song.shows.filtered('uuid IN $0', showUuidList).snapshot();
+    for (const show of showsToRemove) {
+      song.shows.delete(show);
+    }
   }
 }
 
@@ -72,8 +92,11 @@ export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
     const irreparableTrackUuids = new Set<string>();
     const offlineInfoUuidsToDelete = new Set<string>();
 
-    // Snapshot each broken-row query because the repair removes rows from the live result set.
-    for (const show of Array.from(realm.objects(Show).filtered('artist == nil'))) {
+    // Tombstones are permanent, so startup repair only processes active legacy damage once.
+    // Snapshot each query because repaired rows leave its live result set.
+    for (const show of Array.from(
+      realm.objects(Show).filtered('deletedAt == nil AND artist == nil')
+    )) {
       const artist = realm.objectForPrimaryKey(Artist, show.artistUuid);
       if (artist) {
         show.artist = artist;
@@ -83,11 +106,12 @@ export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
           summary.tombstonedRows += 1;
         }
         irreparableShowUuids.add(show.uuid);
-        removeShowFromSongMembership(realm, show);
       }
     }
 
-    for (const source of Array.from(realm.objects(Source).filtered('artist == nil'))) {
+    for (const source of Array.from(
+      realm.objects(Source).filtered('deletedAt == nil AND artist == nil')
+    )) {
       const artist = realm.objectForPrimaryKey(Artist, source.artistUuid);
       if (artist) {
         source.artist = artist;
@@ -103,7 +127,9 @@ export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
     const sourceTracksWithMissingLinks = Array.from(
       realm
         .objects(SourceTrack)
-        .filtered('artist == nil OR year == nil OR show == nil OR source == nil')
+        .filtered(
+          'deletedAt == nil AND (artist == nil OR year == nil OR show == nil OR source == nil)'
+        )
     );
 
     for (const track of sourceTracksWithMissingLinks) {
@@ -120,7 +146,6 @@ export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
         if (track.offlineInfo) {
           offlineInfoUuidsToDelete.add(track.offlineInfo.sourceTrackUuid);
         }
-        removeTrackFromCurrentMembership(realm, track);
         continue;
       }
 
@@ -141,6 +166,9 @@ export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
         summary.repairedLinks += 1;
       }
     }
+
+    removeIrreparableShowsFromSongs(realm, irreparableShowUuids);
+    removeIrreparableTracksFromSourceSets(realm, irreparableTrackUuids);
 
     const malformedHistory = realm
       .objects(PlaybackHistoryEntry)

--- a/relisten/realm/catalog_startup_repair.ts
+++ b/relisten/realm/catalog_startup_repair.ts
@@ -1,0 +1,223 @@
+import Realm from 'realm';
+import { log } from '@/relisten/util/logging';
+import { Artist } from '@/relisten/realm/models/artist';
+import { Year } from '@/relisten/realm/models/year';
+import { Show } from '@/relisten/realm/models/show';
+import { Song } from '@/relisten/realm/models/song';
+import { Source } from '@/relisten/realm/models/source';
+import { SourceSet } from '@/relisten/realm/models/source_set';
+import { SourceTrack } from '@/relisten/realm/models/source_track';
+import { SourceTrackOfflineInfo } from '@/relisten/realm/models/source_track_offline_info';
+import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
+import { PlayerState } from '@/relisten/realm/models/player_state';
+
+const logger = log.extend('catalog-startup-repair');
+
+export interface CatalogRepairSummary {
+  repairedLinks: number;
+  tombstonedRows: number;
+  deletedLeafRows: number;
+  removedQueueEntries: number;
+}
+
+type RepairableFavorite = Show | Source | SourceTrack;
+
+function tombstoneIrreparableRow(row: RepairableFavorite, deletedAt: Date) {
+  const newlyTombstoned = row.deletedAt == null;
+
+  row.deletedAt ??= deletedAt;
+  row.isFavorite = false;
+
+  return newlyTombstoned;
+}
+
+function removeTrackFromCurrentMembership(realm: Realm, track: SourceTrack) {
+  const sourceSets = realm.objects(SourceSet).filtered('ANY sourceTracks.uuid == $0', track.uuid);
+
+  for (const sourceSet of sourceSets) {
+    for (let index = sourceSet.sourceTracks.length - 1; index >= 0; index -= 1) {
+      if (sourceSet.sourceTracks[index].uuid === track.uuid) {
+        sourceSet.sourceTracks.splice(index, 1);
+      }
+    }
+  }
+}
+
+function removeShowFromSongMembership(realm: Realm, show: Show) {
+  const songs = realm.objects(Song).filtered('ANY shows.uuid == $0', show.uuid);
+
+  for (const song of songs) {
+    song.shows.delete(show);
+  }
+}
+
+/**
+ * Repairs damage left by older builds that physically deleted linked catalog rows.
+ *
+ * This is deliberately an explicit list of the links the app treats as required. Keep it close
+ * to the Realm schemas: adding a generic graph walker would make startup behavior harder to audit.
+ */
+export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
+  const summary: CatalogRepairSummary = {
+    repairedLinks: 0,
+    tombstonedRows: 0,
+    deletedLeafRows: 0,
+    removedQueueEntries: 0,
+  };
+  const repairDate = new Date();
+
+  realm.write(() => {
+    const irreparableShowUuids = new Set<string>();
+    const irreparableSourceUuids = new Set<string>();
+    const irreparableTrackUuids = new Set<string>();
+    const offlineInfoUuidsToDelete = new Set<string>();
+
+    // Snapshot each broken-row query because the repair removes rows from the live result set.
+    for (const show of Array.from(realm.objects(Show).filtered('artist == nil'))) {
+      const artist = realm.objectForPrimaryKey(Artist, show.artistUuid);
+      if (artist) {
+        show.artist = artist;
+        summary.repairedLinks += 1;
+      } else {
+        if (tombstoneIrreparableRow(show, repairDate)) {
+          summary.tombstonedRows += 1;
+        }
+        irreparableShowUuids.add(show.uuid);
+        removeShowFromSongMembership(realm, show);
+      }
+    }
+
+    for (const source of Array.from(realm.objects(Source).filtered('artist == nil'))) {
+      const artist = realm.objectForPrimaryKey(Artist, source.artistUuid);
+      if (artist) {
+        source.artist = artist;
+        summary.repairedLinks += 1;
+      } else {
+        if (tombstoneIrreparableRow(source, repairDate)) {
+          summary.tombstonedRows += 1;
+        }
+        irreparableSourceUuids.add(source.uuid);
+      }
+    }
+
+    const sourceTracksWithMissingLinks = Array.from(
+      realm
+        .objects(SourceTrack)
+        .filtered('artist == nil OR year == nil OR show == nil OR source == nil')
+    );
+
+    for (const track of sourceTracksWithMissingLinks) {
+      const artist = track.artist ?? realm.objectForPrimaryKey(Artist, track.artistUuid);
+      const show = track.show ?? realm.objectForPrimaryKey(Show, track.showUuid);
+      const source = track.source ?? realm.objectForPrimaryKey(Source, track.sourceUuid);
+      const year = track.year ?? (show && realm.objectForPrimaryKey(Year, show.yearUuid));
+
+      if (!artist || !show || !source || !year) {
+        if (tombstoneIrreparableRow(track, repairDate)) {
+          summary.tombstonedRows += 1;
+        }
+        irreparableTrackUuids.add(track.uuid);
+        if (track.offlineInfo) {
+          offlineInfoUuidsToDelete.add(track.offlineInfo.sourceTrackUuid);
+        }
+        removeTrackFromCurrentMembership(realm, track);
+        continue;
+      }
+
+      if (!track.artist) {
+        track.artist = artist;
+        summary.repairedLinks += 1;
+      }
+      if (!track.show) {
+        track.show = show;
+        summary.repairedLinks += 1;
+      }
+      if (!track.source) {
+        track.source = source;
+        summary.repairedLinks += 1;
+      }
+      if (!track.year) {
+        track.year = year;
+        summary.repairedLinks += 1;
+      }
+    }
+
+    const malformedHistory = realm
+      .objects(PlaybackHistoryEntry)
+      .filtered('sourceTrack == nil OR artist == nil OR show == nil OR source == nil');
+    const historyUuidsToDelete = new Set(Array.from(malformedHistory, (entry) => entry.uuid));
+
+    if (irreparableShowUuids.size > 0) {
+      for (const entry of realm
+        .objects(PlaybackHistoryEntry)
+        .filtered('show.uuid IN $0', [...irreparableShowUuids])) {
+        historyUuidsToDelete.add(entry.uuid);
+      }
+    }
+    if (irreparableSourceUuids.size > 0) {
+      for (const entry of realm
+        .objects(PlaybackHistoryEntry)
+        .filtered('source.uuid IN $0', [...irreparableSourceUuids])) {
+        historyUuidsToDelete.add(entry.uuid);
+      }
+    }
+    if (irreparableTrackUuids.size > 0) {
+      for (const entry of realm
+        .objects(PlaybackHistoryEntry)
+        .filtered('sourceTrack.uuid IN $0', [...irreparableTrackUuids])) {
+        historyUuidsToDelete.add(entry.uuid);
+      }
+    }
+
+    if (historyUuidsToDelete.size > 0) {
+      const historyToDelete = realm
+        .objects(PlaybackHistoryEntry)
+        .filtered('uuid IN $0', [...historyUuidsToDelete]);
+      summary.deletedLeafRows += historyToDelete.length;
+      realm.delete(historyToDelete);
+    }
+
+    for (const offlineInfo of realm
+      .objects(SourceTrackOfflineInfo)
+      .filtered('sourceTracks.@count == 0')) {
+      offlineInfoUuidsToDelete.add(offlineInfo.sourceTrackUuid);
+    }
+
+    if (offlineInfoUuidsToDelete.size > 0) {
+      const offlineInfoToDelete = realm
+        .objects(SourceTrackOfflineInfo)
+        .filtered('sourceTrackUuid IN $0', [...offlineInfoUuidsToDelete]);
+      summary.deletedLeafRows += offlineInfoToDelete.length;
+      realm.delete(offlineInfoToDelete);
+    }
+
+    if (irreparableTrackUuids.size > 0) {
+      for (const playerState of realm.objects(PlayerState)) {
+        const removedTrackUuids = new Set(
+          [
+            ...playerState.queueSourceTrackUuids,
+            ...playerState.queueSourceTrackShuffledUuids,
+          ].filter((uuid) => irreparableTrackUuids.has(uuid))
+        );
+
+        if (removedTrackUuids.size === 0) {
+          continue;
+        }
+
+        playerState.queueSourceTrackUuids = playerState.queueSourceTrackUuids.filter(
+          (uuid) => !irreparableTrackUuids.has(uuid)
+        );
+        playerState.queueSourceTrackShuffledUuids =
+          playerState.queueSourceTrackShuffledUuids.filter(
+            (uuid) => !irreparableTrackUuids.has(uuid)
+          );
+        playerState.activeSourceTrackIndex = undefined;
+        playerState.activeSourceTrackShuffledIndex = undefined;
+        summary.removedQueueEntries += removedTrackUuids.size;
+      }
+    }
+  });
+
+  logger.info('Catalog startup repair complete', summary);
+  return summary;
+}

--- a/relisten/realm/models/artist.ts
+++ b/relisten/realm/models/artist.ts
@@ -38,6 +38,7 @@ export class Artist
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
       musicbrainzId: 'string',
       name: 'string',
       featured: 'int',
@@ -60,6 +61,7 @@ export class Artist
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  deletedAt?: Date;
   musicbrainzId!: string;
   name!: string;
   featured!: number;

--- a/relisten/realm/models/artist_repo.ts
+++ b/relisten/realm/models/artist_repo.ts
@@ -23,10 +23,6 @@ import { attachArtistsToExistingShows } from '@/relisten/realm/models/show_artis
 
 export const artistRepo = new Repository(Artist);
 
-function artistHasUserInteraction(artist: Artist): boolean {
-  return artist.isFavorite || artist.hasOfflineTracks();
-}
-
 class ArtistsNetworkBackedBehavior extends NetworkBackedModelArrayBehavior<
   Artist,
   ArtistWithCounts,
@@ -35,14 +31,7 @@ class ArtistsNetworkBackedBehavior extends NetworkBackedModelArrayBehavior<
 > {
   override upsert(localData: Realm.Results<Artist>, apiData: ArtistWithCounts[]): void {
     this.realm.write(() => {
-      const { allModels } = artistRepo.upsertMultiple(
-        this.realm,
-        apiData,
-        localData,
-        true,
-        true,
-        artistHasUserInteraction
-      );
+      const { allModels } = artistRepo.upsertMultiple(this.realm, apiData, localData, true, true);
 
       attachArtistsToExistingShows(this.realm, allModels);
     });

--- a/relisten/realm/models/artist_repo.ts
+++ b/relisten/realm/models/artist_repo.ts
@@ -12,7 +12,7 @@ import { useQuery, useRealm } from '../schema';
 import { Artist, ArtistFeaturedFlags, ArtistRequiredProperties } from './artist';
 import { ArtistWithCounts } from '@/relisten/api/models/artist';
 
-import { useIsOfflineTab } from '@/relisten/util/routes';
+import { useGroupSegment, useIsOfflineTab } from '@/relisten/util/routes';
 import { filterForUser, useRealmTabsFilter } from '../realm_filters';
 import { Show } from './show';
 import { Source } from './source';
@@ -47,13 +47,19 @@ export function artistsNetworkBackedBehavior(
   realm: Realm.Realm,
   availableOfflineOnly: boolean,
   includeAutomaticallyCreated: boolean,
+  includeDeleted: boolean,
   options?: NetworkBackedBehaviorOptions
 ) {
   return new ArtistsNetworkBackedBehavior(
     realm,
     artistRepo,
     (realm) => {
-      let q = filterForUser(realm.objects<Artist>(Artist), {
+      let catalogArtists = realm.objects<Artist>(Artist);
+      if (!includeDeleted) {
+        catalogArtists = catalogArtists.filtered('deletedAt == nil');
+      }
+
+      let q = filterForUser(catalogArtists, {
         isFavorite: null,
         isPlayableOffline: availableOfflineOnly ? availableOfflineOnly : null,
       });
@@ -73,10 +79,11 @@ export function artistsNetworkBackedBehavior(
 export function useArtists(options?: NetworkBackedBehaviorOptions) {
   const realm = useRealm();
   const isOfflineTab = useIsOfflineTab();
+  const includeDeleted = useGroupSegment() !== '(artists)';
 
   const behavior = useMemo(() => {
-    return artistsNetworkBackedBehavior(realm, isOfflineTab, false, options);
-  }, [realm, options, isOfflineTab]);
+    return artistsNetworkBackedBehavior(realm, isOfflineTab, false, includeDeleted, options);
+  }, [realm, options, isOfflineTab, includeDeleted]);
 
   return useNetworkBackedBehavior(behavior);
 }
@@ -85,7 +92,7 @@ export function useAllArtists(options?: NetworkBackedBehaviorOptions) {
   const realm = useRealm();
 
   const behavior = useMemo(() => {
-    return artistsNetworkBackedBehavior(realm, false, true, options);
+    return artistsNetworkBackedBehavior(realm, false, true, false, options);
   }, [realm, options]);
 
   return useNetworkBackedBehavior(behavior);
@@ -215,14 +222,20 @@ export function useArtist(
     };
   }, [options]);
   const realm = useRealm();
+  const includeDeleted = useGroupSegment() !== '(artists)';
   const behavior = useMemo(() => {
     return new ArtistBootstrapNetworkBackedBehavior(
       realm,
       (currentRealm) =>
-        currentRealm.objects(Artist).filtered('uuid == $0', artistUuid ?? '__missing__'),
+        currentRealm
+          .objects(Artist)
+          .filtered(
+            includeDeleted ? 'uuid == $0' : 'uuid == $0 && deletedAt == nil',
+            artistUuid ?? '__missing__'
+          ),
       memoOptions
     );
-  }, [artistUuid, memoOptions, realm]);
+  }, [artistUuid, includeDeleted, memoOptions, realm]);
 
   return useNetworkBackedBehavior(behavior);
 }
@@ -238,14 +251,20 @@ export function useArtistBySlug(
     };
   }, [options]);
   const realm = useRealm();
+  const includeDeleted = useGroupSegment() !== '(artists)';
   const behavior = useMemo(() => {
     return new ArtistBootstrapNetworkBackedBehavior(
       realm,
       (currentRealm) =>
-        currentRealm.objects(Artist).filtered('slug == $0', artistSlug ?? '__missing__'),
+        currentRealm
+          .objects(Artist)
+          .filtered(
+            includeDeleted ? 'slug == $0' : 'slug == $0 && deletedAt == nil',
+            artistSlug ?? '__missing__'
+          ),
       memoOptions
     );
-  }, [artistSlug, memoOptions, realm]);
+  }, [artistSlug, includeDeleted, memoOptions, realm]);
 
   return useNetworkBackedBehavior(behavior);
 }

--- a/relisten/realm/models/history/playback_history_entry_repo.ts
+++ b/relisten/realm/models/history/playback_history_entry_repo.ts
@@ -177,16 +177,16 @@ export function useTopPlayedArtistUuidsOnce(
         return;
       }
 
-      const entryUuids = Array.from(
-        realm.objects(PlaybackHistoryEntry).sorted('playbackStartedAt', /* reverse= */ true),
-        (entry) => entry.uuid
-      );
+      const entries = realm
+        .objects(PlaybackHistoryEntry)
+        .sorted('playbackStartedAt', /* reverse= */ true)
+        .snapshot();
       const cutoffTime = Date.now() - EARLY_EXIT_DAYS_MS;
       const counts = new Map<string, number>();
       const sortNames = new Map<string, string>();
       let index = 0;
       let uniqueArtists = 0;
-      const total = entryUuids.length;
+      const total = entries.length;
 
       const finish = () => {
         const computed = rankTopPlayedArtistUuids(counts, sortNames, limit);
@@ -205,7 +205,8 @@ export function useTopPlayedArtistUuidsOnce(
         let shouldStop = false;
 
         while (index < end) {
-          const entry = realm.objectForPrimaryKey(PlaybackHistoryEntry, entryUuids[index]);
+          // Snapshot membership is stable, but clearing history turns deleted slots into null.
+          const entry = entries[index] as PlaybackHistoryEntry | null;
           if (!entry) {
             index += 1;
             continue;

--- a/relisten/realm/models/history/playback_history_entry_repo.ts
+++ b/relisten/realm/models/history/playback_history_entry_repo.ts
@@ -177,15 +177,16 @@ export function useTopPlayedArtistUuidsOnce(
         return;
       }
 
-      const entries = realm
-        .objects(PlaybackHistoryEntry)
-        .sorted('playbackStartedAt', /* reverse= */ true);
+      const entryUuids = Array.from(
+        realm.objects(PlaybackHistoryEntry).sorted('playbackStartedAt', /* reverse= */ true),
+        (entry) => entry.uuid
+      );
       const cutoffTime = Date.now() - EARLY_EXIT_DAYS_MS;
       const counts = new Map<string, number>();
       const sortNames = new Map<string, string>();
       let index = 0;
       let uniqueArtists = 0;
-      const total = entries.length;
+      const total = entryUuids.length;
 
       const finish = () => {
         const computed = rankTopPlayedArtistUuids(counts, sortNames, limit);
@@ -204,7 +205,11 @@ export function useTopPlayedArtistUuidsOnce(
         let shouldStop = false;
 
         while (index < end) {
-          const entry = entries[index];
+          const entry = realm.objectForPrimaryKey(PlaybackHistoryEntry, entryUuids[index]);
+          if (!entry) {
+            index += 1;
+            continue;
+          }
           const artist = entry.artist;
           const uuid = artist?.uuid;
 

--- a/relisten/realm/models/show.ts
+++ b/relisten/realm/models/show.ts
@@ -45,6 +45,7 @@ export class Show
       tourUuid: { type: 'string', optional: true, indexed: true },
       createdAt: 'date',
       updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
       date: { type: 'date', indexed: true },
       avgRating: 'float',
       avgDuration: 'float?',
@@ -74,6 +75,7 @@ export class Show
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  deletedAt?: Date;
   artistUuid!: string;
   yearUuid!: string;
   venueUuid?: string;

--- a/relisten/realm/models/show_artist_relationships.ts
+++ b/relisten/realm/models/show_artist_relationships.ts
@@ -8,19 +8,24 @@ function attachShowsToArtists(
   shows: Iterable<Show>,
   artistsByUuid: Record<string, Artist>
 ): number {
-  const showsWithAvailableArtists = Array.from(shows).filter(
-    (show) => !show.artist && artistsByUuid[show.artistUuid]
-  );
+  const showsNeedingArtists = Array.from(shows).filter((show) => !show.artist);
   let attached = 0;
 
-  if (showsWithAvailableArtists.length === 0) {
+  if (showsNeedingArtists.length === 0) {
     return attached;
   }
 
   const writeHandler = () => {
-    for (const show of showsWithAvailableArtists) {
-      show.artist = artistsByUuid[show.artistUuid];
-      attached += 1;
+    for (const show of showsNeedingArtists) {
+      const artist = artistsByUuid[show.artistUuid];
+      if (artist) {
+        show.artist = artist;
+        attached += 1;
+      } else {
+        // Do not publish a positive API row with a required link still missing.
+        show.deletedAt ??= new Date();
+        show.isFavorite = false;
+      }
     }
   };
 
@@ -50,10 +55,15 @@ export function attachShowArtists(realm: Realm, shows: Iterable<Show>): number {
 
 export function attachArtistsToExistingShows(realm: Realm, artists: Iterable<Artist>): number {
   const artistsByUuid = groupByUuid(Array.from(artists));
+  const artistUuids = Object.keys(artistsByUuid);
 
-  if (Object.keys(artistsByUuid).length === 0) {
+  if (artistUuids.length === 0) {
     return 0;
   }
 
-  return attachShowsToArtists(realm, realm.objects(Show).filtered('artist == nil'), artistsByUuid);
+  return attachShowsToArtists(
+    realm,
+    realm.objects(Show).filtered('artist == nil AND artistUuid IN $0', artistUuids),
+    artistsByUuid
+  );
 }

--- a/relisten/realm/models/show_repo.ts
+++ b/relisten/realm/models/show_repo.ts
@@ -13,6 +13,7 @@ import { NetworkBackedBehaviorOptions } from '../network_backed_behavior';
 import { useNetworkBackedBehavior } from '../network_backed_behavior_hooks';
 import { Show } from './show';
 import { Source } from './source';
+import { SourceTrack } from './source_track';
 import { venueRepo } from './venue_repo';
 import { Artist } from './artist';
 import { Year } from './year';
@@ -145,8 +146,6 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
     const apiSourceTracksBySet = R.groupBy(apiSourceTracks, (s) => s.source_set_uuid);
 
     this.realm.write(() => {
-      // TODO: maybe should be inside if statement?
-      // it broke doing that, but worth reivisiting
       const {
         createdModels: [createdShow],
         updatedModels: [updatedShow],
@@ -228,9 +227,7 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
             true
           );
 
-          // Same reconciliation rule for tracks: the payload is authoritative for membership and
-          // order, even when some rows were found by global lookup instead of being newly created.
-          sourceSet.sourceTracks.splice(0, sourceSet.sourceTracks.length, ...sourceTracks);
+          const currentSourceTracks: SourceTrack[] = [];
 
           for (const sourceTrack of sourceTracks) {
             if (artist) sourceTrack.artist = artist;
@@ -243,8 +240,14 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
               // playback graph. A later complete API response can restore the same object.
               sourceTrack.deletedAt ??= new Date();
               sourceTrack.isFavorite = false;
+            } else {
+              currentSourceTracks.push(sourceTrack);
             }
           }
+
+          // Current membership follows the API order, but never exposes an incomplete Track.
+          // The rejected row remains a tombstone and can recover on a later complete response.
+          sourceSet.sourceTracks.splice(0, sourceSet.sourceTracks.length, ...currentSourceTracks);
         }
       }
     });

--- a/relisten/realm/models/show_repo.ts
+++ b/relisten/realm/models/show_repo.ts
@@ -152,8 +152,8 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
         updatedModels: [updatedShow],
       } = showRepo.upsert(this.realm, apiData, localData.show, true);
 
-      if (createdShow) {
-        createdShow.artist = artist!;
+      if (createdShow && artist) {
+        createdShow.artist = artist;
       }
 
       if (!localData.show) {
@@ -199,7 +199,12 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
       );
 
       for (const source of sourceModels) {
-        source.artist = artist!;
+        if (artist) {
+          source.artist = artist;
+        } else {
+          source.deletedAt ??= new Date();
+          source.isFavorite = false;
+        }
 
         const { allModels: sourceSets } = sourceSetRepo.upsertMultiple(
           this.realm,
@@ -227,12 +232,19 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
           // order, even when some rows were found by global lookup instead of being newly created.
           sourceSet.sourceTracks.splice(0, sourceSet.sourceTracks.length, ...sourceTracks);
 
-          sourceTracks.forEach((st) => {
-            st.artist = artist!;
-            st.year = year!;
-            st.show = localData.show!;
-            st.source = source;
-          });
+          for (const sourceTrack of sourceTracks) {
+            if (artist) sourceTrack.artist = artist;
+            if (year) sourceTrack.year = year;
+            if (localData.show) sourceTrack.show = localData.show;
+            sourceTrack.source = source;
+
+            if (!artist || !year || !localData.show) {
+              // The row stays valid in Realm, but active queries must not expose an incomplete
+              // playback graph. A later complete API response can restore the same object.
+              sourceTrack.deletedAt ??= new Date();
+              sourceTrack.isFavorite = false;
+            }
+          }
         }
       }
     });

--- a/relisten/realm/models/show_repo.ts
+++ b/relisten/realm/models/show_repo.ts
@@ -27,6 +27,7 @@ import { ThrottledNetworkBackedBehavior } from '@/relisten/realm/throttled_netwo
 import { LibraryIndex } from '@/relisten/realm/library_index';
 import { useOfflineAvailabilityIndex } from '@/relisten/realm/root_services';
 import { attachShowArtists } from '@/relisten/realm/models/show_artist_relationships';
+import { useGroupSegment } from '@/relisten/util/routes';
 
 export const showRepo = new Repository(Show);
 
@@ -86,6 +87,7 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
     realm: Realm.Realm,
     public showUuid?: string,
     public sourceUuid?: string,
+    private includeDeleted = false,
     options?: NetworkBackedBehaviorOptions
   ) {
     super(realm, options);
@@ -106,7 +108,7 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
     if (this.sourceUuid !== undefined && this.showUuid === undefined) {
       const source = this.realm.objectForPrimaryKey(Source, this.sourceUuid);
 
-      if (source) {
+      if (source && (this.includeDeleted || source.deletedAt == null)) {
         this.showUuid = source.showUuid;
       }
     }
@@ -114,18 +116,24 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
     const showUuid = this.showUuid || '__no_show_sentinel__';
 
     const showResults = new RealmObjectValueStream(this.realm, Show, showUuid);
+    const sourcePredicate = this.includeDeleted
+      ? 'showUuid == $0'
+      : 'showUuid == $0 && deletedAt == nil';
     const sourcesResults = new RealmQueryValueStream<Source>(
       this.realm,
-      this.realm.objects(Source).filtered('showUuid == $0', showUuid)
+      this.realm.objects(Source).filtered(sourcePredicate, showUuid)
     );
 
     return new CombinedValueStream(showResults, sourcesResults, (show, sources) => {
-      return { show: show || undefined, sources } as ShowWithSources;
+      return {
+        show: show && (this.includeDeleted || show.deletedAt == null) ? show : undefined,
+        sources,
+      };
     });
   }
 
   isLocalDataShowable(localData: ShowWithSources): boolean {
-    return localData.show !== null && localData.sources.length > 0;
+    return localData.show != null && localData.sources.length > 0;
   }
 
   override upsert(localData: ShowWithSources, apiData: ApiShowWithSources): void {
@@ -142,7 +150,7 @@ export class ShowWithFullSourcesNetworkBackedBehavior extends ThrottledNetworkBa
       const {
         createdModels: [createdShow],
         updatedModels: [updatedShow],
-      } = showRepo.upsert(this.realm, apiData, localData.show);
+      } = showRepo.upsert(this.realm, apiData, localData.show, true);
 
       if (createdShow) {
         createdShow.artist = artist!;
@@ -235,9 +243,10 @@ export function useFullShow(
   showUuid: string | undefined
 ): NetworkBackedResults<ShowWithSources | undefined> {
   const realm = useRealm();
+  const includeDeleted = useGroupSegment() !== '(artists)';
   const behavior = useMemo(() => {
-    return new ShowWithFullSourcesNetworkBackedBehavior(realm, showUuid);
-  }, [realm, showUuid]);
+    return new ShowWithFullSourcesNetworkBackedBehavior(realm, showUuid, undefined, includeDeleted);
+  }, [realm, showUuid, includeDeleted]);
 
   return useNetworkBackedBehavior(behavior);
 }
@@ -282,7 +291,13 @@ export function upsertShowWithSources(
 ): Show | undefined {
   const existingShow = realm.objectForPrimaryKey(Show, apiData.uuid) || undefined;
   const existingSources = realm.objects(Source).filtered('showUuid == $0', apiData.uuid);
-  const behavior = new ShowWithFullSourcesNetworkBackedBehavior(realm, apiData.uuid);
+  // Writer lookups are retained so a positive response can restore the existing primary-key row.
+  const behavior = new ShowWithFullSourcesNetworkBackedBehavior(
+    realm,
+    apiData.uuid,
+    undefined,
+    true
+  );
 
   behavior.upsert({ show: existingShow, sources: existingSources }, apiData);
 

--- a/relisten/realm/models/shows/recent_shows_repo.ts
+++ b/relisten/realm/models/shows/recent_shows_repo.ts
@@ -63,7 +63,10 @@ class RecentShowsNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBehavi
 
     return new RealmQueryValueStream<Show>(
       this.realm,
-      this.realm.objects(Show).filtered('artistUuid == $0', this.artistUuid).sorted(sortKey, true)
+      this.realm
+        .objects(Show)
+        .filtered('artistUuid == $0 && deletedAt == nil', this.artistUuid)
+        .sorted(sortKey, true)
     );
   }
 }

--- a/relisten/realm/models/shows/shows_by_momentum_repo.ts
+++ b/relisten/realm/models/shows/shows_by_momentum_repo.ts
@@ -37,7 +37,7 @@ class ShowsByMomentumNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBe
   }
 
   override createLocalUpdatingResults(): RealmQueryValueStream<Show> {
-    let query = this.realm.objects(Show).filtered('popularity != nil');
+    let query = this.realm.objects(Show).filtered('popularity != nil && deletedAt == nil');
 
     if (this.artistUuids.length > 0) {
       query = query.filtered('artistUuid in $0', this.artistUuids);

--- a/relisten/realm/models/shows/song_shows_repo.ts
+++ b/relisten/realm/models/shows/song_shows_repo.ts
@@ -48,11 +48,11 @@ class SongShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
     const songResults = new RealmObjectValueStream(this.realm, Song, this.songUuid);
     const showsResults = new RealmQueryValueStream<Show>(
       this.realm,
-      this.realm.objects(Show).filtered('ANY songs.uuid == $0', this.songUuid)
+      this.realm.objects(Show).filtered('ANY songs.uuid == $0 && deletedAt == nil', this.songUuid)
     );
 
     return new CombinedValueStream(songResults, showsResults, (song, shows) => {
-      return { song, shows };
+      return { song: song?.deletedAt == null ? song : null, shows };
     });
   }
 
@@ -69,7 +69,8 @@ class SongShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
       const { createdModels, updatedModels } = songRepo.upsert(
         this.realm,
         { ...apiData, shows_played_at: apiData.shows.length },
-        localData.song || undefined
+        localData.song || undefined,
+        true
       );
 
       const allModels = [localData.song, ...createdModels, ...updatedModels].filter((s) => !!s);

--- a/relisten/realm/models/shows/today_shows_repo.ts
+++ b/relisten/realm/models/shows/today_shows_repo.ts
@@ -38,7 +38,10 @@ export class TodayShowsNetworkBackedBehavior extends ShowsWithVenueNetworkBacked
 
     let query = this.realm
       .objects(Show)
-      .filtered('displayDate ENDSWITH $0', `-${formattedMonth}-${formattedDay}`);
+      .filtered(
+        'displayDate ENDSWITH $0 && deletedAt == nil',
+        `-${formattedMonth}-${formattedDay}`
+      );
 
     if (this.artistUuids) {
       query = query.filtered('artistUuid in $0', this.artistUuids);

--- a/relisten/realm/models/shows/top_shows_repo.ts
+++ b/relisten/realm/models/shows/top_shows_repo.ts
@@ -49,7 +49,7 @@ class TopShowsNetworkBackedBehavior extends ShowsWithVenueNetworkBackedBehavior 
       this.realm,
       this.realm
         .objects(Show)
-        .filtered('artistUuid == $0', this.artistUuid)
+        .filtered('artistUuid == $0 && deletedAt == nil', this.artistUuid)
         .sorted('avgRating', true)
     );
   }

--- a/relisten/realm/models/shows/tour_shows_repo.ts
+++ b/relisten/realm/models/shows/tour_shows_repo.ts
@@ -48,11 +48,11 @@ class TourShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
     const tourResults = new RealmObjectValueStream(this.realm, Tour, this.tourUuid);
     const showsResults = new RealmQueryValueStream<Show>(
       this.realm,
-      this.realm.objects(Show).filtered('tourUuid == $0', this.tourUuid)
+      this.realm.objects(Show).filtered('tourUuid == $0 && deletedAt == nil', this.tourUuid)
     );
 
     return new CombinedValueStream(tourResults, showsResults, (tour, shows) => {
-      return { tour, shows };
+      return { tour: tour?.deletedAt == null ? tour : null, shows };
     });
   }
 
@@ -76,7 +76,7 @@ class TourShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
         },
       });
 
-      tourRepo.upsert(this.realm, apiData, localData.tour || undefined);
+      tourRepo.upsert(this.realm, apiData, localData.tour || undefined, true);
     });
   }
 }

--- a/relisten/realm/models/shows/venue_shows_repo.ts
+++ b/relisten/realm/models/shows/venue_shows_repo.ts
@@ -48,11 +48,11 @@ class VenueShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
     const venueResults = new RealmObjectValueStream(this.realm, Venue, this.venueUuid);
     const showsResults = new RealmQueryValueStream<Show>(
       this.realm,
-      this.realm.objects(Show).filtered('venueUuid == $0', this.venueUuid)
+      this.realm.objects(Show).filtered('venueUuid == $0 && deletedAt == nil', this.venueUuid)
     );
 
     return new CombinedValueStream(venueResults, showsResults, (venue, shows) => {
-      return { venue, shows };
+      return { venue: venue?.deletedAt == null ? venue : null, shows };
     });
   }
 
@@ -76,7 +76,7 @@ class VenueShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavior<
         },
       });
 
-      venueRepo.upsert(this.realm, apiData, localData.venue || undefined);
+      venueRepo.upsert(this.realm, apiData, localData.venue || undefined, true);
     });
   }
 }

--- a/relisten/realm/models/song.ts
+++ b/relisten/realm/models/song.ts
@@ -27,6 +27,7 @@ export class Song
     properties: {
       createdAt: 'date',
       updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
       artistUuid: 'string',
       name: 'string',
       slug: 'string',
@@ -45,6 +46,7 @@ export class Song
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  deletedAt?: Date;
   artistUuid!: string;
   name!: string;
   slug!: string;

--- a/relisten/realm/models/song_repo.ts
+++ b/relisten/realm/models/song_repo.ts
@@ -17,7 +17,7 @@ export function useSongs(artistUuid: string, options?: NetworkBackedBehaviorOpti
     return new NetworkBackedModelArrayBehavior(
       realm,
       songRepo,
-      (realm) => realm.objects(Song).filtered('artistUuid == $0', artistUuid),
+      (realm) => realm.objects(Song).filtered('artistUuid == $0 && deletedAt == nil', artistUuid),
       (api) => api.songs(artistUuid),
       options
     );

--- a/relisten/realm/models/source.ts
+++ b/relisten/realm/models/source.ts
@@ -46,6 +46,7 @@ export class Source
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
       artistUuid: { type: 'string', indexed: true },
       showUuid: { type: 'string', indexed: true },
       venueUuid: { type: 'string', optional: true, indexed: true },
@@ -85,6 +86,7 @@ export class Source
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  deletedAt?: Date;
   artistUuid!: string;
   venueUuid?: string;
   displayDate!: string;

--- a/relisten/realm/models/source_set.ts
+++ b/relisten/realm/models/source_set.ts
@@ -29,6 +29,7 @@ export class SourceSet
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
       artistUuid: { type: 'string', indexed: true },
       sourceUuid: { type: 'string', indexed: true },
 
@@ -43,6 +44,7 @@ export class SourceSet
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  deletedAt?: Date;
 
   artistUuid!: string;
   sourceUuid!: string;

--- a/relisten/realm/models/source_track.ts
+++ b/relisten/realm/models/source_track.ts
@@ -57,6 +57,7 @@ export class SourceTrack
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
       artistUuid: { type: 'string', indexed: true },
       sourceUuid: { type: 'string', indexed: true },
       sourceSetUuid: { type: 'string', indexed: true },
@@ -85,6 +86,7 @@ export class SourceTrack
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  deletedAt?: Date;
 
   sourceUuid!: string;
   sourceSetUuid!: string;

--- a/relisten/realm/models/tour.ts
+++ b/relisten/realm/models/tour.ts
@@ -27,6 +27,7 @@ export class Tour
     properties: {
       createdAt: 'date',
       updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
       artistUuid: 'string',
       startDate: 'date',
       endDate: 'date',
@@ -41,6 +42,7 @@ export class Tour
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  deletedAt?: Date;
   artistUuid!: string;
   startDate!: Date;
   endDate!: Date;

--- a/relisten/realm/models/tour_repo.ts
+++ b/relisten/realm/models/tour_repo.ts
@@ -17,7 +17,7 @@ export function useTours(artistUuid: string, options?: NetworkBackedBehaviorOpti
     return new NetworkBackedModelArrayBehavior(
       realm,
       tourRepo,
-      (realm) => realm.objects(Tour).filtered('artistUuid == $0', artistUuid),
+      (realm) => realm.objects(Tour).filtered('artistUuid == $0 && deletedAt == nil', artistUuid),
       (api) => api.tours(artistUuid),
       options
     );

--- a/relisten/realm/models/venue.ts
+++ b/relisten/realm/models/venue.ts
@@ -30,6 +30,7 @@ export class Venue
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
       artistUuid: 'string',
       latitude: 'double?',
       longitude: 'double?',
@@ -47,6 +48,7 @@ export class Venue
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  deletedAt?: Date;
   artistUuid!: string;
   latitude?: number;
   longitude?: number;

--- a/relisten/realm/models/venue_repo.ts
+++ b/relisten/realm/models/venue_repo.ts
@@ -17,7 +17,10 @@ export function useVenues(artistUuid: string, options?: NetworkBackedBehaviorOpt
     return new NetworkBackedModelArrayBehavior(
       realm,
       venueRepo,
-      (realm) => realm.objects(Venue).filtered('artistUuid == $0 && showsAtVenue > 0', artistUuid),
+      (realm) =>
+        realm
+          .objects(Venue)
+          .filtered('artistUuid == $0 && showsAtVenue > 0 && deletedAt == nil', artistUuid),
       (api) => api.venues(artistUuid),
       options
     );

--- a/relisten/realm/models/year.ts
+++ b/relisten/realm/models/year.ts
@@ -29,6 +29,7 @@ export class Year
       uuid: 'string',
       createdAt: 'date',
       updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
       artistUuid: { type: 'string', indexed: true },
       showCount: 'int',
       sourceCount: 'int',
@@ -49,6 +50,7 @@ export class Year
   uuid!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  deletedAt?: Date;
   artistUuid!: string;
   showCount!: Realm.Types.Int;
   sourceCount!: Realm.Types.Int;

--- a/relisten/realm/models/year_repo.ts
+++ b/relisten/realm/models/year_repo.ts
@@ -2,7 +2,7 @@ import { Repository } from '../repository';
 import { useQuery, useRealm } from '../schema';
 import { Year } from './year';
 
-import { useIsOfflineTab } from '@/relisten/util/routes';
+import { useGroupSegment, useIsOfflineTab } from '@/relisten/util/routes';
 import { useMemo } from 'react';
 import Realm from 'realm';
 import { RelistenApiClient, RelistenApiResponse } from '../../api/client';
@@ -29,16 +29,25 @@ export function yearsNetworkBackedModelArrayBehavior(
   realm: Realm.Realm,
   isOfflineTab: boolean,
   artistUuid: string,
+  includeDeleted: boolean,
   options?: NetworkBackedBehaviorOptions
 ) {
   return new NetworkBackedModelArrayBehavior(
     realm,
     yearRepo,
     (realm) =>
-      filterForUser<Year>(realm.objects(Year).filtered('artistUuid == $0', artistUuid), {
-        isFavorite: null,
-        isPlayableOffline: isOfflineTab ? true : null,
-      }),
+      filterForUser<Year>(
+        realm
+          .objects(Year)
+          .filtered(
+            includeDeleted ? 'artistUuid == $0' : 'artistUuid == $0 && deletedAt == nil',
+            artistUuid
+          ),
+        {
+          isFavorite: null,
+          isPlayableOffline: isOfflineTab ? true : null,
+        }
+      ),
     (api) => api.years(artistUuid),
     options
   );
@@ -47,10 +56,17 @@ export function yearsNetworkBackedModelArrayBehavior(
 export function useYears(artistUuid: string, options?: NetworkBackedBehaviorOptions) {
   const realm = useRealm();
   const isOfflineTab = useIsOfflineTab();
+  const includeDeleted = useGroupSegment() !== '(artists)';
 
   const behavior = useMemo(() => {
-    return yearsNetworkBackedModelArrayBehavior(realm, isOfflineTab, artistUuid, options);
-  }, [realm, isOfflineTab, artistUuid, options]);
+    return yearsNetworkBackedModelArrayBehavior(
+      realm,
+      isOfflineTab,
+      artistUuid,
+      includeDeleted,
+      options
+    );
+  }, [realm, isOfflineTab, artistUuid, includeDeleted, options]);
 
   return useNetworkBackedBehavior(behavior);
 }
@@ -83,6 +99,7 @@ export class YearShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavi
     public artistUuid: string,
     public yearUuid: string,
     private userFilters: UserFilters,
+    private includeDeleted: boolean,
     options?: NetworkBackedBehaviorOptions
   ) {
     super(realm, options);
@@ -97,16 +114,22 @@ export class YearShowsNetworkBackedBehavior extends ThrottledNetworkBackedBehavi
 
   override createLocalUpdatingResults(): ValueStream<YearShows> {
     const yearResults = new RealmObjectValueStream(this.realm, Year, this.yearUuid);
+    const showPredicate = this.includeDeleted
+      ? 'yearUuid == $0'
+      : 'yearUuid == $0 && deletedAt == nil';
     const showsResults = new RealmQueryValueStream<Show>(
       this.realm,
       filterForUser(
-        this.realm.objects(Show).filtered('yearUuid == $0', this.yearUuid),
+        this.realm.objects(Show).filtered(showPredicate, this.yearUuid),
         this.userFilters
       )
     );
 
     return new CombinedValueStream(yearResults, showsResults, (year, shows) => {
-      return { year, shows };
+      return {
+        year: year && (this.includeDeleted || year.deletedAt == null) ? year : null,
+        shows,
+      };
     });
   }
 
@@ -134,9 +157,17 @@ export function createYearShowsNetworkBackedBehavior(
   artistUuid: string,
   yearUuid: string,
   userFilters: UserFilters,
+  includeDeleted: boolean,
   options?: NetworkBackedBehaviorOptions
 ) {
-  return new YearShowsNetworkBackedBehavior(realm, artistUuid, yearUuid, userFilters, options);
+  return new YearShowsNetworkBackedBehavior(
+    realm,
+    artistUuid,
+    yearUuid,
+    userFilters,
+    includeDeleted,
+    options
+  );
 }
 
 export function useYearShows(
@@ -145,13 +176,20 @@ export function useYearShows(
 ): NetworkBackedResults<YearShows> {
   const realm = useRealm();
   const isOfflineTab = useIsOfflineTab();
+  const includeDeleted = useGroupSegment() !== '(artists)';
 
   const behavior = useMemo(() => {
-    return new YearShowsNetworkBackedBehavior(realm, artistUuid, yearUuid, {
-      isPlayableOffline: isOfflineTab ? true : null,
-      isFavorite: null,
-    });
-  }, [realm, artistUuid, yearUuid, isOfflineTab]);
+    return new YearShowsNetworkBackedBehavior(
+      realm,
+      artistUuid,
+      yearUuid,
+      {
+        isPlayableOffline: isOfflineTab ? true : null,
+        isFavorite: null,
+      },
+      includeDeleted
+    );
+  }, [realm, artistUuid, yearUuid, isOfflineTab, includeDeleted]);
 
   return useNetworkBackedBehavior(behavior);
 }

--- a/relisten/realm/relisten_object.ts
+++ b/relisten/realm/relisten_object.ts
@@ -2,4 +2,5 @@ export interface RelistenObjectRequiredProperties {
   uuid: string;
   createdAt: Date;
   updatedAt: Date;
+  deletedAt?: Date;
 }

--- a/relisten/realm/repository.test.ts
+++ b/relisten/realm/repository.test.ts
@@ -1,0 +1,193 @@
+import Realm from 'realm';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/relisten/util/logging', () => ({
+  log: {
+    extend: () => ({
+      error: vi.fn(),
+      info: vi.fn(),
+    }),
+  },
+}));
+
+import { RelistenApiUpdatableObject, Repository } from '@/relisten/realm/repository';
+import { RelistenObjectRequiredProperties } from '@/relisten/realm/relisten_object';
+
+const TEST_REALM_PATH = '/tmp/relisten-repository-tombstone-test.realm';
+const MIGRATION_REALM_PATH = '/tmp/relisten-repository-migration-test.realm';
+
+interface TestApi extends RelistenApiUpdatableObject {
+  name: string;
+}
+
+interface TestCatalogProperties extends RelistenObjectRequiredProperties {
+  name: string;
+}
+
+class TestParent extends Realm.Object<TestParent> {
+  static schema: Realm.ObjectSchema = {
+    name: 'TestParent',
+    primaryKey: 'uuid',
+    properties: {
+      uuid: 'string',
+    },
+  };
+
+  uuid!: string;
+}
+
+class TestCatalog
+  extends Realm.Object<TestCatalog, keyof TestCatalogProperties>
+  implements TestCatalogProperties
+{
+  static schema: Realm.ObjectSchema = {
+    name: 'TestCatalog',
+    primaryKey: 'uuid',
+    properties: {
+      uuid: 'string',
+      createdAt: 'date',
+      updatedAt: 'date',
+      deletedAt: { type: 'date', optional: true, indexed: true },
+      name: 'string',
+      parent: 'TestParent?',
+    },
+  };
+
+  static propertiesFromApi(api: TestApi): TestCatalogProperties {
+    const updatedAt = new Date(api.updated_at);
+    return {
+      uuid: api.uuid,
+      createdAt: updatedAt,
+      updatedAt,
+      name: api.name,
+    };
+  }
+
+  uuid!: string;
+  createdAt!: Date;
+  updatedAt!: Date;
+  deletedAt?: Date;
+  name!: string;
+  parent?: TestParent;
+}
+
+const repository = new Repository(TestCatalog);
+const config: Realm.Configuration = {
+  path: TEST_REALM_PATH,
+  schema: [TestParent, TestCatalog],
+  schemaVersion: 13,
+};
+
+const apiRow: TestApi = {
+  uuid: 'catalog-row',
+  name: 'Catalog row',
+  updated_at: '2026-08-20T00:00:00.000Z',
+};
+
+function deleteRealm(configToDelete: Realm.Configuration) {
+  if (Realm.exists(configToDelete)) {
+    Realm.deleteFile(configToDelete);
+  }
+}
+
+describe('Repository catalog tombstones', () => {
+  let realm: Realm;
+
+  beforeEach(() => {
+    deleteRealm(config);
+    realm = new Realm(config);
+  });
+
+  afterEach(() => {
+    realm.close();
+    deleteRealm(config);
+    deleteRealm({ path: MIGRATION_REALM_PATH });
+  });
+
+  afterAll(() => {
+    Realm.shutdown();
+  });
+
+  it('tombstones an omitted row without invalidating it or its links', () => {
+    repository.upsert(realm, apiRow, undefined);
+    const model = realm.objectForPrimaryKey(TestCatalog, apiRow.uuid)!;
+    const parent = realm.write(() => realm.create(TestParent, { uuid: 'parent' }));
+    realm.write(() => {
+      model.parent = parent;
+    });
+
+    const result = repository.upsertMultiple(realm, [], realm.objects(TestCatalog), true);
+    const deletedAt = model.deletedAt;
+
+    expect(result.deleted).toBe(1);
+    expect(deletedAt).toBeInstanceOf(Date);
+    expect(model.isValid()).toBe(true);
+    expect(model.parent?.uuid).toBe('parent');
+
+    const repeated = repository.upsertMultiple(realm, [], realm.objects(TestCatalog), true);
+    expect(repeated.deleted).toBe(0);
+    expect(model.deletedAt).toEqual(deletedAt);
+  });
+
+  it('restores a tombstone even when the API timestamp is unchanged', () => {
+    repository.upsert(realm, apiRow, undefined);
+    const model = realm.objectForPrimaryKey(TestCatalog, apiRow.uuid)!;
+    repository.upsertMultiple(realm, [], realm.objects(TestCatalog), true);
+
+    const activeRows = realm.objects(TestCatalog).filtered('deletedAt == nil');
+    const result = repository.upsertMultiple(realm, [apiRow], activeRows, true, true);
+
+    expect(result.updated).toBe(1);
+    expect(result.allModels[0].uuid).toBe(model.uuid);
+    expect(model.deletedAt).toBeNull();
+    expect(model.isValid()).toBe(true);
+  });
+
+  it('preserves omitted rows when deletion is disabled', () => {
+    repository.upsert(realm, apiRow, undefined);
+    const model = realm.objectForPrimaryKey(TestCatalog, apiRow.uuid)!;
+
+    const result = repository.upsertMultiple(realm, [], realm.objects(TestCatalog), false);
+
+    expect(result.deleted).toBe(0);
+    expect(model.deletedAt).toBeNull();
+    expect(model.isValid()).toBe(true);
+  });
+
+  it('opens an older Realm with active rows after adding deletedAt', () => {
+    const oldConfig: Realm.Configuration = {
+      path: MIGRATION_REALM_PATH,
+      schemaVersion: 12,
+      schema: [
+        {
+          name: 'MigrationCatalog',
+          primaryKey: 'uuid',
+          properties: {
+            uuid: 'string',
+          },
+        },
+      ],
+    };
+    const oldRealm = new Realm(oldConfig);
+    oldRealm.write(() => oldRealm.create('MigrationCatalog', { uuid: 'old-row' }));
+    oldRealm.close();
+
+    const migratedRealm = new Realm({
+      ...oldConfig,
+      schemaVersion: 13,
+      schema: [
+        {
+          name: 'MigrationCatalog',
+          primaryKey: 'uuid',
+          properties: {
+            uuid: 'string',
+            deletedAt: { type: 'date', optional: true, indexed: true },
+          },
+        },
+      ],
+    });
+
+    expect(migratedRealm.objectForPrimaryKey('MigrationCatalog', 'old-row')?.deletedAt).toBeNull();
+    migratedRealm.close();
+  });
+});

--- a/relisten/realm/repository.test.ts
+++ b/relisten/realm/repository.test.ts
@@ -14,7 +14,6 @@ import { RelistenApiUpdatableObject, Repository } from '@/relisten/realm/reposit
 import { RelistenObjectRequiredProperties } from '@/relisten/realm/relisten_object';
 
 const TEST_REALM_PATH = '/tmp/relisten-repository-tombstone-test.realm';
-const MIGRATION_REALM_PATH = '/tmp/relisten-repository-migration-test.realm';
 
 interface TestApi extends RelistenApiUpdatableObject {
   name: string;
@@ -75,7 +74,6 @@ const repository = new Repository(TestCatalog);
 const config: Realm.Configuration = {
   path: TEST_REALM_PATH,
   schema: [TestParent, TestCatalog],
-  schemaVersion: 13,
 };
 
 const apiRow: TestApi = {
@@ -101,7 +99,6 @@ describe('Repository catalog tombstones', () => {
   afterEach(() => {
     realm.close();
     deleteRealm(config);
-    deleteRealm({ path: MIGRATION_REALM_PATH });
   });
 
   afterAll(() => {
@@ -154,42 +151,5 @@ describe('Repository catalog tombstones', () => {
     expect(result.deleted).toBe(0);
     expect(model.deletedAt).toBeNull();
     expect(model.isValid()).toBe(true);
-  });
-
-  it('opens an older Realm with active rows after adding deletedAt', () => {
-    const oldConfig: Realm.Configuration = {
-      path: MIGRATION_REALM_PATH,
-      schemaVersion: 12,
-      schema: [
-        {
-          name: 'MigrationCatalog',
-          primaryKey: 'uuid',
-          properties: {
-            uuid: 'string',
-          },
-        },
-      ],
-    };
-    const oldRealm = new Realm(oldConfig);
-    oldRealm.write(() => oldRealm.create('MigrationCatalog', { uuid: 'old-row' }));
-    oldRealm.close();
-
-    const migratedRealm = new Realm({
-      ...oldConfig,
-      schemaVersion: 13,
-      schema: [
-        {
-          name: 'MigrationCatalog',
-          primaryKey: 'uuid',
-          properties: {
-            uuid: 'string',
-            deletedAt: { type: 'date', optional: true, indexed: true },
-          },
-        },
-      ],
-    });
-
-    expect(migratedRealm.objectForPrimaryKey('MigrationCatalog', 'old-row')?.deletedAt).toBeNull();
-    migratedRealm.close();
   });
 });

--- a/relisten/realm/repository.test.ts
+++ b/relisten/realm/repository.test.ts
@@ -123,6 +123,8 @@ describe('Repository catalog tombstones', () => {
     expect(deletedAt).toBeInstanceOf(Date);
     expect(model.isValid()).toBe(true);
     expect(model.parent?.uuid).toBe('parent');
+    expect(realm.objects(TestCatalog).filtered('deletedAt == nil')).toHaveLength(0);
+    expect(realm.objectForPrimaryKey(TestCatalog, model.uuid)?.uuid).toBe(model.uuid);
 
     const repeated = repository.upsertMultiple(realm, [], realm.objects(TestCatalog), true);
     expect(repeated.deleted).toBe(0);

--- a/relisten/realm/repository.ts
+++ b/relisten/realm/repository.ts
@@ -160,6 +160,13 @@ export class Repository<
       }
 
       const shouldUpdateFromApi = this.klass.shouldUpdateFromApi?.(model, api) ?? false;
+      const restored = model.deletedAt != null;
+
+      // A positive API response always restores the existing Realm object. Do this before the
+      // timestamp check because the server may return the same updated_at value after deletion.
+      if (restored) {
+        model.deletedAt = undefined;
+      }
 
       if (getUpdatedAt(api).toDate() > model.updatedAt || shouldUpdateFromApi) {
         this.updateObjectFromApi(realm, model, api);
@@ -170,6 +177,17 @@ export class Repository<
           deleted: 0,
           updatedModels: [model],
           createdModels: [],
+          allModels: [model],
+        };
+      }
+
+      if (restored) {
+        return {
+          created: 0,
+          updated: 1,
+          deleted: 0,
+          createdModels: [],
+          updatedModels: [model],
           allModels: [model],
         };
       }
@@ -231,8 +249,13 @@ export class Repository<
           if (shouldPreserve?.(model)) {
             continue;
           }
-          realm.delete(model);
-          acc.deleted += 1;
+
+          // Catalog rows are permanent. A tombstone hides a row without invalidating managed
+          // references held by React, the player, CarPlay, or asynchronous callbacks.
+          if (model.deletedAt == null) {
+            model.deletedAt = new Date();
+            acc.deleted += 1;
+          }
         }
       }
 

--- a/relisten/realm/schema.ts
+++ b/relisten/realm/schema.ts
@@ -23,6 +23,7 @@ import {
   PopularityWindows,
 } from '@/relisten/realm/models/popularity';
 import { isVerboseProfileLoggingEnabled } from '@/relisten/util/profile_logging';
+import { repairCatalogAtStartup } from '@/relisten/realm/catalog_startup_repair';
 
 if (isVerboseProfileLoggingEnabled()) {
   Realm.setLogger(({ category, level, message }) => {
@@ -82,6 +83,7 @@ export async function openRealm(): Promise<Realm> {
   if (!realmOpenPromise) {
     realmOpenPromise = Realm.open(realmConfig)
       .then((openedRealm) => {
+        repairCatalogAtStartup(openedRealm);
         setRealm(openedRealm);
         return openedRealm;
       })

--- a/relisten/realm/schema.ts
+++ b/relisten/realm/schema.ts
@@ -57,7 +57,7 @@ const realmConfig: Realm.Configuration = {
     PopularityWindow,
     PopularityWindows,
   ],
-  schemaVersion: 12,
+  schemaVersion: 13,
   // As to not conflict with the prior versions default.realm that isn't readable with this version of the SDK
   path: './relisten.realm',
 };

--- a/relisten/realm/schema.ts
+++ b/relisten/realm/schema.ts
@@ -23,7 +23,10 @@ import {
   PopularityWindows,
 } from '@/relisten/realm/models/popularity';
 import { isVerboseProfileLoggingEnabled } from '@/relisten/util/profile_logging';
-import { repairCatalogAtStartup } from '@/relisten/realm/catalog_startup_repair';
+import {
+  CatalogStartupRepairState,
+  repairCatalogAtStartup,
+} from '@/relisten/realm/catalog_startup_repair';
 
 if (isVerboseProfileLoggingEnabled()) {
   Realm.setLogger(({ category, level, message }) => {
@@ -57,6 +60,7 @@ const realmConfig: Realm.Configuration = {
     Popularity,
     PopularityWindow,
     PopularityWindows,
+    CatalogStartupRepairState,
   ],
   schemaVersion: 13,
   // As to not conflict with the prior versions default.realm that isn't readable with this version of the SDK

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': new URL('.', import.meta.url).pathname,
+    },
+  },
+  test: {
+    environment: 'node',
+    fileParallelism: false,
+    include: ['relisten/**/*.test.ts'],
+    maxWorkers: 1,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,6 +2166,11 @@
   dependencies:
     which "^4.0.0"
 
+"@oxc-project/types@=0.146.0":
+  version "0.146.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.146.0.tgz#d57a2591abbf1f6e50981b07ee24ab269530d87a"
+  integrity sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -2582,6 +2587,86 @@
     "@babel/runtime" ">=7"
     react-native ">=0.68"
 
+"@rolldown/binding-android-arm-eabi@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz#165b80910de7cd33f772d5b7b045b259acb7420c"
+  integrity sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==
+
+"@rolldown/binding-android-arm64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz#5ed74d4b8fa56c68eb1aeb81d0d207a85b6de05c"
+  integrity sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==
+
+"@rolldown/binding-darwin-arm64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz#6f27c7060e58ca03061fa7d50f9dc409bc377fe1"
+  integrity sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==
+
+"@rolldown/binding-darwin-x64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz#74ab897d134ede4072fdc6108f00193e6167ee28"
+  integrity sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==
+
+"@rolldown/binding-freebsd-x64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz#7d337f9ae4b739674e1938747118ab0676c8ef8a"
+  integrity sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz#a8195dc1091ade0f912b0613ef6500941e5615f4"
+  integrity sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==
+
+"@rolldown/binding-linux-arm64-gnu@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz#40fbbb97072b1acaa3e0e8fe9774fe524e860bba"
+  integrity sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==
+
+"@rolldown/binding-linux-arm64-musl@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz#3cfe8b0f7c13de29dace9a9fc6c03081164176ab"
+  integrity sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==
+
+"@rolldown/binding-linux-ppc64-gnu@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz#3bd890d96ae29f93718aa142ed0982f2ee2978ad"
+  integrity sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==
+
+"@rolldown/binding-linux-s390x-gnu@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz#0959a0d5af22741d5787918e27aef70dc8602804"
+  integrity sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==
+
+"@rolldown/binding-linux-x64-gnu@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz#7baa94e826328ac6f457d9e1abacffa0353e8d22"
+  integrity sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==
+
+"@rolldown/binding-linux-x64-musl@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz#5f37597eaf0e22313d1e3d4be7d1be1fd332904e"
+  integrity sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==
+
+"@rolldown/binding-openharmony-arm64@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz#d096567af3f738cbe6aa858ab0a01aae9f357ef4"
+  integrity sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==
+
+"@rolldown/binding-win32-arm64-msvc@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz#d53b911aa4e6b547b789c07747fabab2ac8c237d"
+  integrity sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==
+
+"@rolldown/binding-win32-x64-msvc@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz#7bbd08cfda6a98de9b756472c772a36ebb7229bc"
+  integrity sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==
+
+"@rolldown/pluginutils@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
+
 "@sentry-internal/browser-utils@10.37.0":
   version "10.37.0"
   resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-10.37.0.tgz#18271f3d56dad87bc65e9e8042d966bf752a3a98"
@@ -2746,6 +2831,11 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
 "@statsig/client-core@3.31.0":
   version "3.31.0"
   resolved "https://registry.yarnpkg.com/@statsig/client-core/-/client-core-3.31.0.tgz#decec1aaf147f5e283fe1dda2239368ec4ad3ea4"
@@ -2855,6 +2945,14 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
 "@types/concat-stream@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/concat-stream/-/concat-stream-2.0.3.tgz#1f5c2ad26525716c181191f7ed53408f78eb758e"
@@ -2868,6 +2966,11 @@
   integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
   dependencies:
     "@types/ms" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/estree-jsx@^1.0.0":
   version "1.0.5"
@@ -3122,6 +3225,66 @@
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+
+"@vitest/expect@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.11.tgz#5f580d1f9cdbba314dbf23b2d911f8eb23878f5f"
+  integrity sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.11"
+    "@vitest/utils" "4.1.11"
+    chai "^6.2.2"
+    tinyrainbow "^3.1.0"
+
+"@vitest/mocker@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.11.tgz#8e2906361bc5dfa271757a858ae80643118fcbb4"
+  integrity sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==
+  dependencies:
+    "@vitest/spy" "4.1.11"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.11.tgz#8b28eb8240771d6ea970e33beaeb41384b51868e"
+  integrity sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==
+  dependencies:
+    tinyrainbow "^3.1.0"
+
+"@vitest/runner@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.11.tgz#bfbad98c8d6c3f1fb4df12056ad569821ff77f21"
+  integrity sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==
+  dependencies:
+    "@vitest/utils" "4.1.11"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.11.tgz#df461eb165924a3155986dde68e13360f53f3d4c"
+  integrity sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==
+  dependencies:
+    "@vitest/pretty-format" "4.1.11"
+    "@vitest/utils" "4.1.11"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.11.tgz#0add45cae953afed9c88f98e2f6fc9164558c32a"
+  integrity sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==
+
+"@vitest/utils@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.11.tgz#9b27a4293b827942b223539bfab1bd9f7eada31b"
+  integrity sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==
+  dependencies:
+    "@vitest/pretty-format" "4.1.11"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.1.0"
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.10"
@@ -3378,6 +3541,11 @@ asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 async-function@^1.0.0:
   version "1.0.0"
@@ -3830,6 +3998,11 @@ ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chalk@^2.0.1, chalk@^2.4.2:
   version "2.4.2"
@@ -4628,6 +4801,11 @@ es-iterator-helpers@^1.2.1:
     iterator.prototype "^1.1.4"
     safe-array-concat "^1.1.3"
 
+es-module-lexer@^2.0.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.3.2.tgz#311fa4f40168c1975c505477c51b23234d41ad55"
+  integrity sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==
+
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
@@ -4899,6 +5077,13 @@ estree-util-visit@^2.0.0:
     "@types/estree-jsx" "^1.0.0"
     "@types/unist" "^3.0.0"
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -4918,6 +5103,11 @@ expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
+expect-type@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
 
 expo-application@~57.0.0:
   version "57.0.0"
@@ -5429,7 +5619,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -6474,55 +6664,110 @@ lightningcss-android-arm64@1.30.2:
   resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz#6966b7024d39c94994008b548b71ab360eb3a307"
   integrity sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==
 
+lightningcss-android-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz#9a6841f88ae50fc83502903892b41af41bc2b907"
+  integrity sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==
+
 lightningcss-darwin-arm64@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz#a5fa946d27c029e48c7ff929e6e724a7de46eb2c"
   integrity sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==
+
+lightningcss-darwin-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz#c0f2c31c0bfd19fa4dd3f18e957a1f1a152097d6"
+  integrity sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==
 
 lightningcss-darwin-x64@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz#5ce87e9cd7c4f2dcc1b713f5e8ee185c88d9b7cd"
   integrity sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==
 
+lightningcss-darwin-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz#cb0705965acb538c6683949ce6925fb3cdf7c361"
+  integrity sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==
+
 lightningcss-freebsd-x64@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz#6ae1d5e773c97961df5cff57b851807ef33692a5"
   integrity sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==
+
+lightningcss-freebsd-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz#763538828b26bab2680dadafcc84ee78b0eb502b"
+  integrity sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==
 
 lightningcss-linux-arm-gnueabihf@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz#62c489610c0424151a6121fa99d77731536cdaeb"
   integrity sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==
 
+lightningcss-linux-arm-gnueabihf@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz#6862e3176a331aedbdec1ed352b4d7d0dd0784de"
+  integrity sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==
+
 lightningcss-linux-arm64-gnu@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz#2a3661b56fe95a0cafae90be026fe0590d089298"
   integrity sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==
+
+lightningcss-linux-arm64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz#c6a3a2ed15141daf6bdc2628930f8e39bdf473aa"
+  integrity sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==
 
 lightningcss-linux-arm64-musl@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz#d7ddd6b26959245e026bc1ad9eb6aa983aa90e6b"
   integrity sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==
 
+lightningcss-linux-arm64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz#7fa1334971fc82845f9827df6ef8a0b20914bac6"
+  integrity sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==
+
 lightningcss-linux-x64-gnu@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz#5a89814c8e63213a5965c3d166dff83c36152b1a"
   integrity sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==
+
+lightningcss-linux-x64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz#8b927862ea8c2bbc6831a46509244b50d9936e55"
+  integrity sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==
 
 lightningcss-linux-x64-musl@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz#808c2e91ce0bf5d0af0e867c6152e5378c049728"
   integrity sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==
 
+lightningcss-linux-x64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz#0c525bb077dfd94404c059cfe42dad797e96aeaf"
+  integrity sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==
+
 lightningcss-win32-arm64-msvc@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz#ab4a8a8a2e6a82a4531e8bbb6bf0ff161ee6625a"
   integrity sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==
 
+lightningcss-win32-arm64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz#850ee1103dac989cfab50e3ac22d1a69e394e63d"
+  integrity sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==
+
 lightningcss-win32-x64-msvc@1.30.2:
   version "1.30.2"
   resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz#f01f382c8e0a27e1c018b0bee316d210eac43b6e"
   integrity sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==
+
+lightningcss-win32-x64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz#e343ae152eed3609dc6e11949d1a3bf39a1c946f"
+  integrity sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==
 
 lightningcss@^1.30.1:
   version "1.30.2"
@@ -6542,6 +6787,25 @@ lightningcss@^1.30.1:
     lightningcss-linux-x64-musl "1.30.2"
     lightningcss-win32-arm64-msvc "1.30.2"
     lightningcss-win32-x64-msvc "1.30.2"
+
+lightningcss@^1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.33.0.tgz#c08867d71a79385c6e190214fd72fef3e5f95f0b"
+  integrity sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.33.0"
+    lightningcss-darwin-arm64 "1.33.0"
+    lightningcss-darwin-x64 "1.33.0"
+    lightningcss-freebsd-x64 "1.33.0"
+    lightningcss-linux-arm-gnueabihf "1.33.0"
+    lightningcss-linux-arm64-gnu "1.33.0"
+    lightningcss-linux-arm64-musl "1.33.0"
+    lightningcss-linux-x64-gnu "1.33.0"
+    lightningcss-linux-x64-musl "1.33.0"
+    lightningcss-win32-arm64-msvc "1.33.0"
+    lightningcss-win32-x64-msvc "1.33.0"
 
 lilconfig@^2.1.0:
   version "2.1.0"
@@ -6653,6 +6917,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -7630,6 +7901,11 @@ nanoid@^3.3.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.15.tgz#36c490fad8c6e86c824c940dfdde999b69ed4316"
   integrity sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==
 
+nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
+
 napi-build-utils@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-2.0.0.tgz#13c22c0187fcfccce1461844136372a47ddc027e"
@@ -7853,6 +8129,11 @@ object.values@^1.1.6, object.values@^1.2.1:
     call-bound "^1.0.3"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
+
+obug@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.4.tgz#9090d8a548a522517915d2aa6aae907197ac6cf8"
+  integrity sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==
 
 on-finished@2.4.1:
   version "2.4.1"
@@ -8090,6 +8371,11 @@ path-scurry@^2.0.0:
     lru-cache "^11.0.0"
     minipass "^7.1.2"
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -8099,6 +8385,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.3, picomatch@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
 picomatch@^4.0.4:
   version "4.0.4"
@@ -8257,6 +8548,15 @@ postcss@^8.5.14:
   integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
   dependencies:
     nanoid "^3.3.12"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@^8.5.26:
+  version "8.5.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
+  dependencies:
+    nanoid "^3.3.17"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -9019,6 +9319,30 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rolldown@~1.2.4:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.2.5.tgz#1f504a7d05260a769e617d950410bbb051498c50"
+  integrity sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==
+  dependencies:
+    "@oxc-project/types" "=0.146.0"
+    "@rolldown/pluginutils" "^1.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm-eabi" "1.2.5"
+    "@rolldown/binding-android-arm64" "1.2.5"
+    "@rolldown/binding-darwin-arm64" "1.2.5"
+    "@rolldown/binding-darwin-x64" "1.2.5"
+    "@rolldown/binding-freebsd-x64" "1.2.5"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.2.5"
+    "@rolldown/binding-linux-arm64-gnu" "1.2.5"
+    "@rolldown/binding-linux-arm64-musl" "1.2.5"
+    "@rolldown/binding-linux-ppc64-gnu" "1.2.5"
+    "@rolldown/binding-linux-s390x-gnu" "1.2.5"
+    "@rolldown/binding-linux-x64-gnu" "1.2.5"
+    "@rolldown/binding-linux-x64-musl" "1.2.5"
+    "@rolldown/binding-openharmony-arm64" "1.2.5"
+    "@rolldown/binding-win32-arm64-msvc" "1.2.5"
+    "@rolldown/binding-win32-x64-msvc" "1.2.5"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -9262,6 +9586,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.2, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -9388,6 +9717,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
@@ -9414,6 +9748,11 @@ statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+std-env@^4.0.0-rc.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.2.0.tgz#8ebe0ec60485668ab47227b312f4254cdf80c9d3"
+  integrity sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -9800,13 +10139,28 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-tinyglobby@^0.2.15:
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.3.0.tgz#aacc1dbb1d4e93e6ad8dd64944e09f9ad147a474"
+  integrity sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==
+
+tinyglobby@^0.2.15, tinyglobby@^0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
   integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.4"
+
+tinyrainbow@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.1.tgz#c0168387d3d8d70b6b3c2c0936de5fee738cea20"
+  integrity sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==
 
 tmp@^0.2.4:
   version "0.2.5"
@@ -10258,6 +10612,45 @@ vfile@^6.0.0, vfile@^6.0.3:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.2.2.tgz#399aefad3656145145be110d137a07ea5bb55014"
+  integrity sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==
+  dependencies:
+    lightningcss "^1.33.0"
+    picomatch "^4.0.5"
+    postcss "^8.5.26"
+    rolldown "~1.2.4"
+    tinyglobby "^0.2.17"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^4.1.11:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.11.tgz#1653c1521ae917f960d9b21877797c47dfd8bf21"
+  integrity sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==
+  dependencies:
+    "@vitest/expect" "4.1.11"
+    "@vitest/mocker" "4.1.11"
+    "@vitest/pretty-format" "4.1.11"
+    "@vitest/runner" "4.1.11"
+    "@vitest/snapshot" "4.1.11"
+    "@vitest/spy" "4.1.11"
+    "@vitest/utils" "4.1.11"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.1.0"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running "^2.3.0"
+
 vlq@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
@@ -10376,6 +10769,14 @@ which@^4.0.0:
   integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
   dependencies:
     isexe "^3.1.1"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
## Summary

- replace physical catalog deletion with indexed `deletedAt` tombstones
- restore tombstoned rows when the API observes the same UUID again
- hide tombstones from ordinary browse queries while retaining historical catalog links
- repair legacy missing links and remove only invalid leaf history, offline, and queue data
- persist a versioned completion row so every Realm runs each cleanup version once
- emit one aggregate Statsig event when startup repair changes data
- bump the release to 6.1.4 build 6047

## Design

The catalog is durable identity data. Reconciliation updates current membership and tombstones rows absent from authoritative API responses, but it does not physically delete catalog objects. Positive API observations clear `deletedAt` by UUID. Playback history can continue to reference tombstoned catalog rows because that historical identity remains relevant.

Legacy damage is repaired before Realm consumers mount. A missing completion row always runs the full repair. The repair and its completion row commit in one transaction, so a failed repair is retried on the next launch. A completed repair version skips later launches with one primary-key lookup. This is local run-once state, not a remote feature gate.

Non-zero repairs emit one best-effort `catalog_startup_repair` event with aggregate action counts, duration, and repair version. Telemetry failure cannot block startup.

Schema remains at unreleased version 13; the completion state is part of that same migration.

See `docs/plans/active/2026-08-20-permanent-catalog-tombstones.md` for the full plan and invariants.

## Performance

- startup membership cleanup uses one native matching-parent query per relationship
- permanent tombstones are excluded from legacy-repair scans
- top-played history and unpublished reporting use stable Realm snapshots instead of full JavaScript UUID arrays
- an adversarial 7 MiB Realm with 20,000 tracks and damage across every repair branch took 1,000.84 ms for the mandatory first repair on a Mac
- the second completion-flagged call took 0.027 ms; the next ten calls had a 0.00158 ms median and 0.00596 ms p95

The first-run cost has not yet been measured on the target iPhone.

## Testing

- `yarn test` — 3 files, 10 tests
- `yarn lint`
- `yarn ts:check`
- `git diff --check`

Focused Realm coverage includes multi-row cleanup with healthy neighbors, UUID-based restoration, atomic run-once completion across Realm reopen, clean-Realm completion, repair telemetry, telemetry failure isolation, and history deletion during an in-flight report.