### PR TITLE
fix(favorites): restore auto-created artists

### DIFF
--- a/relisten/events.ts
+++ b/relisten/events.ts
@@ -41,11 +41,13 @@ export function catalogStartupRepairEvent(
   return {
     eventName: Events.CatalogStartupRepair,
     value:
+      summary.restoredArtists +
       summary.repairedLinks +
       summary.tombstonedRows +
       summary.deletedLeafRows +
       summary.removedQueueEntries,
     metadata: {
+      restoredArtists: summary.restoredArtists.toString(),
       repairedLinks: summary.repairedLinks.toString(),
       tombstonedRows: summary.tombstonedRows.toString(),
       deletedLeafRows: summary.deletedLeafRows.toString(),

--- a/relisten/realm/catalog_startup_repair.test.ts
+++ b/relisten/realm/catalog_startup_repair.test.ts
@@ -30,7 +30,7 @@ import {
   CatalogStartupRepairState,
   repairCatalogAtStartup,
 } from '@/relisten/realm/catalog_startup_repair';
-import { Artist } from '@/relisten/realm/models/artist';
+import { Artist, ArtistFeaturedFlags } from '@/relisten/realm/models/artist';
 import { Year } from '@/relisten/realm/models/year';
 import { Show } from '@/relisten/realm/models/show';
 import { Venue } from '@/relisten/realm/models/venue';
@@ -75,20 +75,35 @@ const config: Realm.Configuration = {
   ],
 };
 
-function createArtist(realm: Realm) {
+function createArtist(
+  realm: Realm,
+  {
+    uuid = 'artist',
+    featured = ArtistFeaturedFlags.None,
+    isFavorite = false,
+    deletedAt,
+  }: {
+    uuid?: string;
+    featured?: number;
+    isFavorite?: boolean;
+    deletedAt?: Date;
+  } = {}
+) {
   return realm.create(Artist, {
-    uuid: 'artist',
+    uuid,
     createdAt: now,
     updatedAt: now,
+    deletedAt,
     musicbrainzId: '',
-    name: 'Artist',
-    featured: 0,
-    slug: 'artist',
-    sortName: 'Artist',
+    name: uuid,
+    featured,
+    slug: uuid,
+    sortName: uuid,
     featuresRaw: '{}',
     upstreamSourcesRaw: '[]',
     showCount: 1,
     sourceCount: 1,
+    isFavorite,
   });
 }
 
@@ -276,6 +291,7 @@ describe('catalog startup repair', () => {
     });
 
     expect(repairCatalogAtStartup(realm)).toEqual({
+      restoredArtists: 0,
       repairedLinks: 6,
       tombstonedRows: 0,
       deletedLeafRows: 0,
@@ -296,6 +312,7 @@ describe('catalog startup repair', () => {
     realm = new Realm(config);
 
     expect(repairCatalogAtStartup(realm)).toEqual({
+      restoredArtists: 0,
       repairedLinks: 0,
       tombstonedRows: 0,
       deletedLeafRows: 0,
@@ -332,6 +349,7 @@ describe('catalog startup repair', () => {
 
     const summary = repairCatalogAtStartup(realm);
     expect(summary).toEqual({
+      restoredArtists: 0,
       repairedLinks: 0,
       tombstonedRows: 3,
       deletedLeafRows: 2,
@@ -360,6 +378,7 @@ describe('catalog startup repair', () => {
     expect(playerState.activeSourceTrackIndex).toBeNull();
     expect(playerState.activeSourceTrackShuffledIndex).toBeNull();
     expect(repairCatalogAtStartup(realm)).toEqual({
+      restoredArtists: 0,
       repairedLinks: 0,
       tombstonedRows: 0,
       deletedLeafRows: 0,
@@ -403,6 +422,7 @@ describe('catalog startup repair', () => {
     });
 
     expect(repairCatalogAtStartup(realm)).toEqual({
+      restoredArtists: 0,
       repairedLinks: 0,
       tombstonedRows: 4,
       deletedLeafRows: 0,
@@ -412,8 +432,74 @@ describe('catalog startup repair', () => {
     expect(Array.from(song.shows, (show) => show.uuid)).toEqual(['show']);
   });
 
+  it('restores only tombstoned auto-created artists with user interaction', () => {
+    let favoriteArtist!: Artist;
+    let offlineArtist!: Artist;
+    let untouchedAutoCreatedArtist!: Artist;
+    let ordinaryFavoriteArtist!: Artist;
+
+    realm.write(() => {
+      realm.create(CatalogStartupRepairState, {
+        version: 1,
+        completedAt: now,
+      });
+
+      offlineArtist = createArtist(realm, {
+        featured: ArtistFeaturedFlags.Featured | ArtistFeaturedFlags.AutoCreated,
+        deletedAt: now,
+      });
+      const year = createYear(realm);
+      const show = createShow(realm, offlineArtist);
+      const source = createSource(realm, offlineArtist);
+      const offlineInfo = createOfflineInfo(realm);
+      createSourceTrack(realm, { artist: offlineArtist, year, show, source, offlineInfo });
+
+      favoriteArtist = createArtist(realm, {
+        uuid: 'favorite-auto-created',
+        featured: ArtistFeaturedFlags.AutoCreated,
+        isFavorite: true,
+        deletedAt: now,
+      });
+      untouchedAutoCreatedArtist = createArtist(realm, {
+        uuid: 'untouched-auto-created',
+        featured: ArtistFeaturedFlags.AutoCreated,
+        deletedAt: now,
+      });
+      ordinaryFavoriteArtist = createArtist(realm, {
+        uuid: 'ordinary-favorite',
+        isFavorite: true,
+        deletedAt: now,
+      });
+    });
+
+    const summary = repairCatalogAtStartup(realm);
+
+    expect(summary).toEqual({
+      restoredArtists: 2,
+      repairedLinks: 0,
+      tombstonedRows: 0,
+      deletedLeafRows: 0,
+      removedQueueEntries: 0,
+    });
+    expect(favoriteArtist.deletedAt).toBeNull();
+    expect(offlineArtist.deletedAt).toBeNull();
+    expect(untouchedAutoCreatedArtist.deletedAt).toBeInstanceOf(Date);
+    expect(ordinaryFavoriteArtist.deletedAt).toBeInstanceOf(Date);
+    expect(realm.objectForPrimaryKey(CatalogStartupRepairState, 1)).not.toBeNull();
+    expect(
+      realm.objectForPrimaryKey(CatalogStartupRepairState, CATALOG_STARTUP_REPAIR_VERSION)
+    ).not.toBeNull();
+    expect(logStatsigEvent).toHaveBeenCalledWith({
+      eventName: 'catalog_startup_repair',
+      summary,
+      durationMs: expect.any(Number),
+      repairVersion: CATALOG_STARTUP_REPAIR_VERSION,
+    });
+  });
+
   it('marks a clean Realm complete without emitting repair telemetry', () => {
     expect(repairCatalogAtStartup(realm)).toEqual({
+      restoredArtists: 0,
       repairedLinks: 0,
       tombstonedRows: 0,
       deletedLeafRows: 0,

--- a/relisten/realm/catalog_startup_repair.ts
+++ b/relisten/realm/catalog_startup_repair.ts
@@ -7,7 +7,10 @@ import { Song } from '@/relisten/realm/models/song';
 import { Source } from '@/relisten/realm/models/source';
 import { SourceSet } from '@/relisten/realm/models/source_set';
 import { SourceTrack } from '@/relisten/realm/models/source_track';
-import { SourceTrackOfflineInfo } from '@/relisten/realm/models/source_track_offline_info';
+import {
+  SourceTrackOfflineInfo,
+  SourceTrackOfflineInfoStatus,
+} from '@/relisten/realm/models/source_track_offline_info';
 import { PlaybackHistoryEntry } from '@/relisten/realm/models/history/playback_history_entry';
 import { PlayerState } from '@/relisten/realm/models/player_state';
 import { catalogStartupRepairEvent, sharedStatsigClient } from '@/relisten/events';
@@ -15,13 +18,14 @@ import { catalogStartupRepairEvent, sharedStatsigClient } from '@/relisten/event
 const logger = log.extend('catalog-startup-repair');
 
 export interface CatalogRepairSummary {
+  restoredArtists: number;
   repairedLinks: number;
   tombstonedRows: number;
   deletedLeafRows: number;
   removedQueueEntries: number;
 }
 
-export const CATALOG_STARTUP_REPAIR_VERSION = 1;
+export const CATALOG_STARTUP_REPAIR_VERSION = 2;
 
 export class CatalogStartupRepairState extends Realm.Object<CatalogStartupRepairState> {
   static schema: Realm.ObjectSchema = {
@@ -96,6 +100,7 @@ function removeIrreparableShowsFromSongs(realm: Realm, showUuids: ReadonlySet<st
  */
 export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
   const summary: CatalogRepairSummary = {
+    restoredArtists: 0,
     repairedLinks: 0,
     tombstonedRows: 0,
     deletedLeafRows: 0,
@@ -109,6 +114,21 @@ export function repairCatalogAtStartup(realm: Realm): CatalogRepairSummary {
   const repairDate = new Date();
 
   realm.write(() => {
+    const userInteractedDeletedArtists = realm
+      .objects(Artist)
+      .filtered(
+        'deletedAt != nil AND (isFavorite == true OR SUBQUERY(sourceTracks, $track, $track.offlineInfo.status == $0).@count > 0)',
+        SourceTrackOfflineInfoStatus.Succeeded
+      )
+      .snapshot();
+
+    for (const artist of userInteractedDeletedArtists) {
+      if (artist.isAutomaticallyCreated()) {
+        artist.deletedAt = undefined;
+        summary.restoredArtists += 1;
+      }
+    }
+
     const irreparableShowUuids = new Set<string>();
     const irreparableSourceUuids = new Set<string>();
     const irreparableTrackUuids = new Set<string>();

--- a/relisten/realm/models/artist_repo.ts
+++ b/relisten/realm/models/artist_repo.ts
@@ -23,6 +23,10 @@ import { attachArtistsToExistingShows } from '@/relisten/realm/models/show_artis
 
 export const artistRepo = new Repository(Artist);
 
+function artistHasUserInteraction(artist: Artist): boolean {
+  return artist.isFavorite || artist.hasOfflineTracks();
+}
+
 class ArtistsNetworkBackedBehavior extends NetworkBackedModelArrayBehavior<
   Artist,
   ArtistWithCounts,
@@ -31,7 +35,14 @@ class ArtistsNetworkBackedBehavior extends NetworkBackedModelArrayBehavior<
 > {
   override upsert(localData: Realm.Results<Artist>, apiData: ArtistWithCounts[]): void {
     this.realm.write(() => {
-      const { allModels } = artistRepo.upsertMultiple(this.realm, apiData, localData, true, true);
+      const { allModels } = artistRepo.upsertMultiple(
+        this.realm,
+        apiData,
+        localData,
+        true,
+        true,
+        artistHasUserInteraction
+      );
 
       attachArtistsToExistingShows(this.realm, allModels);
     });


### PR DESCRIPTION
## Summary

- preserve favorited or offline auto-created artists when the main artists response omits them
- run catalog startup repair v2 to restore affected rows already tombstoned by build 6047
- report restored artist counts in the existing catalog repair telemetry

## Root cause

The main artists query intentionally includes favorited auto-created artists, while its API request uses include_autocreated=false. The catalog tombstone change stopped passing the existing user-interaction preservation predicate into Repository.upsertMultiple, so favorites such as Dizgo were interpreted as deleted and hidden from the Artists tab.

## OTA compatibility

The fix only changes JavaScript and existing Realm data. It does not add native code or change the Realm schema, so it can ship to the 6.1.4 / 6047 runtime as an OTA after merge.

## Testing

- yarn test — 3 files, 11 tests passed
- yarn lint
- yarn ts:check
- git diff --check
